### PR TITLE
Fix AzDO pipeline: use powershell and double quotes for Windows

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -109,12 +109,12 @@ extends:
           target:
             container: host
 
-        - script: npx turbo build --filter='./packages/*'
+        - powershell: npx turbo build --filter="./packages/*" --force
           displayName: 'Build packages'
           target:
             container: host
 
-        - script: npx turbo test --filter='./packages/*'
+        - powershell: npx turbo test --filter="./packages/*"
           displayName: 'Test packages'
           continueOnError: false
           target:


### PR DESCRIPTION
The turbo `--filter='./packages/*'` glob wasn't working on Windows CI because `cmd.exe` doesn't interpret single quotes. Switches to `powershell` with double quotes and adds `--force` to ensure fresh builds after version stamping.