### PR TITLE
Fix manifest-upload-zip test on Windows

### DIFF
--- a/packages/cli/tests/manifest-upload-zip.test.ts
+++ b/packages/cli/tests/manifest-upload-zip.test.ts
@@ -60,9 +60,13 @@ vi.mock('../src/project/paths.js', () => ({
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
+  const { join } = await import('node:path');
+  const mockStaticsDir = '/mock/statics';
+  const mockColorPath = join(mockStaticsDir, 'color.png');
+  const mockOutlinePath = join(mockStaticsDir, 'outline.png');
   const mockedReadFileSync = vi.fn((...args: Parameters<typeof actual.readFileSync>) => {
     const filePath = args[0];
-    if (typeof filePath === 'string' && filePath.startsWith('/mock/statics')) {
+    if (typeof filePath === 'string' && (filePath === mockColorPath || filePath === mockOutlinePath)) {
       return Buffer.from('default-icon');
     }
     return actual.readFileSync(...args);


### PR DESCRIPTION
## Summary
- The `readFileSync` mock in `manifest-upload-zip.test.ts` used `filePath.startsWith('/mock/statics')` which only matches POSIX-style paths
- On Windows, `path.join('/mock/statics', 'color.png')` produces backslash paths (e.g. `\mock\statics\color.png`), so the mock fell through to the real filesystem causing ENOENT
- Fix: use `path.join` to build the expected mock paths so they match on all platforms

## Test plan
- [x] All 5 tests in `manifest-upload-zip.test.ts` pass on macOS
- [ ] Verify CI passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)