### PR TITLE
Fix manifest version auto-bump ignoring nested field changes

### DIFF
--- a/packages/cli/src/commands/app/manifest/actions.ts
+++ b/packages/cli/src/commands/app/manifest/actions.ts
@@ -134,7 +134,12 @@ export async function uploadManifestFromFile(
           // Same version — bump if content actually changed
           const { version: _sv, ...serverCopy } = serverManifest;
           const { version: _lv, ...localCopy } = manifest;
-          const stableStringify = (obj: unknown) => JSON.stringify(obj, Object.keys(obj as object).sort());
+          const stableStringify = (obj: unknown) =>
+            JSON.stringify(obj, (_key, value) =>
+              value && typeof value === 'object' && !Array.isArray(value)
+                ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
+                : value
+            );
           const contentChanged = stableStringify(serverCopy) !== stableStringify(localCopy);
 
           if (contentChanged) {


### PR DESCRIPTION
## Summary
- `stableStringify` in manifest upload used `JSON.stringify(obj, arrayReplacer)` where the array only contained top-level keys — `JSON.stringify` treats array replacers as a property-name whitelist at **all** nesting levels, silently stripping nested properties (`name.short`, `description.full`, `developer.websiteUrl`, `bots[].scopes`, etc.) from both copies
- This made the server vs local comparison always equal for nested changes, so the version was never auto-bumped
- Switched to a replacer **function** that recursively sorts object keys at every depth, preserving all nested properties in the diff

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (23 tests including `manifest-upload-zip` and `version` suites)
- [x] End-to-end: created a bot and ran 14 upload scenarios against TDP:
  - Nested field changes (`name.short`, `description.short/full`, `developer.name/websiteUrl`) → version bumped ✅
  - Deep nested changes (`bots[0].scopes`, `bots[0].supportsFiles`) → version bumped ✅
  - Top-level changes (`accentColor`, `validDomains`) → version bumped ✅
  - Add/remove entire sections (`composeExtensions`) → version bumped ✅
  - No change (re-upload identical) → no bump ✅
  - `--no-bump-version` flag → no bump ✅
  - Manual version set higher → no bump ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)