### PR TITLE
Move link from Agent Skills doc title to intro paragraph

### DIFF
--- a/teams.md/docs/cli/guides/agent-skills.md
+++ b/teams.md/docs/cli/guides/agent-skills.md
@@ -1,6 +1,6 @@
-# [Agent Skills](https://agentskills.io/what-are-skills)
+# Agent Skills
 
-The `teams-dev` skill is the go-to agent skill for Teams bot development. It gives AI coding assistants (Claude Code, Cursor, GitHub Copilot, and others) relevant context to assist in developing Teams bots and use the Teams CLI to manage your bot infrastructure. Instead of running CLI commands manually, you describe what you want and your AI assistant handles the rest.
+The `teams-dev` skill is the go-to [agent skill](https://agentskills.io/what-are-skills) for Teams bot development. It gives AI coding assistants (Claude Code, Cursor, GitHub Copilot, and others) relevant context to assist in developing Teams bots and use the Teams CLI to manage your bot infrastructure. Instead of running CLI commands manually, you describe what you want and your AI assistant handles the rest.
 
 ## Install the `teams-dev` skill
 


### PR DESCRIPTION
## Summary
- Removed the embedded hyperlink from the `# Agent Skills` heading which rendered poorly as a doc title
- Moved the link to the "agent skill" text in the intro paragraph where it fits more naturally

## Test plan
- [ ] Verify the doc page renders with a clean title (no clickable heading)
- [ ] Verify the "agent skill" text in the intro links to https://agentskills.io/what-are-skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)