### PR TITLE
Add compile-time type checking to TypeScript template dev scripts

### DIFF
--- a/packages/cli/templates/typescript/ai/package.json.hbs
+++ b/packages/cli/templates/typescript/ai/package.json.hbs
@@ -13,7 +13,7 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsup",
 "start": "node .",
-"dev": "tsx watch -r dotenv/config src/index.ts"
+"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
 },
 "dependencies": {
 "@microsoft/teams.ai": "latest",
@@ -24,7 +24,8 @@
 "@types/node": "^22.5.4",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"tsx": "^4.20.6",
+"nodemon": "^3.1.4",
+"ts-node": "^10.9.2",
 "tsup": "^8.4.0",
 "typescript": "^5.4.5"
 }

--- a/packages/cli/templates/typescript/ai/package.json.hbs
+++ b/packages/cli/templates/typescript/ai/package.json.hbs
@@ -13,7 +13,9 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsup",
 "start": "node .",
-"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
+"dev": "concurrently \"tsx watch -r dotenv/config src/index.ts\" \"tsc --noEmit --watch\"",
+"dev:run": "tsx watch -r dotenv/config src/index.ts",
+"dev:check": "tsc --noEmit --watch"
 },
 "dependencies": {
 "@microsoft/teams.ai": "latest",
@@ -24,8 +26,8 @@
 "@types/node": "^22.5.4",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"nodemon": "^3.1.4",
-"ts-node": "^10.9.2",
+"concurrently": "^9.1.2",
+"tsx": "^4.20.6",
 "tsup": "^8.4.0",
 "typescript": "^5.4.5"
 }

--- a/packages/cli/templates/typescript/echo/package.json.hbs
+++ b/packages/cli/templates/typescript/echo/package.json.hbs
@@ -13,7 +13,9 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsup",
 "start": "node .",
-"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
+"dev": "concurrently \"tsx watch -r dotenv/config src/index.ts\" \"tsc --noEmit --watch\"",
+"dev:run": "tsx watch -r dotenv/config src/index.ts",
+"dev:check": "tsc --noEmit --watch"
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest"
@@ -22,8 +24,8 @@
 "@types/node": "^22.5.4",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"nodemon": "^3.1.4",
-"ts-node": "^10.9.2",
+"concurrently": "^9.1.2",
+"tsx": "^4.20.6",
 "tsup": "^8.4.0",
 "typescript": "^5.4.5"
 }

--- a/packages/cli/templates/typescript/echo/package.json.hbs
+++ b/packages/cli/templates/typescript/echo/package.json.hbs
@@ -13,7 +13,7 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsup",
 "start": "node .",
-"dev": "tsx watch -r dotenv/config src/index.ts"
+"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest"
@@ -22,7 +22,8 @@
 "@types/node": "^22.5.4",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"tsx": "^4.20.6",
+"nodemon": "^3.1.4",
+"ts-node": "^10.9.2",
 "tsup": "^8.4.0",
 "typescript": "^5.4.5"
 }

--- a/packages/cli/templates/typescript/graph/package.json.hbs
+++ b/packages/cli/templates/typescript/graph/package.json.hbs
@@ -13,7 +13,9 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsup",
 "start": "node .",
-"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
+"dev": "concurrently \"tsx watch -r dotenv/config src/index.ts\" \"tsc --noEmit --watch\"",
+"dev:run": "tsx watch -r dotenv/config src/index.ts",
+"dev:check": "tsc --noEmit --watch"
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest",
@@ -24,8 +26,8 @@
 "@types/node": "^22.5.4",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"nodemon": "^3.1.4",
-"ts-node": "^10.9.2",
+"concurrently": "^9.1.2",
+"tsx": "^4.20.6",
 "tsup": "^8.4.0",
 "typescript": "^5.4.5"
 }

--- a/packages/cli/templates/typescript/graph/package.json.hbs
+++ b/packages/cli/templates/typescript/graph/package.json.hbs
@@ -13,7 +13,7 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsup",
 "start": "node .",
-"dev": "tsx watch -r dotenv/config src/index.ts"
+"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest",
@@ -24,7 +24,8 @@
 "@types/node": "^22.5.4",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"tsx": "^4.20.6",
+"nodemon": "^3.1.4",
+"ts-node": "^10.9.2",
 "tsup": "^8.4.0",
 "typescript": "^5.4.5"
 }

--- a/packages/cli/templates/typescript/mcp/package.json.hbs
+++ b/packages/cli/templates/typescript/mcp/package.json.hbs
@@ -16,8 +16,7 @@
 "dev": "concurrently \"tsx watch -r dotenv/config src/index.ts\" \"tsc --noEmit --watch\"",
 "dev:run": "tsx watch -r dotenv/config src/index.ts",
 "dev:check": "tsc --noEmit --watch",
-"inspect": "npx cross-env SERVER_PORT=9000 npx @modelcontextprotocol/inspector -e NODE_NO_WARNINGS=1 -e PORT=3978 node
--r dotenv/config ."
+"inspect": "npx cross-env SERVER_PORT=9000 npx @modelcontextprotocol/inspector -e NODE_NO_WARNINGS=1 -e PORT=3978 node -r dotenv/config ."
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest",

--- a/packages/cli/templates/typescript/mcp/package.json.hbs
+++ b/packages/cli/templates/typescript/mcp/package.json.hbs
@@ -13,7 +13,7 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsc",
 "start": "node .",
-"dev": "tsx watch -r dotenv/config src/index.ts",
+"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\"",
 "inspect": "npx cross-env SERVER_PORT=9000 npx @modelcontextprotocol/inspector -e NODE_NO_WARNINGS=1 -e PORT=3978 node
 -r dotenv/config ."
 },
@@ -29,7 +29,8 @@
 "cross-env": "^7.0.3",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"tsx": "^4.20.6",
+"nodemon": "^3.1.4",
+"ts-node": "^10.9.2",
 "typescript": "^5.4.5"
 }
 }

--- a/packages/cli/templates/typescript/mcp/package.json.hbs
+++ b/packages/cli/templates/typescript/mcp/package.json.hbs
@@ -13,7 +13,9 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsc",
 "start": "node .",
-"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\"",
+"dev": "concurrently \"tsx watch -r dotenv/config src/index.ts\" \"tsc --noEmit --watch\"",
+"dev:run": "tsx watch -r dotenv/config src/index.ts",
+"dev:check": "tsc --noEmit --watch",
 "inspect": "npx cross-env SERVER_PORT=9000 npx @modelcontextprotocol/inspector -e NODE_NO_WARNINGS=1 -e PORT=3978 node
 -r dotenv/config ."
 },
@@ -29,8 +31,8 @@
 "cross-env": "^7.0.3",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"nodemon": "^3.1.4",
-"ts-node": "^10.9.2",
+"concurrently": "^9.1.2",
+"tsx": "^4.20.6",
 "typescript": "^5.4.5"
 }
 }

--- a/packages/cli/templates/typescript/mcpclient/package.json.hbs
+++ b/packages/cli/templates/typescript/mcpclient/package.json.hbs
@@ -13,7 +13,9 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsc",
 "start": "node .",
-"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
+"dev": "concurrently \"tsx watch -r dotenv/config src/index.ts\" \"tsc --noEmit --watch\"",
+"dev:run": "tsx watch -r dotenv/config src/index.ts",
+"dev:check": "tsc --noEmit --watch"
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest",
@@ -26,8 +28,8 @@
 "cross-env": "^7.0.3",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"nodemon": "^3.1.4",
-"ts-node": "^10.9.2",
+"concurrently": "^9.1.2",
+"tsx": "^4.20.6",
 "typescript": "^5.4.5"
 }
 }

--- a/packages/cli/templates/typescript/mcpclient/package.json.hbs
+++ b/packages/cli/templates/typescript/mcpclient/package.json.hbs
@@ -13,7 +13,7 @@
 "clean": "npx rimraf ./dist",
 "build": "npx tsc",
 "start": "node .",
-"dev": "tsx watch -r dotenv/config src/index.ts"
+"dev": "nodemon -e ts --watch src --exec \"ts-node -r dotenv/config src/index.ts\""
 },
 "dependencies": {
 "@microsoft/teams.apps": "latest",
@@ -26,7 +26,8 @@
 "cross-env": "^7.0.3",
 "dotenv": "^16.4.5",
 "rimraf": "^6.0.1",
-"tsx": "^4.20.6",
+"nodemon": "^3.1.4",
+"ts-node": "^10.9.2",
 "typescript": "^5.4.5"
 }
 }


### PR DESCRIPTION
## Summary
- Adds `concurrently` to run `tsx watch` and `tsc --noEmit --watch` in parallel during `npm run dev`
- Devs get fast hot reload (tsx) + type errors in the same terminal
- Also adds `dev:run` and `dev:check` scripts for running them individually
- Applies to all 5 TypeScript templates: echo, ai, graph, mcp, mcpclient

## Test plan
- [ ] Scaffold a new app from each template and run `npm run dev`
- [ ] Verify hot reload works (edit a .ts file, confirm restart)
- [ ] Introduce a type error and confirm `tsc` reports it in the terminal