### PR TITLE
Docs: expand logging guide with levels, patterns, env vars; fix broken Python example

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/observability/logging/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/observability/logging/csharp.incl.md
@@ -23,3 +23,19 @@ builder.AddTeams(appBuilder)
 var app = builder.Build();
 var teams = app.UseTeams();
 ```
+
+<!-- log-levels -->
+
+N/A
+
+<!-- pattern-example -->
+
+N/A
+
+<!-- env-vars -->
+
+N/A
+
+<!-- child-logger -->
+
+N/A

--- a/teams.md/src/components/include/in-depth-guides/observability/logging/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/observability/logging/python.incl.md
@@ -1,6 +1,6 @@
 <!-- default-logger -->
 
-`ConsoleLogger`
+Python's standard `logging` module (configured with `ConsoleFormatter` from the SDK).
 
 <!-- package-name -->
 
@@ -8,24 +8,58 @@
 
 <!-- custom-logger-example -->
 
+The Python SDK writes to the standard `logging` module. Configure a handler and formatter at startup:
+
 ```python
 import asyncio
+import logging
 
 from microsoft_teams.api import MessageActivity
-from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
-from microsoft_teams.common import ConsoleLogger, ConsoleLoggerOptions
+from microsoft_teams.common import ConsoleFormatter
 
-logger = ConsoleLogger().create_logger("echo", ConsoleLoggerOptions(level="debug"))
-app = App(logger=logger)
+# Setup logging
+logging.getLogger().setLevel(logging.DEBUG)
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(ConsoleFormatter())
+logging.getLogger().addHandler(stream_handler)
+logger = logging.getLogger(__name__)
+
+app = App()
+
 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     logger.debug(ctx.activity)
-    await ctx.reply(TypingActivityInput())
     await ctx.send(f"You said '{ctx.activity.text}'")
 
 
 if __name__ == "__main__":
     asyncio.run(app.start())
+```
+
+<!-- log-levels -->
+
+Python's standard `logging` levels apply: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+
+<!-- pattern-example -->
+
+Use `ConsoleFilter` to limit which loggers emit, matched by name with `*` wildcards:
+
+```python
+from microsoft_teams.common import ConsoleFilter, ConsoleFormatter
+
+handler = logging.StreamHandler()
+handler.setFormatter(ConsoleFormatter())
+handler.addFilter(ConsoleFilter("microsoft_teams*"))  # only SDK loggers
+logging.getLogger().addHandler(handler)
+```
+
+<!-- env-vars -->
+
+The Python SDK does not read logging environment variables on its own. If you want `LOG_LEVEL` to control verbosity, read it yourself at startup:
+
+```python
+import os
+logging.getLogger().setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
 ```

--- a/teams.md/src/components/include/in-depth-guides/observability/logging/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/observability/logging/typescript.incl.md
@@ -28,3 +28,40 @@ app.on('message', async ({ send, activity, log }) => {
   await app.start();
 })();
 ```
+
+<!-- log-levels -->
+
+Available levels, from most to least severe: `error`, `warn`, `info`, `debug`, `trace`. The default is `info`. Setting `level: 'debug'` emits `error`, `warn`, `info`, and `debug` — but not `trace`.
+
+<!-- pattern-example -->
+
+Each logger has a name. The `pattern` option filters which loggers emit, with `*` as a wildcard. Prefix a pattern with `-` to exclude. Combine with commas.
+
+```typescript
+new ConsoleLogger('my-app', { pattern: '@teams*' });        // only SDK loggers
+new ConsoleLogger('my-app', { pattern: '*,-@teams/http*' }); // everything except HTTP
+```
+
+<!-- env-vars -->
+
+The TypeScript SDK's `ConsoleLogger` reads two environment variables at construction:
+
+| Variable     | Purpose                          | Example                 |
+| ------------ | -------------------------------- | ----------------------- |
+| `LOG_LEVEL`  | Minimum severity                 | `LOG_LEVEL=debug`       |
+| `LOG`        | Logger name pattern (wildcards)  | `LOG=@teams*`           |
+
+Env vars override options passed to the constructor. If you do not pass a logger to `App`, the SDK creates a default `ConsoleLogger` named `@teams/app` — so `LOG_LEVEL=debug` alone is enough to enable debug output.
+
+> **Gotcha:** `LOG` is a name filter, not a toggle. Setting `LOG` to a pattern that doesn't match the default `@teams/app` (for example `LOG=my-app*`) silences the default logger. If in doubt, unset `LOG` to match everything.
+
+<!-- child-logger -->
+
+Call `log.child('scope')` on an existing logger to get a scoped logger. Its name is `parent/scope`, and pattern/level are inherited.
+
+```typescript
+app.on('message', async ({ log }) => {
+  const msgLog = log.child('message-handler');
+  msgLog.debug('processing'); // logged as "@teams/app/message-handler"
+});
+```

--- a/teams.md/src/pages/templates/in-depth-guides/observability/logging.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/observability/logging.mdx
@@ -11,3 +11,21 @@ The `App` will provide a default logger, but you can also provide your own.
 The default `Logger` instance will be set to <LanguageInclude section="default-logger" /> from the <LanguageInclude section="package-name" /> package.
 
 <LanguageInclude section="custom-logger-example" />
+
+## Log Levels
+
+<LanguageInclude section="log-levels" />
+
+## Filtering by Logger Name
+
+Each logger is created with a name. You can filter which loggers emit output by providing a name pattern, using `*` as a wildcard.
+
+<LanguageInclude section="pattern-example" />
+
+## Environment Variables
+
+<LanguageInclude section="env-vars" />
+
+## Child Loggers
+
+<LanguageInclude section="child-logger" />


### PR DESCRIPTION
## Summary

Expands `in-depth-guides/observability/logging` to cover material that was previously missing, and fixes a broken Python example that referenced SDK symbols that don't exist.

**What's added (TS & PY):**
- **Log Levels** — full list of available levels and default behavior.
- **Filtering by Logger Name** — `pattern` option in code (TS), `ConsoleFilter` in code (PY), wildcard and exclusion syntax.
- **Environment Variables** — `LOG_LEVEL` and `LOG` for TS (with a callout that `LOG` must match the default logger name `@teams/app`, or it will silence output). Note for PY that env vars are not read automatically by the SDK.
- **Child Loggers** — `log.child('scope')` pattern (TypeScript only; N/A for Python).

**Python fix:**
The previous `python.incl.md` example imported `ConsoleLogger` and `ConsoleLoggerOptions` from `microsoft_teams.common` and called `App(logger=...)` — none of which exist. Replaced with the canonical pattern from `teams.py/examples/oauth/src/main.py`: stdlib `logging` + `ConsoleFormatter`. A user copy-pasting the old example would have hit `ImportError`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)