### PR TITLE
Fix incomplete package-lock.json from npm audit fix

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'packages/cli/**'
+      - 'package-lock.json'
 
 jobs:
   build-cli:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -8,6 +8,7 @@ on:
       - 'teams.md/**'
       - 'packages/cli/src/commands/**'
       - 'packages/cli/scripts/generate-command-docs.ts'
+      - 'package-lock.json'
 
 jobs:
   build-teams-md:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+os[]=darwin
+os[]=linux
+os[]=win32
+arch[]=x64
+arch[]=arm64
+libc[]=glibc
+libc[]=musl

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "glob": "^11.0.0",
         "prettier": "^3.5.3",
         "turbo": "^2.5.0",
-        "typescript": "5.8.2"
+        "typescript": "5.8.2",
+        "webpack": "5.105.4"
       },
       "engines": {
         "node": ">=20"
@@ -13430,6 +13431,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -19262,6 +19275,18 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -22746,9 +22771,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "version": "5.105.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -22767,8 +22792,9 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-db": "^1.54.0",
+        "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
@@ -23022,10 +23048,22 @@
       }
     },
     "node_modules/webpack/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -23537,6 +23575,8 @@
     },
     "packages/cli/node_modules/open": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "glob": "^11.0.0",
     "prettier": "^3.5.3",
     "turbo": "^2.5.0",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "webpack": "5.105.4"
   },
   "engines": {
     "node": ">=20"
@@ -36,6 +37,7 @@
     ]
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "webpack": "$webpack"
   }
 }


### PR DESCRIPTION
## Summary
- Add `.npmrc` with cross-platform `supportedArchitectures` so `npm install` on macOS preserves Linux/Windows native binaries in the lockfile
- Pin webpack to 5.105.4 to fix Docusaurus build failure from webpack 5.106.0's strict ProgressPlugin validation ([docusaurus#11923](https://github.com/facebook/docusaurus/issues/11923))
- Fix `open@11.0.0` missing transitive deps (`powershell-utils`, `is-in-ssh`) left behind by the previous `npm audit fix`
- Trigger CLI and docs CI on `package-lock.json` changes so lockfile issues get caught early

## Test plan
- [ ] CLI build + 103 tests pass
- [ ] Docs build passes
- [ ] `npm install` from clean state resolves all deps on Linux CI