### PR TITLE
cli: validate MSAL and Azure CLI tenants match

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,6 +78,10 @@ Create AAD apps via TDP's `/aadapp/v2` endpoint (`createAadAppViaTdp` in `src/ap
 - TDP returns a different `id` than Graph's object ID — use `getAadAppByClientId` to look up the Graph object ID before calling `addPassword`
 - Graph replication lag may require retries after TDP creates the app
 
+### Tenant Cross-Validation
+
+Any command that uses both MSAL (Teams login) and Azure CLI must call `ensureTenantMatch(account.tenantId)` from `src/utils/az-prompts.ts` before creating Azure resources. This throws `CliError("TENANT_MISMATCH", ...)` if `account.tenantId` (MSAL) differs from the Azure CLI's active tenant (`az account show`). The `status` command displays the match/mismatch but does not throw.
+
 ### Auth Client ID
 
 Uses shared public client `7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0`. TDP's own web UI uses a different first-party client ID (`e1979c22`) which we cannot use for CLI auth.

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -129,6 +129,10 @@ Create AAD apps via TDP's `/aadapp/v2` endpoint (`createAadAppViaTdp` in `src/ap
 - TDP returns a different `id` than Graph's object ID — use `getAadAppByClientId` to look up the Graph object ID before calling `addPassword`
 - Graph replication lag may require retries after TDP creates the app
 
+## Tenant Cross-Validation
+
+Any command that uses both MSAL (Teams login) and Azure CLI must call `ensureTenantMatch(account.tenantId)` from `src/utils/az-prompts.ts` before creating Azure resources. This throws `CliError("TENANT_MISMATCH", ...)` if `account.tenantId` (MSAL) differs from the Azure CLI's active tenant (`az account show`). The `status` command displays the match/mismatch but does not throw.
+
 ## Auth Client ID
 
 Uses shared public client `7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0`. TDP's own web UI uses a different first-party client ID (`e1979c22`) which we cannot use for CLI auth.

--- a/packages/cli/src/commands/app/bot/migrate.ts
+++ b/packages/cli/src/commands/app/bot/migrate.ts
@@ -13,7 +13,7 @@ import {
 import { fetchAppDetailsV2 } from '../../../apps/api.js';
 import { pickApp } from '../../../utils/app-picker.js';
 import { ensureAz, runAz } from '../../../utils/az.js';
-import { resolveSubscription, resolveResourceGroup } from '../../../utils/az-prompts.js';
+import { resolveSubscription, resolveResourceGroup, ensureTenantMatch } from '../../../utils/az-prompts.js';
 import { CliError, wrapAction } from '../../../utils/errors.js';
 import { confirmAction } from '../../../utils/interactive.js';
 import { outputJson } from '../../../utils/json-output.js';
@@ -116,6 +116,7 @@ export const botMigrateCommand = new Command('migrate')
       await ensureAz();
       const subscription = await resolveSubscription(options.subscription);
       const resourceGroup = await resolveResourceGroup(subscription, options.resourceGroup);
+      await ensureTenantMatch(account.tenantId);
 
       if (options.createResourceGroup) {
         const rgRegion = options.region ?? 'westus2';

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -23,7 +23,7 @@ import { logger } from '../../utils/logger.js';
 import { isInteractive, confirmAction } from '../../utils/interactive.js';
 import { getConfig } from '../../utils/config.js';
 import { ensureAz, runAz } from '../../utils/az.js';
-import { resolveSubscription, resolveResourceGroup } from '../../utils/az-prompts.js';
+import { resolveSubscription, resolveResourceGroup, ensureTenantMatch } from '../../utils/az-prompts.js';
 import { createSilentSpinner } from '../../utils/spinner.js';
 import { openInBrowser, printLinkBanner } from '../../utils/browser.js';
 
@@ -100,6 +100,7 @@ export const appCreateCommand = new Command('create')
         await ensureAz();
         const subscription = await resolveSubscription(options.subscription);
         const resourceGroup = await resolveResourceGroup(subscription, options.resourceGroup);
+        await ensureTenantMatch(account.tenantId);
 
         if (options.createResourceGroup) {
           const rgRegion = options.region ?? 'westus2';

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -28,6 +28,8 @@ interface StatusOutput {
     installed: boolean;
     loggedIn: boolean;
     subscription: { name: string; id: string } | null;
+    tenantId: string | null;
+    tenantMatch: boolean | null;
   };
 }
 
@@ -45,7 +47,7 @@ export const statusCommand = new Command('status')
         username: null,
         tenantId: null,
         tdp: null,
-        azureCli: { installed: false, loggedIn: false, subscription: null },
+        azureCli: { installed: false, loggedIn: false, subscription: null, tenantId: null, tenantMatch: null },
       };
 
       if (!account) {
@@ -150,11 +152,23 @@ export const statusCommand = new Command('status')
             logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('not logged in')}`);
         } else {
           try {
-            const sub = await runAz<{ name: string; id: string }>(['account', 'show']);
+            const sub = await runAz<{ name: string; id: string; tenantId: string }>(['account', 'show']);
             output.azureCli.subscription = { name: sub.name, id: sub.id };
+            output.azureCli.tenantId = sub.tenantId;
+            output.azureCli.tenantMatch = output.tenantId ? output.tenantId === sub.tenantId : null;
             if (!silent) {
               logger.info(`\n${pc.dim('Azure CLI:')} ${pc.green('connected')}`);
               logger.info(`${pc.dim('Subscription:')} ${sub.name} ${pc.dim(`(${sub.id})`)}`);
+              if (output.tenantId && sub.tenantId) {
+                if (output.tenantId === sub.tenantId) {
+                  logger.info(`${pc.dim('Tenant:')} ${pc.green('matches Teams login')}`);
+                } else {
+                  logger.info(`${pc.dim('Tenant:')} ${pc.red('mismatch')}`);
+                  logger.info(`  ${pc.dim('Teams login:')} ${output.tenantId}`);
+                  logger.info(`  ${pc.dim('Azure CLI:')}   ${sub.tenantId}`);
+                  logger.info(`  ${pc.dim('Run')} ${pc.cyan(`az login --tenant ${output.tenantId}`)} ${pc.dim('to align.')}`);
+                }
+              }
             }
           } catch {
             if (!silent)

--- a/packages/cli/src/utils/az-prompts.ts
+++ b/packages/cli/src/utils/az-prompts.ts
@@ -86,6 +86,35 @@ export async function resolveSubscription(flagValue?: string): Promise<string> {
  * - Interactive: pick existing or create new
  * - Non-interactive: required flag
  */
+/**
+ * Get the tenantId of the current Azure CLI session.
+ * Returns null if az CLI is not logged in or the call fails.
+ */
+export async function getAzTenantId(): Promise<string | null> {
+  try {
+    const account = await runAz<{ tenantId: string }>(['account', 'show']);
+    return account.tenantId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Throw if the MSAL tenant (Teams login) and Azure CLI tenant differ.
+ * No-op if the Azure CLI tenant cannot be determined.
+ */
+export async function ensureTenantMatch(msalTenantId: string): Promise<void> {
+  const azureTenantId = await getAzTenantId();
+  if (!azureTenantId) return;
+  if (msalTenantId === azureTenantId) return;
+
+  throw new CliError(
+    'TENANT_MISMATCH',
+    `Tenant mismatch: Teams login tenant (${msalTenantId}) does not match Azure CLI tenant (${azureTenantId}).`,
+    `Run \`az login --tenant ${msalTenantId}\` to align your Azure CLI session.`
+  );
+}
+
 export async function resolveResourceGroup(
   subscription: string,
   flagValue?: string

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -11,6 +11,7 @@ export type ErrorCode =
   | 'VALIDATION_MISSING'
   | 'VALIDATION_FORMAT'
   | 'INVALID_ICON'
+  | 'TENANT_MISMATCH'
   // Not found
   | 'NOT_FOUND_BOT'
   | 'NOT_FOUND_AAD'

--- a/packages/cli/tests/tenant-check.test.ts
+++ b/packages/cli/tests/tenant-check.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CliError } from '../src/utils/errors.js';
+
+const mockRunAz = vi.fn();
+
+vi.mock('../src/utils/az.js', () => ({
+  runAz: (...args: unknown[]) => mockRunAz(...args),
+}));
+
+import { getAzTenantId, ensureTenantMatch } from '../src/utils/az-prompts.js';
+
+describe('getAzTenantId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns tenantId from az account show', async () => {
+    mockRunAz.mockResolvedValue({ tenantId: 'tenant-abc' });
+
+    const result = await getAzTenantId();
+
+    expect(result).toBe('tenant-abc');
+    expect(mockRunAz).toHaveBeenCalledWith(['account', 'show']);
+  });
+
+  it('returns null when az CLI call fails', async () => {
+    mockRunAz.mockRejectedValue(new Error('not logged in'));
+
+    const result = await getAzTenantId();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('ensureTenantMatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does nothing when tenants match', async () => {
+    mockRunAz.mockResolvedValue({ tenantId: 'tenant-abc' });
+
+    await expect(ensureTenantMatch('tenant-abc')).resolves.toBeUndefined();
+  });
+
+  it('throws CliError when tenants differ', async () => {
+    mockRunAz.mockResolvedValue({ tenantId: 'tenant-xyz' });
+
+    await expect(ensureTenantMatch('tenant-abc')).rejects.toThrow(CliError);
+    await expect(ensureTenantMatch('tenant-abc')).rejects.toThrow(/Tenant mismatch/);
+  });
+
+  it('includes both tenant IDs in error message', async () => {
+    mockRunAz.mockResolvedValue({ tenantId: 'tenant-xyz' });
+
+    try {
+      await ensureTenantMatch('tenant-abc');
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CliError);
+      const cliError = error as CliError;
+      expect(cliError.code).toBe('TENANT_MISMATCH');
+      expect(cliError.message).toContain('tenant-abc');
+      expect(cliError.message).toContain('tenant-xyz');
+      expect(cliError.suggestion).toContain('az login --tenant tenant-abc');
+    }
+  });
+
+  it('does nothing when az CLI fails (indeterminate)', async () => {
+    mockRunAz.mockRejectedValue(new Error('not logged in'));
+
+    await expect(ensureTenantMatch('tenant-abc')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- adds `ensureTenantMatch()` utility that throws `TENANT_MISMATCH` if the Teams login tenant differs from the Azure CLI tenant
- `app create` and `bot migrate` now block on tenant mismatch before creating any resources
- `status` command shows tenant match/mismatch with both IDs and a fix suggestion
- adds unit tests for the new tenant check functions

## Test plan
- run `teams status` while logged into different tenants in Teams vs Azure CLI — should show red "mismatch"
- run `teams status` with matching tenants — should show green "matches Teams login"
- run `teams app create --azure` with mismatched tenants — should throw TENANT_MISMATCH error
- `npx vitest run` passes