### PR TITLE
cli: add --device-code flag to teams login

### DIFF
--- a/packages/cli/src/auth/client.ts
+++ b/packages/cli/src/auth/client.ts
@@ -41,13 +41,13 @@ const ERROR_TEMPLATE =
   '<html><body><h2>Authentication failed</h2><p>Something went wrong. Please try again.</p></body></html>';
 
 export interface LoginOptions {
-  useDeviceCode?: boolean;
+  forceDeviceCode?: boolean;
 }
 
 export async function login(options?: LoginOptions): Promise<AccountInfo> {
   const client = await getMsalClient();
 
-  const useBrowser = !options?.useDeviceCode && isInteractive() && isLocalSession();
+  const useBrowser = !options?.forceDeviceCode && isInteractive() && isLocalSession();
   const result = useBrowser
     ? await loginInteractive(client)
     : await loginDeviceCode(client);

--- a/packages/cli/src/auth/client.ts
+++ b/packages/cli/src/auth/client.ts
@@ -40,13 +40,17 @@ const SUCCESS_TEMPLATE =
 const ERROR_TEMPLATE =
   '<html><body><h2>Authentication failed</h2><p>Something went wrong. Please try again.</p></body></html>';
 
-export async function login(): Promise<AccountInfo> {
+export interface LoginOptions {
+  useDeviceCode?: boolean;
+}
+
+export async function login(options?: LoginOptions): Promise<AccountInfo> {
   const client = await getMsalClient();
 
-  const result =
-    isInteractive() && isLocalSession()
-      ? await loginInteractive(client)
-      : await loginDeviceCode(client);
+  const useBrowser = !options?.useDeviceCode && isInteractive() && isLocalSession();
+  const result = useBrowser
+    ? await loginInteractive(client)
+    : await loginDeviceCode(client);
 
   if (!result?.account) {
     throw new Error('Login failed: no account returned');

--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -1,2 +1,2 @@
-export { getMsalClient, getAccount, login, logout, getTokenSilent } from './client.js';
+export { getMsalClient, getAccount, login, logout, getTokenSilent, type LoginOptions } from './client.js';
 export { msalConfig, paths, loginScopes, graphScopes, teamsDevPortalScopes } from './config.js';

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -20,19 +20,32 @@ export const loginCommand = new Command('login')
       return;
     }
 
-    const useDeviceCode = options.deviceCode;
-    const useBrowser = !useDeviceCode && isInteractive() && isLocalSession();
-    const spinner = createSpinner(
-      useBrowser ? 'Opening browser for login...' : 'Authenticating...'
-    ).start();
-    try {
-      const account = await login({ useDeviceCode });
-      spinner.success({ text: `Logged in as ${account.username}` });
-    } catch (error) {
-      spinner.error({ text: 'Login failed' });
-      if (error instanceof Error) {
-        logger.error(error.message);
+    const forceDeviceCode = options.deviceCode;
+    const useBrowser = !forceDeviceCode && isInteractive() && isLocalSession();
+
+    if (useBrowser) {
+      const spinner = createSpinner('Opening browser for login...').start();
+      try {
+        const account = await login();
+        spinner.success({ text: `Logged in as ${account.username}` });
+      } catch (error) {
+        spinner.error({ text: 'Login failed' });
+        if (error instanceof Error) {
+          logger.error(error.message);
+        }
+        process.exit(1);
       }
-      process.exit(1);
+    } else {
+      // No spinner for device code — MSAL prints the code/URL to stdout
+      try {
+        const account = await login({ forceDeviceCode });
+        logger.info(`Logged in as ${account.username}`);
+      } catch (error) {
+        logger.error('Login failed');
+        if (error instanceof Error) {
+          logger.error(error.message);
+        }
+        process.exit(1);
+      }
     }
   });

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -4,9 +4,14 @@ import { login, getAccount } from '../../auth/index.js';
 import { logger } from '../../utils/logger.js';
 import { isInteractive, isLocalSession } from '../../utils/interactive.js';
 
+interface LoginCommandOptions {
+  deviceCode?: boolean;
+}
+
 export const loginCommand = new Command('login')
   .description('Log in to Microsoft 365')
-  .action(async () => {
+  .option('--device-code', '[OPTIONAL] Use device code flow instead of opening a browser')
+  .action(async (options: LoginCommandOptions) => {
     const existingAccount = await getAccount();
 
     if (existingAccount) {
@@ -15,12 +20,13 @@ export const loginCommand = new Command('login')
       return;
     }
 
-    const useBrowser = isInteractive() && isLocalSession();
+    const useDeviceCode = options.deviceCode;
+    const useBrowser = !useDeviceCode && isInteractive() && isLocalSession();
     const spinner = createSpinner(
       useBrowser ? 'Opening browser for login...' : 'Authenticating...'
     ).start();
     try {
-      const account = await login();
+      const account = await login({ useDeviceCode });
       spinner.success({ text: `Logged in as ${account.username}` });
     } catch (error) {
       spinner.error({ text: 'Login failed' });

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -3,6 +3,7 @@ import { createSpinner } from 'nanospinner';
 import { login, getAccount } from '../../auth/index.js';
 import { logger } from '../../utils/logger.js';
 import { isInteractive, isLocalSession } from '../../utils/interactive.js';
+import { wrapAction } from '../../utils/errors.js';
 
 interface LoginCommandOptions {
   deviceCode?: boolean;
@@ -11,41 +12,32 @@ interface LoginCommandOptions {
 export const loginCommand = new Command('login')
   .description('Log in to Microsoft 365')
   .option('--device-code', '[OPTIONAL] Use device code flow instead of opening a browser')
-  .action(async (options: LoginCommandOptions) => {
-    const existingAccount = await getAccount();
+  .action(
+    wrapAction(async (options: LoginCommandOptions) => {
+      const existingAccount = await getAccount();
 
-    if (existingAccount) {
-      logger.info(`Already logged in as ${existingAccount.username}`);
-      logger.info('Run "teams logout" first to switch accounts.');
-      return;
-    }
-
-    const forceDeviceCode = options.deviceCode;
-    const useBrowser = !forceDeviceCode && isInteractive() && isLocalSession();
-
-    if (useBrowser) {
-      const spinner = createSpinner('Opening browser for login...').start();
-      try {
-        const account = await login();
-        spinner.success({ text: `Logged in as ${account.username}` });
-      } catch (error) {
-        spinner.error({ text: 'Login failed' });
-        if (error instanceof Error) {
-          logger.error(error.message);
-        }
-        process.exit(1);
+      if (existingAccount) {
+        logger.info(`Already logged in as ${existingAccount.username}`);
+        logger.info('Run "teams logout" first to switch accounts.');
+        return;
       }
-    } else {
-      // No spinner for device code — MSAL prints the code/URL to stdout
-      try {
+
+      const forceDeviceCode = options.deviceCode;
+      const useBrowser = !forceDeviceCode && isInteractive() && isLocalSession();
+
+      if (useBrowser) {
+        const spinner = createSpinner('Opening browser for login...').start();
+        try {
+          const account = await login();
+          spinner.success({ text: `Logged in as ${account.username}` });
+        } catch (error) {
+          spinner.error({ text: 'Login failed' });
+          throw error;
+        }
+      } else {
+        // No spinner for device code — MSAL prints the code/URL to stdout
         const account = await login({ forceDeviceCode });
         logger.info(`Logged in as ${account.username}`);
-      } catch (error) {
-        logger.error('Login failed');
-        if (error instanceof Error) {
-          logger.error(error.message);
-        }
-        process.exit(1);
       }
-    }
-  });
+    })
+  );


### PR DESCRIPTION
## Summary
- adds `--device-code` flag to `teams login` so users can force device code flow
- on WSL (and similar), the default browser profile may be logged into the wrong tenant — device code lets users pick which browser/profile to authenticate in
- the device code flow already existed for non-interactive sessions, this just lets interactive users opt into it

## Test plan
- `teams login --help` shows the new `--device-code` option
- `teams login --device-code` prints a device code URL instead of opening the browser
- `teams login` (without flag) still opens browser as before
- `npx vitest run` passes