### PR TITLE
[Docs] Fix C# MCP client transport — StreamableHttp is supported and default

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/ai/mcp/mcp-client/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/mcp/mcp-client/csharp.incl.md
@@ -1,6 +1,6 @@
 <!-- protocol-name -->
 
-SSE protocol
+Streamable HTTP protocol
 
 <!-- install -->
 
@@ -12,11 +12,11 @@ dotnet add package Microsoft.Teams.Plugins.External.McpClient --prerelease
 
 <!-- remote-protocol -->
 
-SSE
+Streamable HTTP/SSE
 
 <!-- server-setup -->
 
-a valid SSE
+valid remote
 
 <!-- auth-requirements -->
 
@@ -102,6 +102,20 @@ new McpClientPlugin()
         {
                HeadersFactory = () => new Dictionary<string, string>()
                { { "HEADER_KEY", "HEADER_VALUE" } }
+        }
+    );
+```
+
+### Transport Mode
+
+The client defaults to the Streamable HTTP transport. If the MCP server you are connecting to only supports SSE, set `Transport` to `McpClientTransport.Sse`:
+
+```csharp
+new McpClientPlugin()
+    .UseMcpServer("https://<your-mcp-server>/mcp",
+        new McpClientPluginParams()
+        {
+               Transport = McpClientTransport.Sse
         }
     );
 ```

--- a/teams.md/src/components/include/in-depth-guides/ai/mcp/mcp-client/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/mcp/mcp-client/csharp.incl.md
@@ -100,8 +100,8 @@ new McpClientPlugin()
     .UseMcpServer("https://learn.microsoft.com/api/mcp",
         new McpClientPluginParams()
         {
-               HeadersFactory = () => new Dictionary<string, string>()
-               { { "HEADER_KEY", "HEADER_VALUE" } }
+            HeadersFactory = () => new Dictionary<string, string>()
+            { { "HEADER_KEY", "HEADER_VALUE" } }
         }
     );
 ```
@@ -115,7 +115,7 @@ new McpClientPlugin()
     .UseMcpServer("https://<your-mcp-server>/mcp",
         new McpClientPluginParams()
         {
-               Transport = McpClientTransport.Sse
+            Transport = McpClientTransport.Sse
         }
     );
 ```


### PR DESCRIPTION
## Summary
- The C# MCP client plugin supports both Streamable HTTP and SSE transports; `StreamableHttp` is the default (see `McpClientPluginParams.Transport` in `teams.net`).
- The csharp include claimed only SSE was supported, which is incorrect.
- Updates protocol wording to match TS/Python, and adds a **Transport Mode** snippet showing how to opt into SSE when a server doesn't support Streamable HTTP.

Reported in microsoft/teams.net#426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)