### PR TITLE
cli: bump manifest to v1.25

### DIFF
--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -1,5 +1,6 @@
 import { input, checkbox } from '@inquirer/prompts';
 import { isInteractive } from '../utils/interactive.js';
+import type { BotScope } from './manifest.js';
 
 /**
  * Placeholder bot ID for manifest generation when no real bot ID is available.
@@ -9,7 +10,7 @@ export const PLACEHOLDER_BOT_ID = '00000000-0000-0000-0000-000000000000';
 export interface ManifestCustomization {
   description?: { short: string; full?: string };
   icons?: { colorIconPath?: string; outlineIconPath?: string };
-  scopes?: string[];
+  scopes?: BotScope[];
   developer?: {
     name: string;
     websiteUrl: string;
@@ -58,7 +59,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
   }
 
   if (customizeFields.includes('scopes')) {
-    result.scopes = await checkbox({
+    result.scopes = await checkbox<BotScope>({
       message: 'Select bot scopes:',
       choices: [
         { name: 'Personal', value: 'personal', checked: true },

--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -63,7 +63,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
       choices: [
         { name: 'Personal', value: 'personal', checked: true },
         { name: 'Team', value: 'team', checked: true },
-        { name: 'Group Chat', value: 'groupchat', checked: true },
+        { name: 'Group Chat', value: 'groupChat', checked: true },
       ],
     });
   }

--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -3,12 +3,14 @@ import path from 'node:path';
 import AdmZip from 'adm-zip';
 import { staticsDir } from '../project/paths.js';
 
+export type BotScope = 'personal' | 'team' | 'groupChat' | 'copilot';
+
 export interface ManifestOptions {
   botId: string;
   botName: string;
   endpoint?: string;
   description?: { short: string; full?: string };
-  scopes?: string[];
+  scopes?: BotScope[];
   developer?: {
     name: string;
     websiteUrl: string;
@@ -31,7 +33,7 @@ export function extractDomain(url: string): string | null {
 export interface Manifest {
   id: string;
   name: { short: string; full?: string };
-  bots?: Array<{ botId: string; scopes: string[] }>;
+  bots?: Array<{ botId: string; scopes: BotScope[] }>;
   [key: string]: unknown;
 }
 

--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -41,7 +41,7 @@ export function createManifest(options: ManifestOptions): object {
     botName,
     endpoint,
     description,
-    scopes = ['personal', 'team', 'groupchat'],
+    scopes = ['personal', 'team', 'groupChat'],
     developer,
   } = options;
 
@@ -53,11 +53,10 @@ export function createManifest(options: ManifestOptions): object {
 
   return {
     $schema:
-      'https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.schema.json',
-    manifestVersion: '1.16',
+      'https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json',
+    manifestVersion: '1.25',
     version: '1.0.0',
     id: botId,
-    packageName: `com.teams.${botId}`,
     developer: developer ?? {
       name: 'Developer',
       websiteUrl: 'https://www.example.com',
@@ -85,8 +84,13 @@ export function createManifest(options: ManifestOptions): object {
         isNotificationOnly: false,
       },
     ],
+    staticTabs: [
+      { entityId: 'conversations', scopes: ['personal'] },
+      { entityId: 'about', scopes: ['personal'] },
+    ],
     permissions: [],
     validDomains,
+    supportsChannelFeatures: 'tier1',
   };
 }
 

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -9,6 +9,7 @@ import {
   getAadAppByClientId,
   importAppPackage,
   type ManifestOptions,
+  type BotScope,
   createTdpBotHandler,
   createAzureBotHandler,
   type AzureContext,
@@ -173,7 +174,7 @@ export const appCreateCommand = new Command('create')
 
       // Collect manifest customization options
       let descriptionOpts: { short: string; full?: string } | undefined;
-      let scopeChoices: string[] | undefined;
+      let scopeChoices: BotScope[] | undefined;
       let developerOpts:
         | {
             name: string;

--- a/packages/cli/tests/manifest-upload-zip.test.ts
+++ b/packages/cli/tests/manifest-upload-zip.test.ts
@@ -11,7 +11,7 @@ const MOCK_OUTLINE_ICON = Buffer.from('mock-outline-icon-data');
 const SERVER_MANIFEST = JSON.stringify({
   id: 'test-app-id',
   version: '1.0.0',
-  manifestVersion: '1.16',
+  manifestVersion: '1.25',
   name: { short: 'Test' },
 });
 

--- a/packages/cli/tests/rsc-set.test.ts
+++ b/packages/cli/tests/rsc-set.test.ts
@@ -116,7 +116,7 @@ const mockDetails: AppDetails = {
   websiteUrl: 'https://example.com',
   privacyUrl: 'https://example.com/privacy',
   termsOfUseUrl: 'https://example.com/terms',
-  manifestVersion: '1.16',
+  manifestVersion: '1.25',
   webApplicationInfoId: 'existing-aad-app-id',
   mpnId: '',
   accentColor: '#FFFFFF',

--- a/packages/cli/tests/rsc-web-app-info.test.ts
+++ b/packages/cli/tests/rsc-web-app-info.test.ts
@@ -24,7 +24,7 @@ const mockDetails: AppDetails = {
   websiteUrl: 'https://example.com',
   privacyUrl: 'https://example.com/privacy',
   termsOfUseUrl: 'https://example.com/terms',
-  manifestVersion: '1.16',
+  manifestVersion: '1.25',
   webApplicationInfoId: '',
   mpnId: '',
   accentColor: '#FFFFFF',


### PR DESCRIPTION
## Summary
- bumps Teams app manifest from 1.16 → 1.25 (latest schema)
- fixes schema validation issues: removed deprecated `packageName`, fixed `groupchat` → `groupChat` casing
- adds `staticTabs` (conversations + about) and `supportsChannelFeatures: tier1`

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — all 109 tests pass
- [x] validated generated manifest against v1.25 JSON schema with ajv