### PR TITLE
cli: auto-bump app version on update

### DIFF
--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -35,7 +35,7 @@ throw new CliError("AUTH_REQUIRED", "Not logged in.", "Run `teams login` first."
 
 Wrap command `.action()` handlers with `wrapAction()` — it catches `CliError` and unknown errors, routes to JSON or human output, and handles `ExitPromptError` gracefully. In interactive menus (not wrapped by `wrapAction`), catch errors inline with `logger.error()`.
 
-**API helpers (`src/apps/`) must never log directly.** Functions like `updateAppDetails`, `uploadIcon`, and other API layer code should return metadata (e.g., `result.versionBumped`) instead of calling `logger`. Only command-layer code should log, because it knows whether the caller is in `--json` mode, has active spinners, etc. Logging from API helpers corrupts `--json` output and breaks spinner rendering.
+**HTTP/API helper modules (for example, `src/apps/api.ts` and similar transport/helper code) must never log directly.** Functions like `updateAppDetails`, `uploadIcon`, and other API layer code should return metadata (e.g., `result.versionBumped`) instead of calling `logger`. Only command-layer code should log, because it knows whether the caller is in `--json` mode, has active spinners, etc. Logging from API helpers corrupts `--json` output and breaks spinner rendering. This restriction does not apply to interactive/UI modules that also live under `src/apps/`.
 
 ## Spinners
 

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -35,6 +35,8 @@ throw new CliError("AUTH_REQUIRED", "Not logged in.", "Run `teams login` first."
 
 Wrap command `.action()` handlers with `wrapAction()` — it catches `CliError` and unknown errors, routes to JSON or human output, and handles `ExitPromptError` gracefully. In interactive menus (not wrapped by `wrapAction`), catch errors inline with `logger.error()`.
 
+**API helpers (`src/apps/`) must never log directly.** Functions like `updateAppDetails`, `uploadIcon`, and other API layer code should return metadata (e.g., `result.versionBumped`) instead of calling `logger`. Only command-layer code should log, because it knows whether the caller is in `--json` mode, has active spinners, etc. Logging from API helpers corrupts `--json` output and breaks spinner rendering.
+
 ## Spinners
 
 Use `createSilentSpinner()` from `src/utils/spinner.ts` (not `createSpinner` from nanospinner directly). Pass `silent = true` when `--json` is active to suppress visual output. Always include descriptive text.

--- a/packages/cli/src/apps/api.ts
+++ b/packages/cli/src/apps/api.ts
@@ -1,10 +1,13 @@
 import AdmZip from 'adm-zip';
 import fs from 'node:fs';
 import path from 'node:path';
+import pc from 'picocolors';
 import type { AppSummary, AppDetails, AppBot } from './types.js';
 import { importAppPackage } from './tdp.js';
 import { apiFetch } from '../utils/http.js';
 import { CliError } from '../utils/errors.js';
+import { logger } from '../utils/logger.js';
+import { bumpPatchVersion } from '../utils/version.js';
 import { staticsDir } from '../project/paths.js';
 
 /**
@@ -165,13 +168,26 @@ export async function fetchAppDetailsV2(token: string, teamsAppId: string): Prom
 }
 
 /**
+ * Stable JSON.stringify that sorts object keys for reliable deep comparison.
+ */
+function stableStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) =>
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
+      : value
+  );
+}
+
+/**
  * Update app details using the read-modify-write pattern.
  * Fetches current full object, merges updates, and POSTs the full object back.
+ * Auto-bumps the patch version when content changes (unless version is explicitly set).
  */
 export async function updateAppDetails(
   token: string,
   teamsAppId: string,
-  updates: Partial<AppDetails>
+  updates: Partial<AppDetails>,
+  options?: { autoBumpVersion?: boolean }
 ): Promise<AppDetails> {
   // 1. Fetch current full object
   const currentDetails = await fetchAppDetailsV2(token, teamsAppId);
@@ -179,7 +195,21 @@ export async function updateAppDetails(
   // 2. Merge updates into it
   const updatedDetails = { ...currentDetails, ...updates };
 
-  // 3. POST full object back
+  // 3. Auto-bump version if content changed and caller didn't set version explicitly
+  const autoBump = options?.autoBumpVersion ?? true;
+  if (autoBump && !('version' in updates) && currentDetails.version) {
+    const { version: _cv, ...currentWithoutVersion } = currentDetails;
+    const { version: _uv, ...updatedWithoutVersion } = updatedDetails;
+    if (stableStringify(currentWithoutVersion) !== stableStringify(updatedWithoutVersion)) {
+      const bumped = bumpPatchVersion(currentDetails.version);
+      if (bumped) {
+        updatedDetails.version = bumped;
+        logger.info(pc.dim(`Version auto-bumped: ${currentDetails.version} → ${bumped} — reinstall may be needed`));
+      }
+    }
+  }
+
+  // 4. POST full object back
   const response = await apiFetch(`${TDP_BASE_URL}/appdefinitions/v2/${teamsAppId}`, {
     method: 'POST',
     headers: {
@@ -204,7 +234,8 @@ export async function uploadIcon(
   token: string,
   teamsAppId: string,
   iconType: 'color' | 'outline',
-  base64String: string
+  base64String: string,
+  options?: { autoBumpVersion?: boolean }
 ): Promise<void> {
   // Step 1: Upload icon bytes
   const uploadResponse = await apiFetch(`${TDP_BASE_URL}/appdefinitions/${teamsAppId}/image`, {
@@ -233,7 +264,7 @@ export async function uploadIcon(
   // Step 2: Write URL back to app definition (read-modify-write to preserve the other icon)
   const field = iconType === 'color' ? 'colorIcon' : 'outlineIcon';
   try {
-    await updateAppDetails(token, teamsAppId, { [field]: iconUrl });
+    await updateAppDetails(token, teamsAppId, { [field]: iconUrl }, options);
   } catch (error) {
     if (error instanceof CliError) throw error;
     const msg = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/apps/api.ts
+++ b/packages/cli/src/apps/api.ts
@@ -7,7 +7,7 @@ import { importAppPackage } from './tdp.js';
 import { apiFetch } from '../utils/http.js';
 import { CliError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
-import { bumpPatchVersion } from '../utils/version.js';
+import { bumpPatchVersion, stableStringify } from '../utils/version.js';
 import { staticsDir } from '../project/paths.js';
 
 /**
@@ -165,17 +165,6 @@ export async function fetchAppDetailsV2(token: string, teamsAppId: string): Prom
   }
 
   return response.json();
-}
-
-/**
- * Stable JSON.stringify that sorts object keys for reliable deep comparison.
- */
-function stableStringify(obj: unknown): string {
-  return JSON.stringify(obj, (_key, value) =>
-    value && typeof value === 'object' && !Array.isArray(value)
-      ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
-      : value
-  );
 }
 
 /**

--- a/packages/cli/src/apps/api.ts
+++ b/packages/cli/src/apps/api.ts
@@ -1,12 +1,10 @@
 import AdmZip from 'adm-zip';
 import fs from 'node:fs';
 import path from 'node:path';
-import pc from 'picocolors';
 import type { AppSummary, AppDetails, AppBot } from './types.js';
 import { importAppPackage } from './tdp.js';
 import { apiFetch } from '../utils/http.js';
 import { CliError } from '../utils/errors.js';
-import { logger } from '../utils/logger.js';
 import { bumpPatchVersion, stableStringify } from '../utils/version.js';
 import { staticsDir } from '../project/paths.js';
 
@@ -185,6 +183,8 @@ export async function updateAppDetails(
   const updatedDetails = { ...currentDetails, ...updates };
 
   // 3. Auto-bump version if content changed and caller didn't set version explicitly
+  let versionBumped = false;
+  let previousVersion: string | undefined;
   const autoBump = options?.autoBumpVersion ?? true;
   if (autoBump && !('version' in updates) && currentDetails.version) {
     const { version: _cv, ...currentWithoutVersion } = currentDetails;
@@ -192,8 +192,9 @@ export async function updateAppDetails(
     if (stableStringify(currentWithoutVersion) !== stableStringify(updatedWithoutVersion)) {
       const bumped = bumpPatchVersion(currentDetails.version);
       if (bumped) {
+        previousVersion = currentDetails.version;
         updatedDetails.version = bumped;
-        logger.info(pc.dim(`Version auto-bumped: ${currentDetails.version} → ${bumped} — reinstall may be needed`));
+        versionBumped = true;
       }
     }
   }
@@ -212,7 +213,10 @@ export async function updateAppDetails(
     throw new Error(`Failed to update app details: ${response.status} ${response.statusText}`);
   }
 
-  return response.json();
+  const result = (await response.json()) as AppDetails;
+  result.versionBumped = versionBumped;
+  if (previousVersion) result.previousVersion = previousVersion;
+  return result;
 }
 
 /**

--- a/packages/cli/src/apps/api.ts
+++ b/packages/cli/src/apps/api.ts
@@ -165,6 +165,11 @@ export async function fetchAppDetailsV2(token: string, teamsAppId: string): Prom
   return response.json();
 }
 
+export interface UpdateAppDetailsResult extends AppDetails {
+  versionBumped: boolean;
+  previousVersion?: string;
+}
+
 /**
  * Update app details using the read-modify-write pattern.
  * Fetches current full object, merges updates, and POSTs the full object back.
@@ -175,7 +180,7 @@ export async function updateAppDetails(
   teamsAppId: string,
   updates: Partial<AppDetails>,
   options?: { autoBumpVersion?: boolean }
-): Promise<AppDetails> {
+): Promise<UpdateAppDetailsResult> {
   // 1. Fetch current full object
   const currentDetails = await fetchAppDetailsV2(token, teamsAppId);
 
@@ -210,13 +215,15 @@ export async function updateAppDetails(
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to update app details: ${response.status} ${response.statusText}`);
+    const errorText = await response.text();
+    throw new CliError(
+      'API_ERROR',
+      `Failed to update app details: ${response.status} ${errorText}`
+    );
   }
 
-  const result = (await response.json()) as AppDetails;
-  result.versionBumped = versionBumped;
-  if (previousVersion) result.previousVersion = previousVersion;
-  return result;
+  const details = (await response.json()) as AppDetails;
+  return { ...details, versionBumped, previousVersion };
 }
 
 /**
@@ -229,7 +236,7 @@ export async function uploadIcon(
   iconType: 'color' | 'outline',
   base64String: string,
   options?: { autoBumpVersion?: boolean }
-): Promise<void> {
+): Promise<UpdateAppDetailsResult> {
   // Step 1: Upload icon bytes
   const uploadResponse = await apiFetch(`${TDP_BASE_URL}/appdefinitions/${teamsAppId}/image`, {
     method: 'POST',
@@ -257,7 +264,7 @@ export async function uploadIcon(
   // Step 2: Write URL back to app definition (read-modify-write to preserve the other icon)
   const field = iconType === 'color' ? 'colorIcon' : 'outlineIcon';
   try {
-    await updateAppDetails(token, teamsAppId, { [field]: iconUrl }, options);
+    return await updateAppDetails(token, teamsAppId, { [field]: iconUrl }, options);
   } catch (error) {
     if (error instanceof CliError) throw error;
     const msg = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/apps/basic-info.ts
+++ b/packages/cli/src/apps/basic-info.ts
@@ -102,6 +102,9 @@ async function editField(
       [fieldKey]: newValue.trim(),
     });
     spinner.success({ text: `${field.label} updated successfully` });
+    if (updated.versionBumped) {
+      logger.info(pc.dim(`Version auto-bumped: ${updated.previousVersion} → ${updated.version} — reinstall may be needed`));
+    }
     return updated;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/cli/src/commands/app/manifest/actions.ts
+++ b/packages/cli/src/commands/app/manifest/actions.ts
@@ -8,7 +8,7 @@ import { CliError } from '../../../utils/errors.js';
 import { isAutoConfirm } from '../../../utils/interactive.js';
 import { logger } from '../../../utils/logger.js';
 import { createSilentSpinner } from '../../../utils/spinner.js';
-import { bumpPatchVersion, compareVersions } from '../../../utils/version.js';
+import { bumpPatchVersion, compareVersions, stableStringify } from '../../../utils/version.js';
 
 export interface UploadResult {
   version?: string;
@@ -134,12 +134,6 @@ export async function uploadManifestFromFile(
           // Same version — bump if content actually changed
           const { version: _sv, ...serverCopy } = serverManifest;
           const { version: _lv, ...localCopy } = manifest;
-          const stableStringify = (obj: unknown) =>
-            JSON.stringify(obj, (_key, value) =>
-              value && typeof value === 'object' && !Array.isArray(value)
-                ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
-                : value
-            );
           const contentChanged = stableStringify(serverCopy) !== stableStringify(localCopy);
 
           if (contentChanged) {

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -354,8 +354,11 @@ export const appUpdateCommand = new Command('update')
       }
 
       // Scripting mode: apply all mutation flags
-      // Snapshot before updates for version-bump comparison
-      const detailsBefore = await fetchAppDetailsV2(token, appId);
+      // Snapshot before updates for version-bump comparison (skip if user set --version)
+      let detailsBefore: AppDetails | undefined;
+      if (!options.version) {
+        detailsBefore = await fetchAppDetailsV2(token, appId);
+      }
 
       const allUpdates: AppUpdateOutput['updated'] = {};
       let endpointBotId: string | undefined;
@@ -540,7 +543,7 @@ export const appUpdateCommand = new Command('update')
 
       // Single version bump after all updates (skip if user set --version explicitly)
       let versionBumped = false;
-      if (!options.version) {
+      if (detailsBefore) {
         const detailsAfter = await fetchAppDetailsV2(token, appId);
         const { version: _bv, ...beforeSnapshot } = detailsBefore;
         const { version: _av, ...afterSnapshot } = detailsAfter;

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -50,6 +50,7 @@ interface AppUpdateOutput {
   teamsAppId: string;
   botId?: string;
   validDomains?: string[];
+  needsReinstall?: boolean;
   updated: {
     endpoint?: string;
     shortName?: string;
@@ -196,8 +197,11 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
           const domains = (appDetails.validDomains as string[]) ?? [];
           if (!domains.includes(domain)) {
             const domainSpinner = createSilentSpinner('Updating valid domains...').start();
-            await updateAppDetails(token, app.teamsAppId, { validDomains: [...domains, domain] });
+            const domainResult = await updateAppDetails(token, app.teamsAppId, { validDomains: [...domains, domain] });
             domainSpinner.success({ text: `Added ${domain} to valid domains` });
+            if (domainResult.versionBumped) {
+              logger.info(pc.dim(`Version auto-bumped: ${domainResult.previousVersion} → ${domainResult.version} — reinstall may be needed`));
+            }
           }
         }
         continue;
@@ -225,8 +229,11 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
           const domains = (appDetails.validDomains as string[]) ?? [];
           if (!domains.includes(domain)) {
             const domainSpinner = createSilentSpinner('Updating valid domains...').start();
-            await updateAppDetails(token, app.teamsAppId, { validDomains: [...domains, domain] });
+            const domainResult = await updateAppDetails(token, app.teamsAppId, { validDomains: [...domains, domain] });
             domainSpinner.success({ text: `Added ${domain} to valid domains` });
+            if (domainResult.versionBumped) {
+              logger.info(pc.dim(`Version auto-bumped: ${domainResult.previousVersion} → ${domainResult.version} — reinstall may be needed`));
+            }
           }
         }
         continue;
@@ -400,8 +407,9 @@ export const appUpdateCommand = new Command('update')
           }
         }
 
-        // Update validDomains with the new endpoint's domain
-        const domains = (detailsBefore.validDomains as string[]) ?? [];
+        // Update validDomains with the new endpoint's domain (fresh fetch to avoid stale data)
+        const currentDetails = await fetchAppDetailsV2(token, appId);
+        const domains = (currentDetails.validDomains as string[]) ?? [];
         const domain = extractDomain(options.endpoint);
         endpointValidDomains = domains;
         if (domain && !domains.includes(domain)) {
@@ -553,7 +561,7 @@ export const appUpdateCommand = new Command('update')
 
       // Single JSON output for all updates
       if (options.json) {
-        const result: AppUpdateOutput & { needsReinstall?: boolean } = {
+        const result: AppUpdateOutput = {
           teamsAppId: appId,
           ...(endpointBotId ? { botId: endpointBotId } : {}),
           ...(endpointValidDomains ? { validDomains: endpointValidDomains } : {}),

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -23,9 +23,19 @@ import { outputJson } from '../../utils/json-output.js';
 import { logger } from '../../utils/logger.js';
 import { pickApp } from '../../utils/app-picker.js';
 import { createSilentSpinner } from '../../utils/spinner.js';
+import { bumpPatchVersion } from '../../utils/version.js';
 import type { AppSummary, AppDetails } from '../../apps/types.js';
 import type { BotDetails } from '../../apps/tdp.js';
 import type { BotLocation } from '../../apps/bot-location.js';
+
+/** Stable JSON.stringify with sorted keys for reliable deep comparison. */
+function stableStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) =>
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
+      : value
+  );
+}
 
 interface UpdateOptions {
   endpoint?: string;
@@ -346,6 +356,9 @@ export const appUpdateCommand = new Command('update')
       }
 
       // Scripting mode: apply all mutation flags
+      // Snapshot before updates for version-bump comparison
+      const detailsBefore = await fetchAppDetailsV2(token, appId);
+
       const allUpdates: AppUpdateOutput['updated'] = {};
       let endpointBotId: string | undefined;
       let endpointValidDomains: string[] | undefined;
@@ -397,14 +410,13 @@ export const appUpdateCommand = new Command('update')
         }
 
         // Update validDomains with the new endpoint's domain
-        const details = await fetchAppDetailsV2(token, appId);
-        const domains = (details.validDomains as string[]) ?? [];
+        const domains = (detailsBefore.validDomains as string[]) ?? [];
         const domain = extractDomain(options.endpoint);
         endpointValidDomains = domains;
         if (domain && !domains.includes(domain)) {
           const domainSpinner = createSilentSpinner('Updating valid domains...', silent).start();
           endpointValidDomains = [...domains, domain];
-          await updateAppDetails(token, appId, { validDomains: endpointValidDomains });
+          await updateAppDetails(token, appId, { validDomains: endpointValidDomains }, { autoBumpVersion: false });
           domainSpinner.success({ text: `Added ${domain} to valid domains` });
         }
 
@@ -498,7 +510,7 @@ export const appUpdateCommand = new Command('update')
       const { endpoint: _ep, colorIcon: _ci, outlineIcon: _oi, ...basicInfoUpdates } = allUpdates;
       if (Object.keys(basicInfoUpdates).length > 0) {
         const spinner = createSilentSpinner('Updating app details...', silent).start();
-        await updateAppDetails(token, appId, basicInfoUpdates);
+        await updateAppDetails(token, appId, basicInfoUpdates, { autoBumpVersion: false });
         spinner.success({ text: 'App details updated successfully' });
 
         if (!options.json) {
@@ -515,25 +527,47 @@ export const appUpdateCommand = new Command('update')
       // --- Icons ---
       if (colorIconData) {
         const spinner = createSilentSpinner('Uploading color icon...', silent).start();
-        await uploadIcon(token, appId, 'color', colorIconData.base64);
+        await uploadIcon(token, appId, 'color', colorIconData.base64, { autoBumpVersion: false });
         spinner.success({ text: 'Color icon uploaded' });
         allUpdates.colorIcon = true;
       }
 
       if (outlineIconData) {
         const spinner = createSilentSpinner('Uploading outline icon...', silent).start();
-        await uploadIcon(token, appId, 'outline', outlineIconData.base64);
+        await uploadIcon(token, appId, 'outline', outlineIconData.base64, { autoBumpVersion: false });
         spinner.success({ text: 'Outline icon uploaded' });
         allUpdates.outlineIcon = true;
       }
 
+      // Single version bump after all updates (skip if user set --version explicitly)
+      let versionBumped = false;
+      if (!options.version) {
+        const detailsAfter = await fetchAppDetailsV2(token, appId);
+        const { version: _bv, ...beforeSnapshot } = detailsBefore;
+        const { version: _av, ...afterSnapshot } = detailsAfter;
+        const contentChanged = stableStringify(beforeSnapshot) !== stableStringify(afterSnapshot);
+
+        if (contentChanged) {
+          const bumped = bumpPatchVersion(detailsAfter.version);
+          if (bumped) {
+            await updateAppDetails(token, appId, { version: bumped }, { autoBumpVersion: false });
+            versionBumped = true;
+            allUpdates.version = bumped;
+            if (!silent) {
+              logger.info(pc.dim(`Version auto-bumped: ${detailsAfter.version} → ${bumped} — reinstall may be needed`));
+            }
+          }
+        }
+      }
+
       // Single JSON output for all updates
       if (options.json) {
-        const result: AppUpdateOutput = {
+        const result: AppUpdateOutput & { versionBumped?: boolean } = {
           teamsAppId: appId,
           ...(endpointBotId ? { botId: endpointBotId } : {}),
           ...(endpointValidDomains ? { validDomains: endpointValidDomains } : {}),
           updated: allUpdates,
+          ...(versionBumped ? { versionBumped: true } : {}),
         };
         outputJson(result);
       }

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -23,19 +23,10 @@ import { outputJson } from '../../utils/json-output.js';
 import { logger } from '../../utils/logger.js';
 import { pickApp } from '../../utils/app-picker.js';
 import { createSilentSpinner } from '../../utils/spinner.js';
-import { bumpPatchVersion } from '../../utils/version.js';
+import { bumpPatchVersion, stableStringify } from '../../utils/version.js';
 import type { AppSummary, AppDetails } from '../../apps/types.js';
 import type { BotDetails } from '../../apps/tdp.js';
 import type { BotLocation } from '../../apps/bot-location.js';
-
-/** Stable JSON.stringify with sorted keys for reliable deep comparison. */
-function stableStringify(obj: unknown): string {
-  return JSON.stringify(obj, (_key, value) =>
-    value && typeof value === 'object' && !Array.isArray(value)
-      ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
-      : value
-  );
-}
 
 interface UpdateOptions {
   endpoint?: string;

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -553,12 +553,12 @@ export const appUpdateCommand = new Command('update')
 
       // Single JSON output for all updates
       if (options.json) {
-        const result: AppUpdateOutput & { versionBumped?: boolean } = {
+        const result: AppUpdateOutput & { needsReinstall?: boolean } = {
           teamsAppId: appId,
           ...(endpointBotId ? { botId: endpointBotId } : {}),
           ...(endpointValidDomains ? { validDomains: endpointValidDomains } : {}),
           updated: allUpdates,
-          ...(versionBumped ? { versionBumped: true } : {}),
+          ...(versionBumped ? { needsReinstall: true } : {}),
         };
         outputJson(result);
       }

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -15,12 +15,14 @@ export function bumpPatchVersion(version: string): string | null {
  * Stable JSON.stringify that sorts object keys for reliable deep comparison.
  */
 export function stableStringify(obj: unknown): string {
-  return JSON.stringify(obj, (_key, value) =>
-    value && typeof value === 'object' && !Array.isArray(value)
-      ? Object.fromEntries(
-          Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-        )
-      : value
+  return (
+    JSON.stringify(obj, (_key, value) =>
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? Object.fromEntries(
+            Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          )
+        : value
+    ) ?? ''
   );
 }
 

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -17,7 +17,9 @@ export function bumpPatchVersion(version: string): string | null {
 export function stableStringify(obj: unknown): string {
   return JSON.stringify(obj, (_key, value) =>
     value && typeof value === 'object' && !Array.isArray(value)
-      ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
+      ? Object.fromEntries(
+          Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        )
       : value
   );
 }

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -12,6 +12,17 @@ export function bumpPatchVersion(version: string): string | null {
 }
 
 /**
+ * Stable JSON.stringify that sorts object keys for reliable deep comparison.
+ */
+export function stableStringify(obj: unknown): string {
+  return JSON.stringify(obj, (_key, value) =>
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)))
+      : value
+  );
+}
+
+/**
  * Compare two dotted version strings numerically.
  * Returns 1 if a > b, -1 if a < b, 0 if equal, null if unparseable.
  */

--- a/packages/cli/tests/update-app-details-bump.test.ts
+++ b/packages/cli/tests/update-app-details-bump.test.ts
@@ -34,10 +34,6 @@ vi.mock('../src/utils/http.js', () => ({
   }),
 }));
 
-vi.mock('../src/utils/logger.js', () => ({
-  logger: { info: vi.fn() },
-}));
-
 import { updateAppDetails } from '../src/apps/api.js';
 
 describe('updateAppDetails version auto-bump', () => {
@@ -49,11 +45,13 @@ describe('updateAppDetails version auto-bump', () => {
   });
 
   it('bumps patch version when content changes', async () => {
-    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'New Name' });
+    const result = await updateAppDetails('token', 'test-teams-app-id', { shortName: 'New Name' });
 
     expect(postedBody).not.toBeNull();
     expect(postedBody!.version).toBe('1.0.1');
     expect(postedBody!.shortName).toBe('New Name');
+    expect(result.versionBumped).toBe(true);
+    expect(result.previousVersion).toBe('1.0.0');
   });
 
   it('does NOT bump when updates include explicit version', async () => {
@@ -67,10 +65,12 @@ describe('updateAppDetails version auto-bump', () => {
   });
 
   it('does NOT bump when content is identical (no-op)', async () => {
-    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'Test App' });
+    const result = await updateAppDetails('token', 'test-teams-app-id', { shortName: 'Test App' });
 
     expect(postedBody).not.toBeNull();
     expect(postedBody!.version).toBe('1.0.0');
+    expect(result.versionBumped).toBe(false);
+    expect(result.previousVersion).toBeUndefined();
   });
 
   it('does NOT bump when autoBumpVersion is false', async () => {

--- a/packages/cli/tests/update-app-details-bump.test.ts
+++ b/packages/cli/tests/update-app-details-bump.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AppDetails } from '../src/apps/types.js';
+
+// --- Mocks ---
+
+const mockDetails: AppDetails = {
+  teamsAppId: 'test-teams-app-id',
+  appId: '00000000-0000-0000-0000-000000000001',
+  shortName: 'Test App',
+  longName: 'Test App',
+  shortDescription: 'desc',
+  longDescription: 'desc',
+  version: '1.0.0',
+  developerName: 'dev',
+  websiteUrl: 'https://example.com',
+  privacyUrl: 'https://example.com/privacy',
+  termsOfUseUrl: 'https://example.com/terms',
+  manifestVersion: '1.25',
+  webApplicationInfoId: '',
+  mpnId: '',
+  accentColor: '#FFFFFF',
+};
+
+let postedBody: AppDetails | null = null;
+
+vi.mock('../src/utils/http.js', () => ({
+  apiFetch: vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method === 'POST') {
+      postedBody = JSON.parse(init.body as string);
+      return { ok: true, json: async () => postedBody };
+    }
+    // GET — return current details
+    return { ok: true, json: async () => structuredClone(mockDetails) };
+  }),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn() },
+}));
+
+import { updateAppDetails } from '../src/apps/api.js';
+
+describe('updateAppDetails version auto-bump', () => {
+  beforeEach(() => {
+    postedBody = null;
+    mockDetails.version = '1.0.0';
+    mockDetails.shortName = 'Test App';
+    mockDetails.webApplicationInfoId = '';
+  });
+
+  it('bumps patch version when content changes', async () => {
+    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'New Name' });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('1.0.1');
+    expect(postedBody!.shortName).toBe('New Name');
+  });
+
+  it('does NOT bump when updates include explicit version', async () => {
+    await updateAppDetails('token', 'test-teams-app-id', {
+      shortName: 'New Name',
+      version: '2.0.0',
+    });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('2.0.0');
+  });
+
+  it('does NOT bump when content is identical (no-op)', async () => {
+    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'Test App' });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('1.0.0');
+  });
+
+  it('does NOT bump when autoBumpVersion is false', async () => {
+    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'New Name' }, { autoBumpVersion: false });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('1.0.0');
+  });
+
+  it('handles unparseable version gracefully', async () => {
+    mockDetails.version = 'not-a-version';
+
+    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'New Name' });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('not-a-version');
+  });
+
+  it('bumps when webApplicationInfoId changes', async () => {
+    await updateAppDetails('token', 'test-teams-app-id', {
+      webApplicationInfoId: 'new-aad-app-id',
+    });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('1.0.1');
+  });
+
+  it('bumps two-part versions correctly', async () => {
+    mockDetails.version = '1.0';
+
+    await updateAppDetails('token', 'test-teams-app-id', { shortName: 'New Name' });
+
+    expect(postedBody).not.toBeNull();
+    expect(postedBody!.version).toBe('1.1');
+  });
+});


### PR DESCRIPTION
## Summary
- `updateAppDetails` now auto-bumps the patch version when content actually changes (uses stable deep comparison, skips if user explicitly set `--version`)
- In scripting mode (`teams app update --flag1 --flag2`), all intermediate API calls suppress auto-bump and a single bump happens at the end — one command = one version increment
- Adds reinstall hint when version bumps: `Version auto-bumped: 1.0.0 → 1.0.1 — reinstall may be needed`
- `uploadIcon` now threads `autoBumpVersion` option through to its internal `updateAppDetails` call

## Test plan
- [x] `npm run test` — 7 new tests in `update-app-details-bump.test.ts`, existing RSC tests unaffected
- [x] `teams app update <id> --web-app-info-id <val>` bumps version once
- [x] `teams app update <id> --name "X" --color-icon ./icon.png` still bumps only once
- [x] `teams app update <id> --version 2.0.0 --name "X"` uses explicit version, no auto-bump
- [x] `teams app update <id> --name "<same name>"` does NOT bump (no-op detection)