### PR TITLE
cli: validate endpoint and inputs before creating resources

### DIFF
--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -50,10 +50,6 @@ export function validateEndpoint(url: string): string | null {
   if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
     return null; // allow localhost for dev
   }
-  // Reject placeholder/template URLs like <your-tunnel-url>
-  if (parsed.hostname.includes('<') || parsed.hostname.includes('>')) {
-    return 'Endpoint contains placeholder characters — replace with an actual URL.';
-  }
   return null;
 }
 

--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -44,6 +44,9 @@ export function validateEndpoint(url: string): string | null {
   if (parsed.protocol !== 'https:') {
     return 'Endpoint must use HTTPS.';
   }
+  if (!parsed.hostname) {
+    return 'Endpoint is missing a hostname.';
+  }
   if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
     return null; // allow localhost for dev
   }

--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -30,6 +30,30 @@ export function extractDomain(url: string): string | null {
   }
 }
 
+/**
+ * Validates that an endpoint URL is a well-formed HTTPS URL.
+ * Returns an error message string if invalid, or `null` if valid.
+ */
+export function validateEndpoint(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Endpoint is not a valid URL.';
+  }
+  if (parsed.protocol !== 'https:') {
+    return 'Endpoint must use HTTPS.';
+  }
+  if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+    return null; // allow localhost for dev
+  }
+  // Reject placeholder/template URLs like <your-tunnel-url>
+  if (parsed.hostname.includes('<') || parsed.hostname.includes('>')) {
+    return 'Endpoint contains placeholder characters — replace with an actual URL.';
+  }
+  return null;
+}
+
 export interface Manifest {
   id: string;
   name: { short: string; full?: string };

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -95,11 +95,19 @@ export const appCreateCommand = new Command('create')
       }
 
       // Validate CLI flags upfront (before any resource creation)
-      if (options.endpoint) {
-        const endpointError = validateEndpoint(options.endpoint);
+      if (options.endpoint !== undefined) {
+        const trimmedEndpoint = options.endpoint.trim();
+        if (!trimmedEndpoint) {
+          throw new CliError(
+            'VALIDATION_FORMAT',
+            'Bot messaging endpoint URL cannot be empty.'
+          );
+        }
+        const endpointError = validateEndpoint(trimmedEndpoint);
         if (endpointError) {
           throw new CliError('VALIDATION_FORMAT', endpointError);
         }
+        options.endpoint = trimmedEndpoint;
       }
       if (options.colorIcon) readAndValidateIcon(options.colorIcon, 192);
       if (options.outlineIcon) readAndValidateIcon(options.outlineIcon, 32);

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -109,8 +109,8 @@ export const appCreateCommand = new Command('create')
         }
         options.endpoint = trimmedEndpoint;
       }
-      if (options.colorIcon) readAndValidateIcon(options.colorIcon, 192);
-      if (options.outlineIcon) readAndValidateIcon(options.outlineIcon, 32);
+      const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
+      const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
 
       // Resolve bot location: explicit flag > config > default (teams-managed)
       let location: BotLocation;
@@ -222,9 +222,13 @@ export const appCreateCommand = new Command('create')
       const colorIconPath = options.colorIcon;
       const outlineIconPath = options.outlineIcon;
 
-      // Validate icons upfront (before any API calls)
-      const colorIcon = colorIconPath ? readAndValidateIcon(colorIconPath, 192) : undefined;
-      const outlineIcon = outlineIconPath ? readAndValidateIcon(outlineIconPath, 32) : undefined;
+      // Validate icons (reuse early result for flag-provided paths, otherwise validate now)
+      const colorIcon = colorIconPath
+        ? (earlyColorIcon ?? readAndValidateIcon(colorIconPath, 192))
+        : undefined;
+      const outlineIcon = outlineIconPath
+        ? (earlyOutlineIcon ?? readAndValidateIcon(outlineIconPath, 32))
+        : undefined;
 
       // ===== All inputs gathered — confirm before proceeding =====
       const summaryLines: [string, string][] = [['App name', name]];

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -12,6 +12,7 @@ import {
   type BotScope,
   createTdpBotHandler,
   createAzureBotHandler,
+  validateEndpoint,
   type AzureContext,
   type BotLocation,
   installLink,
@@ -93,6 +94,16 @@ export const appCreateCommand = new Command('create')
         );
       }
 
+      // Validate CLI flags upfront (before any resource creation)
+      if (options.endpoint) {
+        const endpointError = validateEndpoint(options.endpoint);
+        if (endpointError) {
+          throw new CliError('VALIDATION_FORMAT', endpointError);
+        }
+      }
+      if (options.colorIcon) readAndValidateIcon(options.colorIcon, 192);
+      if (options.outlineIcon) readAndValidateIcon(options.outlineIcon, 32);
+
       // Resolve bot location: explicit flag > config > default (teams-managed)
       let location: BotLocation;
       if (options.azure) location = 'azure';
@@ -160,6 +171,10 @@ export const appCreateCommand = new Command('create')
         (interactive && !hasFlags
           ? (await input({
               message: 'Bot messaging endpoint URL (leave empty to skip):',
+              validate: (value) => {
+                if (!value.trim()) return true; // allow empty (skip)
+                return validateEndpoint(value.trim()) ?? true;
+              },
             })) || undefined
           : undefined);
 

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -81,20 +81,14 @@ export const appCreateCommand = new Command('create')
   .action(
     wrapAction(async (options: CreateOptions) => {
       const silent = !!options.json;
-      const account = await getAccount();
-      if (!account) {
-        throw new CliError('AUTH_REQUIRED', 'Not logged in.', 'Run `teams login` first.');
-      }
 
-      // Validate conflicting flags
+      // Validate CLI flags upfront (before auth or any resource creation)
       if (options.azure && options.teamsManaged) {
         throw new CliError(
           'VALIDATION_CONFLICT',
           'Cannot specify both --azure and --teams-managed.'
         );
       }
-
-      // Validate CLI flags upfront (before any resource creation)
       if (options.endpoint !== undefined) {
         const trimmedEndpoint = options.endpoint.trim();
         if (!trimmedEndpoint) {
@@ -111,6 +105,11 @@ export const appCreateCommand = new Command('create')
       }
       const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
       const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
+
+      const account = await getAccount();
+      if (!account) {
+        throw new CliError('AUTH_REQUIRED', 'Not logged in.', 'Run `teams login` first.');
+      }
 
       // Resolve bot location: explicit flag > config > default (teams-managed)
       let location: BotLocation;

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -319,11 +319,16 @@ export const appUpdateCommand = new Command('update')
           );
         }
       }
-      if (options.endpoint) {
-        const endpointError = validateEndpoint(options.endpoint);
+      if (options.endpoint !== undefined) {
+        const trimmedEndpoint = options.endpoint.trim();
+        if (!trimmedEndpoint) {
+          throw new CliError('VALIDATION_FORMAT', 'Endpoint URL cannot be empty.');
+        }
+        const endpointError = validateEndpoint(trimmedEndpoint);
         if (endpointError) {
           throw new CliError('VALIDATION_FORMAT', endpointError);
         }
+        options.endpoint = trimmedEndpoint;
       }
       if (options.name !== undefined && options.name.length > 30) {
         throw new CliError('VALIDATION_FORMAT', 'Short name must be 30 characters or less.');

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -14,6 +14,7 @@ import {
   createAzureBotHandler,
   discoverAzureBot,
   extractDomain,
+  validateEndpoint,
   uploadIcon,
 } from '../../apps/index.js';
 import { ensureAz } from '../../utils/az.js';
@@ -173,6 +174,10 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
         const botId = appDetails.bots![0].botId;
         const newEndpoint = await input({
           message: 'Enter new messaging endpoint URL:',
+          validate: (value) => {
+            if (!value.trim()) return true;
+            return validateEndpoint(value.trim()) ?? true;
+          },
         });
 
         if (!newEndpoint.trim()) {
@@ -211,6 +216,10 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
         const newEndpoint = await input({
           message: 'Enter new messaging endpoint URL:',
           default: bot.messagingEndpoint,
+          validate: (value) => {
+            if (!value.trim()) return true;
+            return validateEndpoint(value.trim()) ?? true;
+          },
         });
 
         if (newEndpoint.trim() === bot.messagingEndpoint) {
@@ -309,6 +318,34 @@ export const appUpdateCommand = new Command('update')
             'webApplicationInfo resource URI must start with "api://" (e.g., api://botid-<your-bot-id>).'
           );
         }
+      }
+      if (options.endpoint) {
+        const endpointError = validateEndpoint(options.endpoint);
+        if (endpointError) {
+          throw new CliError('VALIDATION_FORMAT', endpointError);
+        }
+      }
+      if (options.name !== undefined && options.name.length > 30) {
+        throw new CliError('VALIDATION_FORMAT', 'Short name must be 30 characters or less.');
+      }
+      if (options.longName !== undefined && options.longName.length > 100) {
+        throw new CliError('VALIDATION_FORMAT', 'Long name must be 100 characters or less.');
+      }
+      if (options.shortDescription !== undefined && options.shortDescription.length > 80) {
+        throw new CliError('VALIDATION_FORMAT', 'Short description must be 80 characters or less.');
+      }
+      if (options.longDescription !== undefined && options.longDescription.length > 4000) {
+        throw new CliError('VALIDATION_FORMAT', 'Long description must be 4000 characters or less.');
+      }
+      const httpsUrlRegex = /^https:\/\/\S+$/i;
+      if (options.website !== undefined && !httpsUrlRegex.test(options.website)) {
+        throw new CliError('VALIDATION_FORMAT', 'Website URL must start with https:// and include a domain.');
+      }
+      if (options.privacyUrl !== undefined && !httpsUrlRegex.test(options.privacyUrl)) {
+        throw new CliError('VALIDATION_FORMAT', 'Privacy URL must start with https:// and include a domain.');
+      }
+      if (options.termsUrl !== undefined && !httpsUrlRegex.test(options.termsUrl)) {
+        throw new CliError('VALIDATION_FORMAT', 'Terms of use URL must start with https:// and include a domain.');
       }
 
       // Interactive mode (no appId, no mutation flags): picker loop
@@ -425,80 +462,16 @@ export const appUpdateCommand = new Command('update')
         allUpdates.endpoint = options.endpoint;
       }
 
-      // --- Basic info fields ---
-      if (options.name !== undefined) {
-        if (options.name.length > 30) {
-          throw new CliError('VALIDATION_FORMAT', 'Short name must be 30 characters or less.');
-        }
-        allUpdates.shortName = options.name;
-      }
-
-      if (options.longName !== undefined) {
-        if (options.longName.length > 100) {
-          throw new CliError('VALIDATION_FORMAT', 'Long name must be 100 characters or less.');
-        }
-        allUpdates.longName = options.longName;
-      }
-
-      if (options.shortDescription !== undefined) {
-        if (options.shortDescription.length > 80) {
-          throw new CliError(
-            'VALIDATION_FORMAT',
-            'Short description must be 80 characters or less.'
-          );
-        }
-        allUpdates.shortDescription = options.shortDescription;
-      }
-
-      if (options.longDescription !== undefined) {
-        if (options.longDescription.length > 4000) {
-          throw new CliError(
-            'VALIDATION_FORMAT',
-            'Long description must be 4000 characters or less.'
-          );
-        }
-        allUpdates.longDescription = options.longDescription;
-      }
-
-      if (options.version !== undefined) {
-        allUpdates.version = options.version;
-      }
-
-      if (options.developer !== undefined) {
-        allUpdates.developerName = options.developer;
-      }
-
-      const httpsUrlRegex = /^https:\/\/\S+$/i;
-
-      if (options.website !== undefined) {
-        if (!httpsUrlRegex.test(options.website)) {
-          throw new CliError(
-            'VALIDATION_FORMAT',
-            'Website URL must start with https:// and include a domain.'
-          );
-        }
-        allUpdates.websiteUrl = options.website;
-      }
-
-      if (options.privacyUrl !== undefined) {
-        if (!httpsUrlRegex.test(options.privacyUrl)) {
-          throw new CliError(
-            'VALIDATION_FORMAT',
-            'Privacy URL must start with https:// and include a domain.'
-          );
-        }
-        allUpdates.privacyUrl = options.privacyUrl;
-      }
-
-      if (options.termsUrl !== undefined) {
-        if (!httpsUrlRegex.test(options.termsUrl)) {
-          throw new CliError(
-            'VALIDATION_FORMAT',
-            'Terms of use URL must start with https:// and include a domain.'
-          );
-        }
-        allUpdates.termsOfUseUrl = options.termsUrl;
-      }
+      // --- Basic info fields (validation already done upfront) ---
+      if (options.name !== undefined) allUpdates.shortName = options.name;
+      if (options.longName !== undefined) allUpdates.longName = options.longName;
+      if (options.shortDescription !== undefined) allUpdates.shortDescription = options.shortDescription;
+      if (options.longDescription !== undefined) allUpdates.longDescription = options.longDescription;
+      if (options.version !== undefined) allUpdates.version = options.version;
+      if (options.developer !== undefined) allUpdates.developerName = options.developer;
+      if (options.website !== undefined) allUpdates.websiteUrl = options.website;
+      if (options.privacyUrl !== undefined) allUpdates.privacyUrl = options.privacyUrl;
+      if (options.termsUrl !== undefined) allUpdates.termsOfUseUrl = options.termsUrl;
 
       if (options.webAppInfoId !== undefined) {
         allUpdates.webApplicationInfoId = options.webAppInfoId;

--- a/packages/cli/tests/endpoint-validation.test.ts
+++ b/packages/cli/tests/endpoint-validation.test.ts
@@ -12,23 +12,17 @@ interface JsonErrorResponse {
   };
 }
 
-function run(command: string): { stdout: string; stderr: string; exitCode: number } {
+function runJson(command: string): { data: JsonErrorResponse; exitCode: number } {
   try {
     const stdout = execSync(command, { encoding: 'utf-8', stdio: 'pipe' });
-    return { stdout, stderr: '', exitCode: 0 };
+    return { data: JSON.parse(stdout) as JsonErrorResponse, exitCode: 0 };
   } catch (error: unknown) {
-    const execError = error as { stdout?: string; stderr?: string; status?: number };
+    const execError = error as { stdout?: string; status?: number };
     return {
-      stdout: execError.stdout ?? '',
-      stderr: execError.stderr ?? '',
+      data: JSON.parse(execError.stdout ?? '{}') as JsonErrorResponse,
       exitCode: execError.status ?? 1,
     };
   }
-}
-
-function runJson(command: string): { data: JsonErrorResponse; exitCode: number } {
-  const { stdout, exitCode } = run(command);
-  return { data: JSON.parse(stdout) as JsonErrorResponse, exitCode };
 }
 
 describe('validateEndpoint()', () => {
@@ -60,24 +54,6 @@ describe('validateEndpoint()', () => {
 
   it('rejects FTP protocol', () => {
     expect(validateEndpoint('ftp://example.com/api')).toBe('Endpoint must use HTTPS.');
-  });
-});
-
-describe('app create --endpoint validation (offline)', () => {
-  it('rejects HTTP endpoint before auth', () => {
-    const { stderr, exitCode } = run(
-      `${CLI} app create --name Test --endpoint "http://example.com/api" --yes`
-    );
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain('Endpoint must use HTTPS.');
-  });
-
-  it('rejects empty endpoint', () => {
-    const { stderr, exitCode } = run(
-      `${CLI} app create --name Test --endpoint "" --yes`
-    );
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain('cannot be empty');
   });
 });
 

--- a/packages/cli/tests/endpoint-validation.test.ts
+++ b/packages/cli/tests/endpoint-validation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { validateEndpoint } from '../src/apps/manifest.js';
+import { execSync } from 'node:child_process';
+
+const CLI = 'node dist/index.js';
+
+interface JsonErrorResponse {
+  ok: false;
+  error: {
+    code: string;
+    message?: string;
+  };
+}
+
+function run(command: string): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execSync(command, { encoding: 'utf-8', stdio: 'pipe' });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (error: unknown) {
+    const execError = error as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: execError.stdout ?? '',
+      stderr: execError.stderr ?? '',
+      exitCode: execError.status ?? 1,
+    };
+  }
+}
+
+function runJson(command: string): { data: JsonErrorResponse; exitCode: number } {
+  const { stdout, exitCode } = run(command);
+  return { data: JSON.parse(stdout) as JsonErrorResponse, exitCode };
+}
+
+describe('validateEndpoint()', () => {
+  it('accepts valid HTTPS URL', () => {
+    expect(validateEndpoint('https://example.com/api/messages')).toBeNull();
+  });
+
+  it('accepts localhost for dev', () => {
+    expect(validateEndpoint('https://localhost:3978/api/messages')).toBeNull();
+  });
+
+  it('accepts 127.0.0.1 for dev', () => {
+    expect(validateEndpoint('https://127.0.0.1:3978/api/messages')).toBeNull();
+  });
+
+  it('rejects HTTP', () => {
+    expect(validateEndpoint('http://example.com/api/messages')).toBe('Endpoint must use HTTPS.');
+  });
+
+  it('rejects malformed URL', () => {
+    expect(validateEndpoint('not-a-url')).toBe('Endpoint is not a valid URL.');
+  });
+
+  it('rejects placeholder URL', () => {
+    expect(validateEndpoint('https://<your-tunnel-url>/api/messages')).toBe(
+      'Endpoint is not a valid URL.'
+    );
+  });
+
+  it('rejects FTP protocol', () => {
+    expect(validateEndpoint('ftp://example.com/api')).toBe('Endpoint must use HTTPS.');
+  });
+});
+
+describe('app create --endpoint validation (offline)', () => {
+  it('rejects HTTP endpoint before auth', () => {
+    const { stderr, exitCode } = run(
+      `${CLI} app create --name Test --endpoint "http://example.com/api" --yes`
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Endpoint must use HTTPS.');
+  });
+
+  it('rejects empty endpoint', () => {
+    const { stderr, exitCode } = run(
+      `${CLI} app create --name Test --endpoint "" --yes`
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('cannot be empty');
+  });
+});
+
+describe('app update --endpoint validation (offline)', () => {
+  it('rejects non-HTTPS endpoint in JSON mode', () => {
+    const { data, exitCode } = runJson(
+      `${CLI} app update some-app-id --endpoint "ftp://bad.com" --json`
+    );
+    expect(exitCode).toBe(1);
+    expect(data.error.code).toBe('VALIDATION_FORMAT');
+    expect(data.error.message).toContain('HTTPS');
+  });
+
+  it('rejects malformed endpoint in JSON mode', () => {
+    const { data, exitCode } = runJson(
+      `${CLI} app update some-app-id --endpoint "not-a-url" --json`
+    );
+    expect(exitCode).toBe(1);
+    expect(data.error.code).toBe('VALIDATION_FORMAT');
+    expect(data.error.message).toContain('not a valid URL');
+  });
+
+  it('rejects empty endpoint in JSON mode', () => {
+    const { data, exitCode } = runJson(
+      `${CLI} app update some-app-id --endpoint "" --json`
+    );
+    expect(exitCode).toBe(1);
+    expect(data.error.code).toBe('VALIDATION_FORMAT');
+    expect(data.error.message).toContain('cannot be empty');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `validateEndpoint()` to catch bad URLs (placeholders, HTTP, malformed) before any resources get created
- Moves all field validations (name length, description length, URL format) upfront in `app update` so a bad flag doesn't leave the app half-updated
- Adds inline `validate` on interactive endpoint prompts in both `create` and `update` so users get immediate feedback

## Test plan
- [x] `teams app create --name Test --endpoint "https://<foo>/api" --yes` → fails immediately with "Endpoint is not a valid URL."
- [x] `teams app create --name Test --endpoint "http://example.com/api" --yes` → fails with "Endpoint must use HTTPS."
- [x] `teams app update <id> --endpoint "ftp://bad" --json` → fails with validation error before any API calls
- [x] `teams app update <id> --name "x]x31" --json` → fails upfront, no partial mutations
- [x] Interactive `app create` → entering a bad endpoint re-prompts instead of accepting
- [x] `npm run test` passes