### PR TITLE
cli: add --no-secret flag to app create

### DIFF
--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -197,6 +197,8 @@ export const appCreateCommand = new Command('create')
             })) || undefined
           : undefined);
 
+      const generateSecret = options.secret !== false;
+
       // Collect manifest customization options
       let descriptionOpts: { short: string; full?: string } | undefined;
       let scopeChoices: BotScope[] | undefined;
@@ -246,7 +248,7 @@ export const appCreateCommand = new Command('create')
       if (developerOpts?.name.trim()) summaryLines.push(['Developer', developerOpts.name.trim()]);
       if (colorIconPath) summaryLines.push(['Color icon', colorIconPath]);
       if (outlineIconPath) summaryLines.push(['Outline icon', outlineIconPath]);
-      if (options.secret === false) summaryLines.push(['Secret', 'Skipped (--no-secret)']);
+      if (!generateSecret) summaryLines.push(['Secret', 'Skipped']);
       if (envPath) summaryLines.push(['Credentials file', envPath]);
 
       if (interactive && !silent) {
@@ -266,7 +268,7 @@ export const appCreateCommand = new Command('create')
 
       // Graph token only needed for secret generation
       let graphToken: string | null | undefined;
-      if (options.secret !== false) {
+      if (generateSecret) {
         graphToken = await getTokenSilent(graphScopes);
         if (!graphToken) {
           spinner.error({ text: 'Failed to get Graph token' });
@@ -311,7 +313,7 @@ export const appCreateCommand = new Command('create')
 
       // Generate client secret (skipped with --no-secret)
       let secretText: string | undefined;
-      if (options.secret !== false) {
+      if (generateSecret) {
         spinner = createSilentSpinner('Generating client secret...', silent).start();
         let graphApp: { id: string } | null = null;
         for (let i = 0; i < 10; i++) {
@@ -347,7 +349,7 @@ export const appCreateCommand = new Command('create')
       const install = installLink(teamsAppId, account.tenantId);
       const portal = portalLink(teamsAppId);
 
-      const secretSkipped = options.secret === false;
+      const secretSkipped = !generateSecret;
       const credentialValues: EnvValues = {
         CLIENT_ID: clientId,
         ...(secretText !== undefined && { CLIENT_SECRET: secretText }),

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -19,7 +19,7 @@ import {
   portalLink,
 } from '../../apps/index.js';
 import { getAccount, getTokenSilent, graphScopes, teamsDevPortalScopes } from '../../auth/index.js';
-import { isJsonFile, outputCredentials, writeEnvFile, writeJsonCredentials } from '../../utils/env.js';
+import { type EnvValues, isJsonFile, outputCredentials, writeEnvFile, writeJsonCredentials } from '../../utils/env.js';
 import { CliError, wrapAction } from '../../utils/errors.js';
 import { readAndValidateIcon } from '../../utils/icon.js';
 import { outputJson } from '../../utils/json-output.js';
@@ -39,9 +39,10 @@ interface AppCreateOutput {
   installLink: string;
   portalLink: string;
   botLocation: 'teams-managed' | 'azure';
+  secretSkipped?: boolean;
   credentials?: {
     CLIENT_ID: string;
-    CLIENT_SECRET: string;
+    CLIENT_SECRET?: string;
     TENANT_ID: string;
   };
   credentialsFile?: string;
@@ -54,6 +55,7 @@ interface CreateOptions {
   envFile?: string;
   colorIcon?: string;
   outlineIcon?: string;
+  secret?: boolean;
   azure?: boolean;
   teamsManaged?: boolean;
   subscription?: string;
@@ -69,6 +71,7 @@ export const appCreateCommand = new Command('create')
   .option('-e, --endpoint <url>', '[OPTIONAL] Bot messaging endpoint URL')
   .option('--env <path>', '[OPTIONAL] Path to credentials file (.env or appsettings.json)')
   .option('--env-file <path>', '[OPTIONAL] Alias for --env')
+  .option('--no-secret', '[OPTIONAL] Skip client secret generation (for managed identity or federated credentials)')
   .option('--azure', '[OPTIONAL] Create bot in Azure (requires az CLI)')
   .option('--teams-managed', '[OPTIONAL] Create bot managed by Teams (default)')
   .option('--subscription <id>', '[OPTIONAL] Azure subscription ID (defaults to az CLI default)')
@@ -243,6 +246,7 @@ export const appCreateCommand = new Command('create')
       if (developerOpts?.name.trim()) summaryLines.push(['Developer', developerOpts.name.trim()]);
       if (colorIconPath) summaryLines.push(['Color icon', colorIconPath]);
       if (outlineIconPath) summaryLines.push(['Outline icon', outlineIconPath]);
+      if (options.secret === false) summaryLines.push(['Secret', 'Skipped (--no-secret)']);
       if (envPath) summaryLines.push(['Credentials file', envPath]);
 
       if (interactive && !silent) {
@@ -260,14 +264,18 @@ export const appCreateCommand = new Command('create')
       // Get tokens
       let spinner = createSilentSpinner('Acquiring tokens...', silent).start();
 
-      const graphToken = await getTokenSilent(graphScopes);
-      if (!graphToken) {
-        spinner.error({ text: 'Failed to get Graph token' });
-        throw new CliError(
-          'AUTH_TOKEN_FAILED',
-          'Failed to get Graph token.',
-          'Try `teams login` again.'
-        );
+      // Graph token only needed for secret generation
+      let graphToken: string | null | undefined;
+      if (options.secret !== false) {
+        graphToken = await getTokenSilent(graphScopes);
+        if (!graphToken) {
+          spinner.error({ text: 'Failed to get Graph token' });
+          throw new CliError(
+            'AUTH_TOKEN_FAILED',
+            'Failed to get Graph token.',
+            'Try `teams login` again.'
+          );
+        }
       }
 
       const tdpToken = await getTokenSilent(teamsDevPortalScopes);
@@ -301,23 +309,26 @@ export const appCreateCommand = new Command('create')
 
       const zipBuffer = createManifestZip(manifestOpts);
 
-      // Look up Graph object ID (TDP returns a different ID; retry for replication lag)
-      spinner = createSilentSpinner('Generating client secret...', silent).start();
-      let graphApp: { id: string } | null = null;
-      for (let i = 0; i < 10; i++) {
-        try {
-          graphApp = await getAadAppByClientId(graphToken, clientId);
-          break;
-        } catch {
-          await new Promise((r) => setTimeout(r, 3000));
+      // Generate client secret (skipped with --no-secret)
+      let secretText: string | undefined;
+      if (options.secret !== false) {
+        spinner = createSilentSpinner('Generating client secret...', silent).start();
+        let graphApp: { id: string } | null = null;
+        for (let i = 0; i < 10; i++) {
+          try {
+            graphApp = await getAadAppByClientId(graphToken!, clientId);
+            break;
+          } catch {
+            await new Promise((r) => setTimeout(r, 3000));
+          }
         }
+        if (!graphApp) {
+          throw new Error('AAD app not yet available in Graph API. Try again shortly.');
+        }
+        const secret = await createClientSecret(graphToken!, graphApp.id);
+        secretText = secret.secretText;
+        spinner.success({ text: 'Generated client secret' });
       }
-      if (!graphApp) {
-        throw new Error('AAD app not yet available in Graph API. Try again shortly.');
-      }
-      const secret = await createClientSecret(graphToken, graphApp.id);
-      const secretText = secret.secretText;
-      spinner.success({ text: 'Generated client secret' });
 
       // Import to Teams
       spinner = createSilentSpinner('Creating Teams app...', silent).start();
@@ -336,13 +347,14 @@ export const appCreateCommand = new Command('create')
       const install = installLink(teamsAppId, account.tenantId);
       const portal = portalLink(teamsAppId);
 
-      if (options.json) {
-        const credentialValues = {
-          CLIENT_ID: clientId,
-          CLIENT_SECRET: secretText,
-          TENANT_ID: account.tenantId,
-        };
+      const secretSkipped = options.secret === false;
+      const credentialValues: EnvValues = {
+        CLIENT_ID: clientId,
+        ...(secretText !== undefined && { CLIENT_SECRET: secretText }),
+        TENANT_ID: account.tenantId,
+      };
 
+      if (options.json) {
         if (envPath) {
           if (isJsonFile(envPath)) {
             writeJsonCredentials(envPath, credentialValues);
@@ -359,6 +371,7 @@ export const appCreateCommand = new Command('create')
           installLink: install,
           portalLink: portal,
           botLocation: location === 'tm' ? 'teams-managed' : 'azure',
+          ...(secretSkipped && { secretSkipped: true }),
           ...(envPath
             ? { credentialsFile: envPath }
             : { credentials: credentialValues }),
@@ -376,15 +389,12 @@ export const appCreateCommand = new Command('create')
         printLinkBanner('Install in Teams', install);
         printLinkBanner('Developer Portal', portal);
 
-        outputCredentials(
-          envPath,
-          {
-            CLIENT_ID: clientId,
-            CLIENT_SECRET: secretText,
-            TENANT_ID: account.tenantId,
-          },
-          'Credentials:'
-        );
+        outputCredentials(envPath, credentialValues, 'Credentials:');
+
+        if (secretSkipped) {
+          logger.info(`\nSecret generation skipped. To create one later, run:`);
+          logger.info(`  ${pc.cyan(`teams app auth secret create ${teamsAppId}`)}`);
+        }
 
         if (isInteractive()) {
           try {

--- a/packages/cli/src/utils/env.ts
+++ b/packages/cli/src/utils/env.ts
@@ -7,7 +7,7 @@ import { createSilentSpinner } from './spinner.js';
 
 export interface EnvValues {
   CLIENT_ID: string;
-  CLIENT_SECRET: string;
+  CLIENT_SECRET?: string;
   TENANT_ID: string;
 }
 
@@ -67,7 +67,7 @@ export function writeJsonCredentials(filePath: string, values: EnvValues): void 
   json.Teams = {
     ...existing,
     ClientId: values.CLIENT_ID,
-    ClientSecret: values.CLIENT_SECRET,
+    ...(values.CLIENT_SECRET !== undefined && { ClientSecret: values.CLIENT_SECRET }),
     TenantId: values.TENANT_ID,
   };
 
@@ -97,9 +97,13 @@ export function outputCredentials(
   } else {
     logger.info(pc.bold(pc.green(`\n${successMessage}`)));
     logger.info(`\n${pc.dim('CLIENT_ID=')}${values.CLIENT_ID}`);
-    logger.info(`${pc.dim('CLIENT_SECRET=')}${values.CLIENT_SECRET}`);
+    if (values.CLIENT_SECRET !== undefined) {
+      logger.info(`${pc.dim('CLIENT_SECRET=')}${values.CLIENT_SECRET}`);
+    }
     logger.info(`${pc.dim('TENANT_ID=')}${values.TENANT_ID}`);
 
-    logger.warn("Save the client secret - it won't be shown again!");
+    if (values.CLIENT_SECRET !== undefined) {
+      logger.warn("Save the client secret - it won't be shown again!");
+    }
   }
 }

--- a/packages/cli/tests/env-credentials.test.ts
+++ b/packages/cli/tests/env-credentials.test.ts
@@ -201,4 +201,40 @@ describe('outputCredentials', () => {
     expect(logger.info).toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it('omits CLIENT_SECRET and save warning when secret is undefined', async () => {
+    const { logger } = await import('../src/utils/logger.js');
+
+    outputCredentials(undefined, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' }, 'Credentials:');
+
+    const infoCalls = (logger.info as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[0]);
+    expect(infoCalls.some((c: string) => c.includes('CLIENT_ID'))).toBe(true);
+    expect(infoCalls.some((c: string) => c.includes('TENANT_ID'))).toBe(true);
+    expect(infoCalls.some((c: string) => c.includes('CLIENT_SECRET'))).toBe(false);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('omits ClientSecret from JSON file when secret is undefined', () => {
+    const filePath = tmpFile('appsettings.json');
+    files.push(filePath);
+
+    writeJsonCredentials(filePath, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' });
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(json.Teams.ClientId).toBe('id-123');
+    expect(json.Teams.TenantId).toBe('tenant-456');
+    expect(json.Teams).not.toHaveProperty('ClientSecret');
+  });
+
+  it('omits CLIENT_SECRET from .env file when secret is undefined', () => {
+    const filePath = tmpFile('.env');
+    files.push(filePath);
+
+    writeEnvFile(filePath, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' });
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('CLIENT_ID=id-123');
+    expect(content).toContain('TENANT_ID=tenant-456');
+    expect(content).not.toContain('CLIENT_SECRET');
+  });
 });

--- a/packages/cli/tests/env-flag-json.test.ts
+++ b/packages/cli/tests/env-flag-json.test.ts
@@ -272,4 +272,31 @@ describe('app create — JSON env-flag behavior', () => {
       TenantId: FAKE_TENANT_ID,
     });
   });
+
+  // Must be last — --no-secret sets Commander state that persists on the shared Command instance
+  it('--json --no-secret --env — secretSkipped true, file has no CLIENT_SECRET', async () => {
+    const envFile = tmpFile('.env');
+    files.push(envFile);
+
+    const { appCreateCommand } = await import(
+      '../src/commands/app/create.js'
+    );
+
+    await appCreateCommand.parseAsync(
+      ['--name', 'TestApp', '--json', '--no-secret', '--env', envFile],
+      { from: 'user' }
+    );
+
+    expect(jsonOutput).not.toBeNull();
+    const output = jsonOutput as Record<string, unknown>;
+    expect(output.secretSkipped).toBe(true);
+    expect(output.credentialsFile).toBe(envFile);
+    expect(output).not.toHaveProperty('credentials');
+
+    // .env file should have CLIENT_ID and TENANT_ID but no CLIENT_SECRET
+    const content = fs.readFileSync(envFile, 'utf-8');
+    expect(content).toContain(`CLIENT_ID=${FAKE_CLIENT_ID}`);
+    expect(content).toContain(`TENANT_ID=${FAKE_TENANT_ID}`);
+    expect(content).not.toContain('CLIENT_SECRET');
+  });
 });

--- a/teams.md/docs/cli/commands/app/create.md
+++ b/teams.md/docs/cli/commands/app/create.md
@@ -28,6 +28,7 @@ teams app create [options]
 | `--resource-group <name>` | Azure resource group (required for --azure) |
 | `--create-resource-group` | [OPTIONAL] Create the resource group if it doesn't exist |
 | `--region <name>` | [OPTIONAL] Azure region for resource group (default: westus2) |
+| `--no-secret` | [OPTIONAL] Skip client secret generation (for managed identity or federated credentials) |
 | `--color-icon <path>` | [OPTIONAL] Path to color icon (192x192 PNG) |
 | `--outline-icon <path>` | [OPTIONAL] Path to outline icon (32x32 PNG) |
 | `--json` | [OPTIONAL] Output as JSON |
@@ -66,6 +67,16 @@ teams app create --name "My Bot" --env appsettings.json
 ```
 
 This writes credentials under a `Teams` section with PascalCase keys (`ClientId`, `ClientSecret`, `TenantId`).
+
+### Skipping Secret Generation
+
+Use `--no-secret` to skip client secret generation when using managed identity or federated credentials:
+
+```bash
+teams app create --name "My Bot" --no-secret
+```
+
+Only `CLIENT_ID` and `TENANT_ID` are output. You can generate a secret later with [`teams app auth secret create`](./auth-secret-create).
 
 ### Output
 


### PR DESCRIPTION
## Summary
- adds `--no-secret` flag to `teams app create` so users can skip client secret generation when using managed identity or federated credentials
- skips Graph token acquisition entirely when `--no-secret` is set (perf win)
- outputs a helpful hint with the command to generate a secret later
- updates docs, types (`EnvValues.CLIENT_SECRET` now optional), and credential output to handle missing secret

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npm run test` — all 130 tests pass (4 new tests added)
- [ ] smoke: `node dist/index.js app create --name TestBot --no-secret --json` — JSON output has `secretSkipped: true`, no `CLIENT_SECRET`
- [ ] smoke: `node dist/index.js app create --name TestBot --json` — existing behavior unchanged, secret still generated