### PR TITLE
cli: bump version to 3.0.0-alpha.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teams.cli",
-  "version": "2.1.0",
+  "version": "3.0.0-alpha.0",
   "description": "CLI for scaffolding Teams applications",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps CLI version from 2.1.0 to 3.0.0-alpha.0 for the v3 release cycle
- Main branch publishes as `alpha`, preview branch will use `preview` tag

## Test plan
- [ ] `npm pkg get version` returns `3.0.0-alpha.0`
- [ ] `node dist/index.js --version` prints `3.0.0-alpha.0` after build