### PR TITLE
cli: show environment status after login

### DIFF
--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -4,7 +4,7 @@ import { login, getAccount } from '../../auth/index.js';
 import { logger } from '../../utils/logger.js';
 import { isInteractive, isLocalSession } from '../../utils/interactive.js';
 import { wrapAction } from '../../utils/errors.js';
-import { checkAndDisplayEnvironment } from '../status.js';
+import { checkAndDisplayEnvironment } from '../../utils/environment.js';
 
 interface LoginCommandOptions {
   deviceCode?: boolean;

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -4,6 +4,7 @@ import { login, getAccount } from '../../auth/index.js';
 import { logger } from '../../utils/logger.js';
 import { isInteractive, isLocalSession } from '../../utils/interactive.js';
 import { wrapAction } from '../../utils/errors.js';
+import { checkAndDisplayEnvironment } from '../status.js';
 
 interface LoginCommandOptions {
   deviceCode?: boolean;
@@ -25,10 +26,11 @@ export const loginCommand = new Command('login')
       const forceDeviceCode = options.deviceCode;
       const useBrowser = !forceDeviceCode && isInteractive() && isLocalSession();
 
+      let account;
       if (useBrowser) {
         const spinner = createSpinner('Opening browser for login...').start();
         try {
-          const account = await login();
+          account = await login();
           spinner.success({ text: `Logged in as ${account.username}` });
         } catch (error) {
           spinner.error({ text: 'Login failed' });
@@ -36,8 +38,10 @@ export const loginCommand = new Command('login')
         }
       } else {
         // No spinner for device code — MSAL prints the code/URL to stdout
-        const account = await login({ forceDeviceCode });
+        account = await login({ forceDeviceCode });
         logger.info(`Logged in as ${account.username}`);
       }
+
+      await checkAndDisplayEnvironment(account);
     })
   );

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,11 +1,12 @@
 import { Command } from 'commander';
 import { createSilentSpinner } from '../utils/spinner.js';
 import pc from 'picocolors';
+import { type AccountInfo } from '@azure/msal-node';
 import { getAccount, getTokenSilent, paths, teamsDevPortalScopes } from '../auth/index.js';
 import { isAzInstalled, isAzLoggedIn, runAz } from '../utils/az.js';
 import { wrapAction } from '../utils/errors.js';
-import { isVerbose } from '../utils/logger.js';
-import { logger } from '../utils/logger.js';
+import { isInteractive } from '../utils/interactive.js';
+import { isVerbose, logger } from '../utils/logger.js';
 import { outputJson } from '../utils/json-output.js';
 import { fetchTenantSettings, fetchUserAppPolicy } from '../apps/api.js';
 
@@ -18,6 +19,11 @@ interface StatusOutput {
   username: string | null;
   tenantId: string | null;
   userObjectId: string | null;
+  tdp: EnvironmentCheckResult['tdp'];
+  azureCli: EnvironmentCheckResult['azureCli'];
+}
+
+export interface EnvironmentCheckResult {
   tdp: {
     connected: boolean;
     sideloading: {
@@ -32,6 +38,139 @@ interface StatusOutput {
     tenantId: string | null;
     tenantMatch: boolean | null;
   };
+}
+
+/**
+ * Check TDP sideloading and Azure CLI status, display results unless silent.
+ * Used by both the `status` command and post-login flow.
+ */
+export async function checkAndDisplayEnvironment(
+  account: AccountInfo,
+  silent = false
+): Promise<EnvironmentCheckResult> {
+  const muteSpinners = silent || !isInteractive();
+  const tenantId = account.tenantId;
+  const result: EnvironmentCheckResult = {
+    tdp: null,
+    azureCli: { installed: false, loggedIn: false, subscription: null, tenantId: null, tenantMatch: null },
+  };
+
+  // ── TDP / sideloading ─────────────────────────────────────────────
+  const tdpSpinner = createSilentSpinner('Checking sideloading status...', muteSpinners).start();
+  const tdpToken = await getTokenSilent(teamsDevPortalScopes);
+
+  if (!tdpToken) {
+    result.tdp = { connected: false, sideloading: { tenant: null, user: null } };
+    const text = `TDP: ${pc.yellow('not connected')} ${pc.dim('(token unavailable)')}`;
+    tdpSpinner.warn({ text });
+    if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+  } else {
+    result.tdp = { connected: true, sideloading: { tenant: null, user: null } };
+
+    try {
+      const [tenantSettings, userPolicy] = await Promise.all([
+        fetchTenantSettings(tdpToken),
+        fetchUserAppPolicy(tdpToken),
+      ]);
+
+      const tenantEnabled = tenantSettings.isSideLoadingInteractionEnabled ?? false;
+      const userAllowed = userPolicy.value?.isSideloadingAllowed ?? false;
+
+      result.tdp.sideloading.tenant = tenantEnabled;
+      result.tdp.sideloading.user = userAllowed;
+
+      if (tenantEnabled && userAllowed) {
+        const text = `Sideloading: ${pc.green('enabled')}`;
+        tdpSpinner.success({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.green('✔')} ${text}`);
+      } else if (!tenantEnabled && userAllowed) {
+        const text = `Sideloading: ${pc.yellow('disabled at tenant level')}`;
+        tdpSpinner.warn({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+        if (!silent) {
+          logger.info(
+            `  ${pc.dim('Your user policy allows sideloading, but the tenant-wide setting is off.')}`
+          );
+          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
+          logger.info(
+            `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
+          );
+        }
+      } else if (tenantEnabled && !userAllowed) {
+        const text = `Sideloading: ${pc.yellow('not allowed for your account')}`;
+        tdpSpinner.warn({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+        if (!silent) {
+          logger.info(
+            `  ${pc.dim('Sideloading is enabled for the tenant, but your user policy blocks it.')}`
+          );
+          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
+          logger.info(
+            `  ${pc.dim('Users → Find the user → Policies → App setup policy → "Upload custom apps"')}`
+          );
+        }
+      } else {
+        const text = `Sideloading: ${pc.yellow('disabled')}`;
+        tdpSpinner.warn({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+        if (!silent) {
+          logger.info(
+            `  ${pc.dim('Neither the tenant nor your user policy allows sideloading.')}`
+          );
+          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
+          logger.info(
+            `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
+          );
+        }
+      }
+    } catch {
+      const text = `Sideloading: ${pc.yellow('could not determine')}`;
+      tdpSpinner.warn({ text });
+      if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+    }
+  }
+
+  // ── Azure CLI ─────────────────────────────────────────────────────
+  const azInstalled = await isAzInstalled();
+  result.azureCli.installed = azInstalled;
+
+  if (!azInstalled) {
+    if (!silent) logger.info(`\n${pc.dim('Azure CLI:')} ${pc.yellow('not installed')}`);
+  } else {
+    const azLoggedIn = await isAzLoggedIn();
+    result.azureCli.loggedIn = azLoggedIn;
+
+    if (!azLoggedIn) {
+      if (!silent)
+        logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('not logged in')}`);
+    } else {
+      try {
+        const sub = await runAz<{ name: string; id: string; tenantId: string }>(['account', 'show']);
+        result.azureCli.subscription = { name: sub.name, id: sub.id };
+        result.azureCli.tenantId = sub.tenantId;
+        result.azureCli.tenantMatch = tenantId ? tenantId === sub.tenantId : null;
+        if (!silent) {
+          logger.info(`\n${pc.dim('Azure CLI:')} ${pc.green('connected')}`);
+          logger.info(`${pc.dim('Subscription:')} ${sub.name} ${pc.dim(`(${sub.id})`)}`);
+          if (tenantId && sub.tenantId) {
+            if (tenantId === sub.tenantId) {
+              logger.info(`${pc.dim('Tenant:')} ${pc.green('matches Teams login')}`);
+            } else {
+              logger.info(`${pc.dim('Tenant:')} ${pc.red('mismatch')}`);
+              logger.info(`  ${pc.dim('Teams login:')} ${tenantId}`);
+              logger.info(`  ${pc.dim('Azure CLI:')}   ${sub.tenantId}`);
+              logger.info(`  ${pc.dim('Run')} ${pc.cyan(`az login --tenant ${tenantId}`)} ${pc.dim('to align.')}`);
+            }
+          }
+        }
+      } catch {
+        if (!silent)
+          logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('status unknown')}`);
+      }
+    }
+  }
+
+  return result;
 }
 
 export const statusCommand = new Command('status')
@@ -75,110 +214,9 @@ export const statusCommand = new Command('status')
         }
       }
 
-      // ── TDP / sideloading ─────────────────────────────────────────────
-      const tdpSpinner = createSilentSpinner('Checking sideloading status...', silent).start();
-      const tdpToken = await getTokenSilent(teamsDevPortalScopes);
-
-      if (!tdpToken) {
-        output.tdp = { connected: false, sideloading: { tenant: null, user: null } };
-        tdpSpinner.warn({
-          text: `TDP: ${pc.yellow('not connected')} ${pc.dim('(token unavailable)')}`,
-        });
-      } else {
-        output.tdp = { connected: true, sideloading: { tenant: null, user: null } };
-
-        try {
-          const [tenantSettings, userPolicy] = await Promise.all([
-            fetchTenantSettings(tdpToken),
-            fetchUserAppPolicy(tdpToken),
-          ]);
-
-          const tenantEnabled = tenantSettings.isSideLoadingInteractionEnabled ?? false;
-          const userAllowed = userPolicy.value?.isSideloadingAllowed ?? false;
-
-          output.tdp.sideloading.tenant = tenantEnabled;
-          output.tdp.sideloading.user = userAllowed;
-
-          if (tenantEnabled && userAllowed) {
-            tdpSpinner.success({ text: `Sideloading: ${pc.green('enabled')}` });
-          } else if (!tenantEnabled && userAllowed) {
-            tdpSpinner.warn({ text: `Sideloading: ${pc.yellow('disabled at tenant level')}` });
-            if (!silent) {
-              logger.info(
-                `  ${pc.dim('Your user policy allows sideloading, but the tenant-wide setting is off.')}`
-              );
-              logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
-              logger.info(
-                `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
-              );
-            }
-          } else if (tenantEnabled && !userAllowed) {
-            tdpSpinner.warn({ text: `Sideloading: ${pc.yellow('not allowed for your account')}` });
-            if (!silent) {
-              logger.info(
-                `  ${pc.dim('Sideloading is enabled for the tenant, but your user policy blocks it.')}`
-              );
-              logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
-              logger.info(
-                `  ${pc.dim('Users → Find the user → Policies → App setup policy → "Upload custom apps"')}`
-              );
-            }
-          } else {
-            tdpSpinner.warn({ text: `Sideloading: ${pc.yellow('disabled')}` });
-            if (!silent) {
-              logger.info(
-                `  ${pc.dim('Neither the tenant nor your user policy allows sideloading.')}`
-              );
-              logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
-              logger.info(
-                `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
-              );
-            }
-          }
-        } catch {
-          tdpSpinner.warn({ text: `Sideloading: ${pc.yellow('could not determine')}` });
-        }
-      }
-
-      // ── Azure CLI ─────────────────────────────────────────────────────
-      const azInstalled = await isAzInstalled();
-      output.azureCli.installed = azInstalled;
-
-      if (!azInstalled) {
-        if (!silent) logger.info(`\n${pc.dim('Azure CLI:')} ${pc.yellow('not installed')}`);
-      } else {
-        const azLoggedIn = await isAzLoggedIn();
-        output.azureCli.loggedIn = azLoggedIn;
-
-        if (!azLoggedIn) {
-          if (!silent)
-            logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('not logged in')}`);
-        } else {
-          try {
-            const sub = await runAz<{ name: string; id: string; tenantId: string }>(['account', 'show']);
-            output.azureCli.subscription = { name: sub.name, id: sub.id };
-            output.azureCli.tenantId = sub.tenantId;
-            output.azureCli.tenantMatch = output.tenantId ? output.tenantId === sub.tenantId : null;
-            if (!silent) {
-              logger.info(`\n${pc.dim('Azure CLI:')} ${pc.green('connected')}`);
-              logger.info(`${pc.dim('Subscription:')} ${sub.name} ${pc.dim(`(${sub.id})`)}`);
-              if (output.tenantId && sub.tenantId) {
-                if (output.tenantId === sub.tenantId) {
-                  logger.info(`${pc.dim('Tenant:')} ${pc.green('matches Teams login')}`);
-                } else {
-                  logger.info(`${pc.dim('Tenant:')} ${pc.red('mismatch')}`);
-                  logger.info(`  ${pc.dim('Teams login:')} ${output.tenantId}`);
-                  logger.info(`  ${pc.dim('Azure CLI:')}   ${sub.tenantId}`);
-                  logger.info(`  ${pc.dim('Run')} ${pc.cyan(`az login --tenant ${output.tenantId}`)} ${pc.dim('to align.')}`);
-                }
-              }
-            }
-          } catch {
-            if (!silent)
-              logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('status unknown')}`);
-          }
-        }
-      }
+      const envResult = await checkAndDisplayEnvironment(account, silent);
+      output.tdp = envResult.tdp;
+      output.azureCli = envResult.azureCli;
 
       if (options.json) outputJson(output);
     })

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,14 +1,13 @@
 import { Command } from 'commander';
-import { createSilentSpinner } from '../utils/spinner.js';
 import pc from 'picocolors';
-import { type AccountInfo } from '@azure/msal-node';
-import { getAccount, getTokenSilent, paths, teamsDevPortalScopes } from '../auth/index.js';
-import { isAzInstalled, isAzLoggedIn, runAz } from '../utils/az.js';
+import { getAccount, paths } from '../auth/index.js';
 import { wrapAction } from '../utils/errors.js';
-import { isInteractive } from '../utils/interactive.js';
 import { isVerbose, logger } from '../utils/logger.js';
 import { outputJson } from '../utils/json-output.js';
-import { fetchTenantSettings, fetchUserAppPolicy } from '../apps/api.js';
+import {
+  checkAndDisplayEnvironment,
+  type EnvironmentCheckResult,
+} from '../utils/environment.js';
 
 interface StatusOptions {
   json?: boolean;
@@ -21,156 +20,6 @@ interface StatusOutput {
   userObjectId: string | null;
   tdp: EnvironmentCheckResult['tdp'];
   azureCli: EnvironmentCheckResult['azureCli'];
-}
-
-export interface EnvironmentCheckResult {
-  tdp: {
-    connected: boolean;
-    sideloading: {
-      tenant: boolean | null;
-      user: boolean | null;
-    };
-  } | null;
-  azureCli: {
-    installed: boolean;
-    loggedIn: boolean;
-    subscription: { name: string; id: string } | null;
-    tenantId: string | null;
-    tenantMatch: boolean | null;
-  };
-}
-
-/**
- * Check TDP sideloading and Azure CLI status, display results unless silent.
- * Used by both the `status` command and post-login flow.
- */
-export async function checkAndDisplayEnvironment(
-  account: AccountInfo,
-  silent = false
-): Promise<EnvironmentCheckResult> {
-  const muteSpinners = silent || !isInteractive();
-  const tenantId = account.tenantId;
-  const result: EnvironmentCheckResult = {
-    tdp: null,
-    azureCli: { installed: false, loggedIn: false, subscription: null, tenantId: null, tenantMatch: null },
-  };
-
-  // ── TDP / sideloading ─────────────────────────────────────────────
-  const tdpSpinner = createSilentSpinner('Checking sideloading status...', muteSpinners).start();
-  const tdpToken = await getTokenSilent(teamsDevPortalScopes);
-
-  if (!tdpToken) {
-    result.tdp = { connected: false, sideloading: { tenant: null, user: null } };
-    const text = `TDP: ${pc.yellow('not connected')} ${pc.dim('(token unavailable)')}`;
-    tdpSpinner.warn({ text });
-    if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
-  } else {
-    result.tdp = { connected: true, sideloading: { tenant: null, user: null } };
-
-    try {
-      const [tenantSettings, userPolicy] = await Promise.all([
-        fetchTenantSettings(tdpToken),
-        fetchUserAppPolicy(tdpToken),
-      ]);
-
-      const tenantEnabled = tenantSettings.isSideLoadingInteractionEnabled ?? false;
-      const userAllowed = userPolicy.value?.isSideloadingAllowed ?? false;
-
-      result.tdp.sideloading.tenant = tenantEnabled;
-      result.tdp.sideloading.user = userAllowed;
-
-      if (tenantEnabled && userAllowed) {
-        const text = `Sideloading: ${pc.green('enabled')}`;
-        tdpSpinner.success({ text });
-        if (!silent && muteSpinners) logger.info(`${pc.green('✔')} ${text}`);
-      } else if (!tenantEnabled && userAllowed) {
-        const text = `Sideloading: ${pc.yellow('disabled at tenant level')}`;
-        tdpSpinner.warn({ text });
-        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
-        if (!silent) {
-          logger.info(
-            `  ${pc.dim('Your user policy allows sideloading, but the tenant-wide setting is off.')}`
-          );
-          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
-          logger.info(
-            `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
-          );
-        }
-      } else if (tenantEnabled && !userAllowed) {
-        const text = `Sideloading: ${pc.yellow('not allowed for your account')}`;
-        tdpSpinner.warn({ text });
-        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
-        if (!silent) {
-          logger.info(
-            `  ${pc.dim('Sideloading is enabled for the tenant, but your user policy blocks it.')}`
-          );
-          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
-          logger.info(
-            `  ${pc.dim('Users → Find the user → Policies → App setup policy → "Upload custom apps"')}`
-          );
-        }
-      } else {
-        const text = `Sideloading: ${pc.yellow('disabled')}`;
-        tdpSpinner.warn({ text });
-        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
-        if (!silent) {
-          logger.info(
-            `  ${pc.dim('Neither the tenant nor your user policy allows sideloading.')}`
-          );
-          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
-          logger.info(
-            `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
-          );
-        }
-      }
-    } catch {
-      const text = `Sideloading: ${pc.yellow('could not determine')}`;
-      tdpSpinner.warn({ text });
-      if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
-    }
-  }
-
-  // ── Azure CLI ─────────────────────────────────────────────────────
-  const azInstalled = await isAzInstalled();
-  result.azureCli.installed = azInstalled;
-
-  if (!azInstalled) {
-    if (!silent) logger.info(`\n${pc.dim('Azure CLI:')} ${pc.yellow('not installed')}`);
-  } else {
-    const azLoggedIn = await isAzLoggedIn();
-    result.azureCli.loggedIn = azLoggedIn;
-
-    if (!azLoggedIn) {
-      if (!silent)
-        logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('not logged in')}`);
-    } else {
-      try {
-        const sub = await runAz<{ name: string; id: string; tenantId: string }>(['account', 'show']);
-        result.azureCli.subscription = { name: sub.name, id: sub.id };
-        result.azureCli.tenantId = sub.tenantId;
-        result.azureCli.tenantMatch = tenantId ? tenantId === sub.tenantId : null;
-        if (!silent) {
-          logger.info(`\n${pc.dim('Azure CLI:')} ${pc.green('connected')}`);
-          logger.info(`${pc.dim('Subscription:')} ${sub.name} ${pc.dim(`(${sub.id})`)}`);
-          if (tenantId && sub.tenantId) {
-            if (tenantId === sub.tenantId) {
-              logger.info(`${pc.dim('Tenant:')} ${pc.green('matches Teams login')}`);
-            } else {
-              logger.info(`${pc.dim('Tenant:')} ${pc.red('mismatch')}`);
-              logger.info(`  ${pc.dim('Teams login:')} ${tenantId}`);
-              logger.info(`  ${pc.dim('Azure CLI:')}   ${sub.tenantId}`);
-              logger.info(`  ${pc.dim('Run')} ${pc.cyan(`az login --tenant ${tenantId}`)} ${pc.dim('to align.')}`);
-            }
-          }
-        }
-      } catch {
-        if (!silent)
-          logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('status unknown')}`);
-      }
-    }
-  }
-
-  return result;
 }
 
 export const statusCommand = new Command('status')

--- a/packages/cli/src/utils/environment.ts
+++ b/packages/cli/src/utils/environment.ts
@@ -1,0 +1,158 @@
+import { createSilentSpinner } from './spinner.js';
+import pc from 'picocolors';
+import { type AccountInfo } from '@azure/msal-node';
+import { getTokenSilent, teamsDevPortalScopes } from '../auth/index.js';
+import { isAzInstalled, isAzLoggedIn, runAz } from './az.js';
+import { isInteractive } from './interactive.js';
+import { logger } from './logger.js';
+import { fetchTenantSettings, fetchUserAppPolicy } from '../apps/api.js';
+
+export interface EnvironmentCheckResult {
+  tdp: {
+    connected: boolean;
+    sideloading: {
+      tenant: boolean | null;
+      user: boolean | null;
+    };
+  } | null;
+  azureCli: {
+    installed: boolean;
+    loggedIn: boolean;
+    subscription: { name: string; id: string } | null;
+    tenantId: string | null;
+    tenantMatch: boolean | null;
+  };
+}
+
+/**
+ * Check TDP sideloading and Azure CLI status, display results unless silent.
+ * Used by both the `status` command and post-login flow.
+ */
+export async function checkAndDisplayEnvironment(
+  account: AccountInfo,
+  silent = false
+): Promise<EnvironmentCheckResult> {
+  const muteSpinners = silent || !isInteractive();
+  const tenantId = account.tenantId;
+  const result: EnvironmentCheckResult = {
+    tdp: null,
+    azureCli: { installed: false, loggedIn: false, subscription: null, tenantId: null, tenantMatch: null },
+  };
+
+  // ── TDP / sideloading ─────────────────────────────────────────────
+  const tdpSpinner = createSilentSpinner('Checking sideloading status...', muteSpinners).start();
+  const tdpToken = await getTokenSilent(teamsDevPortalScopes);
+
+  if (!tdpToken) {
+    result.tdp = { connected: false, sideloading: { tenant: null, user: null } };
+    const text = `TDP: ${pc.yellow('not connected')} ${pc.dim('(token unavailable)')}`;
+    tdpSpinner.warn({ text });
+    if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+  } else {
+    result.tdp = { connected: true, sideloading: { tenant: null, user: null } };
+
+    try {
+      const [tenantSettings, userPolicy] = await Promise.all([
+        fetchTenantSettings(tdpToken),
+        fetchUserAppPolicy(tdpToken),
+      ]);
+
+      const tenantEnabled = tenantSettings.isSideLoadingInteractionEnabled ?? false;
+      const userAllowed = userPolicy.value?.isSideloadingAllowed ?? false;
+
+      result.tdp.sideloading.tenant = tenantEnabled;
+      result.tdp.sideloading.user = userAllowed;
+
+      if (tenantEnabled && userAllowed) {
+        const text = `Sideloading: ${pc.green('enabled')}`;
+        tdpSpinner.success({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.green('✔')} ${text}`);
+      } else if (!tenantEnabled && userAllowed) {
+        const text = `Sideloading: ${pc.yellow('disabled at tenant level')}`;
+        tdpSpinner.warn({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+        if (!silent) {
+          logger.info(
+            `  ${pc.dim('Your user policy allows sideloading, but the tenant-wide setting is off.')}`
+          );
+          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
+          logger.info(
+            `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
+          );
+        }
+      } else if (tenantEnabled && !userAllowed) {
+        const text = `Sideloading: ${pc.yellow('not allowed for your account')}`;
+        tdpSpinner.warn({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+        if (!silent) {
+          logger.info(
+            `  ${pc.dim('Sideloading is enabled for the tenant, but your user policy blocks it.')}`
+          );
+          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
+          logger.info(
+            `  ${pc.dim('Users → Find the user → Policies → App setup policy → "Upload custom apps"')}`
+          );
+        }
+      } else {
+        const text = `Sideloading: ${pc.yellow('disabled')}`;
+        tdpSpinner.warn({ text });
+        if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+        if (!silent) {
+          logger.info(
+            `  ${pc.dim('Neither the tenant nor your user policy allows sideloading.')}`
+          );
+          logger.info(`  ${pc.dim('Ask your admin to enable it in Teams Admin Center →')}`);
+          logger.info(
+            `  ${pc.dim('Org-wide app settings → Custom apps → "Allow interaction with custom apps"')}`
+          );
+        }
+      }
+    } catch {
+      const text = `Sideloading: ${pc.yellow('could not determine')}`;
+      tdpSpinner.warn({ text });
+      if (!silent && muteSpinners) logger.info(`${pc.yellow('⚠')} ${text}`);
+    }
+  }
+
+  // ── Azure CLI ─────────────────────────────────────────────────────
+  const azInstalled = await isAzInstalled();
+  result.azureCli.installed = azInstalled;
+
+  if (!azInstalled) {
+    if (!silent) logger.info(`\n${pc.dim('Azure CLI:')} ${pc.yellow('not installed')}`);
+  } else {
+    const azLoggedIn = await isAzLoggedIn();
+    result.azureCli.loggedIn = azLoggedIn;
+
+    if (!azLoggedIn) {
+      if (!silent)
+        logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('not logged in')}`);
+    } else {
+      try {
+        const sub = await runAz<{ name: string; id: string; tenantId: string }>(['account', 'show']);
+        result.azureCli.subscription = { name: sub.name, id: sub.id };
+        result.azureCli.tenantId = sub.tenantId;
+        result.azureCli.tenantMatch = tenantId ? tenantId === sub.tenantId : null;
+        if (!silent) {
+          logger.info(`\n${pc.dim('Azure CLI:')} ${pc.green('connected')}`);
+          logger.info(`${pc.dim('Subscription:')} ${sub.name} ${pc.dim(`(${sub.id})`)}`);
+          if (tenantId && sub.tenantId) {
+            if (tenantId === sub.tenantId) {
+              logger.info(`${pc.dim('Tenant:')} ${pc.green('matches Teams login')}`);
+            } else {
+              logger.info(`${pc.dim('Tenant:')} ${pc.red('mismatch')}`);
+              logger.info(`  ${pc.dim('Teams login:')} ${tenantId}`);
+              logger.info(`  ${pc.dim('Azure CLI:')}   ${sub.tenantId}`);
+              logger.info(`  ${pc.dim('Run')} ${pc.cyan(`az login --tenant ${tenantId}`)} ${pc.dim('to align.')}`);
+            }
+          }
+        }
+      } catch {
+        if (!silent)
+          logger.info(`\n${pc.dim('Azure CLI:')} installed, ${pc.yellow('status unknown')}`);
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- After `teams login` succeeds, automatically runs the same sideloading + Azure CLI checks that `teams status` shows
- Extracted environment check logic from `status.ts` into a shared `checkAndDisplayEnvironment()` function used by both commands
- Spinners auto-mute in non-interactive terminals, falls back to plain `logger.info` output

## Test plan
- [x] `teams login` (interactive) — shows sideloading + Azure CLI status with spinners after login
- [x] `TEAMS_NO_INTERACTIVE=1 teams login` — shows same info without spinners
- [x] `teams status` — unchanged behavior
- [x] `teams status --json` — JSON output unchanged
- [x] `npm run test` — all tests pass