### PR TITLE
cli: add copilot scope support

### DIFF
--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -65,6 +65,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
         { name: 'Personal', value: 'personal', checked: true },
         { name: 'Team', value: 'team', checked: true },
         { name: 'Group Chat', value: 'groupChat', checked: true },
+        { name: 'Copilot', value: 'copilot' },
       ],
     });
   }

--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -1,5 +1,7 @@
 import { input, checkbox } from '@inquirer/prompts';
+import pc from 'picocolors';
 import { isInteractive } from '../utils/interactive.js';
+import { logger } from '../utils/logger.js';
 import type { BotScope } from './manifest.js';
 
 /**
@@ -59,15 +61,24 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
   }
 
   if (customizeFields.includes('scopes')) {
-    result.scopes = await checkbox<BotScope>({
-      message: 'Select bot scopes:',
-      choices: [
-        { name: 'Personal', value: 'personal', checked: true },
-        { name: 'Team', value: 'team', checked: true },
-        { name: 'Group Chat', value: 'groupChat', checked: true },
-        { name: 'Copilot', value: 'copilot' },
-      ],
-    });
+    while (true) {
+      const scopes = await checkbox<BotScope>({
+        message: 'Select bot scopes:',
+        choices: [
+          { name: 'Personal', value: 'personal', checked: true },
+          { name: 'Team', value: 'team', checked: true },
+          { name: 'Group Chat', value: 'groupChat', checked: true },
+          { name: 'Copilot', value: 'copilot' },
+        ],
+      });
+
+      if (scopes.length > 0) {
+        result.scopes = scopes;
+        break;
+      }
+
+      logger.warn(pc.yellow('Select at least 1 scope.'));
+    }
   }
 
   if (customizeFields.includes('developer')) {

--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -66,9 +66,16 @@ export function createManifest(options: ManifestOptions): object {
     botName,
     endpoint,
     description,
-    scopes = ['personal', 'team', 'groupChat'],
     developer,
   } = options;
+  let scopes = options.scopes ?? ['personal', 'team', 'groupChat'];
+
+  const hasCopilot = scopes.includes('copilot');
+
+  // Copilot requires personal scope
+  if (hasCopilot && !scopes.includes('personal')) {
+    scopes = ['personal', ...scopes];
+  }
 
   const validDomains: string[] = ['*.botframework.com'];
   if (endpoint) {
@@ -76,7 +83,7 @@ export function createManifest(options: ManifestOptions): object {
     if (domain) validDomains.push(domain);
   }
 
-  return {
+  const manifest: Record<string, unknown> = {
     $schema:
       'https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json',
     manifestVersion: '1.25',
@@ -117,6 +124,14 @@ export function createManifest(options: ManifestOptions): object {
     validDomains,
     supportsChannelFeatures: 'tier1',
   };
+
+  if (hasCopilot) {
+    manifest.copilotAgents = {
+      customEngineAgents: [{ type: 'bot', id: botId }],
+    };
+  }
+
+  return manifest;
 }
 
 function defaultIcon(name: string): Buffer {

--- a/packages/cli/src/apps/manifest.ts
+++ b/packages/cli/src/apps/manifest.ts
@@ -68,7 +68,7 @@ export function createManifest(options: ManifestOptions): object {
     description,
     developer,
   } = options;
-  let scopes = options.scopes ?? ['personal', 'team', 'groupChat'];
+  let scopes = options.scopes?.length ? options.scopes : ['personal', 'team', 'groupChat'];
 
   const hasCopilot = scopes.includes('copilot');
 

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -37,6 +37,8 @@ const VALID_SCOPES: BotScope[] = ['personal', 'team', 'groupChat', 'copilot'];
  * Enforces `personal` when `copilot` is selected, and manages the `copilotAgents` block.
  */
 export function buildScopeUpdates(appDetails: AppDetails, newScopes: BotScope[]): Partial<AppDetails> {
+  if (newScopes.length === 0) return {};
+
   let scopes = [...newScopes];
   const hasCopilot = scopes.includes('copilot');
 
@@ -57,7 +59,7 @@ export function buildScopeUpdates(appDetails: AppDetails, newScopes: BotScope[])
       customEngineAgents: [{ type: 'bot', id: currentBot.botId }],
     };
   } else {
-    // Explicitly null out copilotAgents to remove it
+    // Explicitly unset/remove copilotAgents
     updates.copilotAgents = undefined;
   }
 
@@ -179,15 +181,26 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
 
     if (action === 'edit-scopes') {
       const currentScopes = (appDetails.bots?.[0]?.scopes ?? ['personal']) as BotScope[];
-      const newScopes = await checkbox<BotScope>({
-        message: 'Select bot scopes:',
-        choices: [
-          { name: 'Personal', value: 'personal', checked: currentScopes.includes('personal') },
-          { name: 'Team', value: 'team', checked: currentScopes.includes('team') },
-          { name: 'Group Chat', value: 'groupChat', checked: currentScopes.includes('groupChat') },
-          { name: 'Copilot', value: 'copilot', checked: currentScopes.includes('copilot') },
-        ],
-      });
+      let newScopes: BotScope[];
+
+      while (true) {
+        const selectedScopes = await checkbox<BotScope>({
+          message: 'Select bot scopes:',
+          choices: [
+            { name: 'Personal', value: 'personal', checked: currentScopes.includes('personal') },
+            { name: 'Team', value: 'team', checked: currentScopes.includes('team') },
+            { name: 'Group Chat', value: 'groupChat', checked: currentScopes.includes('groupChat') },
+            { name: 'Copilot', value: 'copilot', checked: currentScopes.includes('copilot') },
+          ],
+        });
+
+        if (selectedScopes.length > 0) {
+          newScopes = selectedScopes;
+          break;
+        }
+
+        logger.warn(pc.yellow('Select at least 1 scope.'));
+      }
 
       if (JSON.stringify(newScopes.sort()) === JSON.stringify([...currentScopes].sort())) {
         logger.info(pc.dim('\nNo changes made.'));

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { select, input } from '@inquirer/prompts';
+import { select, input, checkbox } from '@inquirer/prompts';
 import pc from 'picocolors';
 import { getAccount, getTokenSilent, teamsDevPortalScopes } from '../../auth/index.js';
 import {
@@ -28,9 +28,45 @@ import { bumpPatchVersion, stableStringify } from '../../utils/version.js';
 import type { AppSummary, AppDetails } from '../../apps/types.js';
 import type { BotDetails } from '../../apps/tdp.js';
 import type { BotLocation } from '../../apps/bot-location.js';
+import type { BotScope } from '../../apps/manifest.js';
+
+const VALID_SCOPES: BotScope[] = ['personal', 'team', 'groupChat', 'copilot'];
+
+/**
+ * Build the partial AppDetails update for a scope change.
+ * Enforces `personal` when `copilot` is selected, and manages the `copilotAgents` block.
+ */
+export function buildScopeUpdates(appDetails: AppDetails, newScopes: BotScope[]): Partial<AppDetails> {
+  let scopes = [...newScopes];
+  const hasCopilot = scopes.includes('copilot');
+
+  // Copilot requires personal scope
+  if (hasCopilot && !scopes.includes('personal')) {
+    scopes = ['personal', ...scopes];
+  }
+
+  const currentBot = appDetails.bots?.[0];
+  if (!currentBot) return {};
+
+  const updates: Partial<AppDetails> = {
+    bots: [{ ...currentBot, scopes }],
+  };
+
+  if (hasCopilot) {
+    updates.copilotAgents = {
+      customEngineAgents: [{ type: 'bot', id: currentBot.botId }],
+    };
+  } else {
+    // Explicitly null out copilotAgents to remove it
+    updates.copilotAgents = undefined;
+  }
+
+  return updates;
+}
 
 interface UpdateOptions {
   endpoint?: string;
+  scopes?: string;
   name?: string;
   longName?: string;
   shortDescription?: string;
@@ -63,6 +99,7 @@ interface AppUpdateOutput {
     websiteUrl?: string;
     privacyUrl?: string;
     termsOfUseUrl?: string;
+    scopes?: string[];
     colorIcon?: boolean;
     outlineIcon?: boolean;
     webApplicationInfoId?: string;
@@ -121,11 +158,13 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
     }
 
     const showEndpoint = bot || botLocation === 'azure';
+    const hasBots = appDetails.bots && appDetails.bots.length > 0;
     const action = await select({
       message: 'What would you like to update?',
       choices: [
         { name: 'Basic info', value: 'edit-basic-info' },
         ...(showEndpoint ? [{ name: 'Endpoint', value: 'edit-endpoint' }] : []),
+        ...(hasBots ? [{ name: 'Scopes', value: 'edit-scopes' }] : []),
         { name: 'Icons', value: 'edit-icons' },
         { name: 'Back', value: 'back' },
       ],
@@ -135,6 +174,36 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
 
     if (action === 'edit-basic-info') {
       appDetails = await showBasicInfoEditor(appDetails, token);
+      continue;
+    }
+
+    if (action === 'edit-scopes') {
+      const currentScopes = (appDetails.bots?.[0]?.scopes ?? ['personal']) as BotScope[];
+      const newScopes = await checkbox<BotScope>({
+        message: 'Select bot scopes:',
+        choices: [
+          { name: 'Personal', value: 'personal', checked: currentScopes.includes('personal') },
+          { name: 'Team', value: 'team', checked: currentScopes.includes('team') },
+          { name: 'Group Chat', value: 'groupChat', checked: currentScopes.includes('groupChat') },
+          { name: 'Copilot', value: 'copilot', checked: currentScopes.includes('copilot') },
+        ],
+      });
+
+      if (JSON.stringify(newScopes.sort()) === JSON.stringify([...currentScopes].sort())) {
+        logger.info(pc.dim('\nNo changes made.'));
+        continue;
+      }
+
+      const scopeUpdates = buildScopeUpdates(appDetails, newScopes);
+      const scopeSpinner = createSilentSpinner('Updating scopes...').start();
+      const result = await updateAppDetails(token, app.teamsAppId, scopeUpdates);
+      scopeSpinner.success({ text: `Scopes updated: ${(scopeUpdates.bots?.[0]?.scopes ?? []).join(', ')}` });
+      if (result.versionBumped) {
+        logger.info(pc.dim(`Version auto-bumped: ${result.previousVersion} → ${result.version} — reinstall may be needed`));
+      }
+
+      // Refresh appDetails
+      appDetails = await fetchAppDetailsV2(token, app.teamsAppId);
       continue;
     }
 
@@ -255,6 +324,7 @@ export const appUpdateCommand = new Command('update')
   .description("Update a Teams app's properties")
   .argument('[appId]', 'App ID')
   .option('--endpoint <url>', '[OPTIONAL] Set the bot messaging endpoint URL')
+  .option('--scopes <scopes>', '[OPTIONAL] Set bot scopes (comma-separated: personal,team,groupChat,copilot)')
   .option('--name <name>', '[OPTIONAL] Set the app short name (max 30 chars)')
   .option('--long-name <name>', '[OPTIONAL] Set the app long name (max 100 chars)')
   .option('--short-description <desc>', '[OPTIONAL] Set the short description (max 80 chars)')
@@ -276,6 +346,7 @@ export const appUpdateCommand = new Command('update')
       // Check if any mutation flags were provided
       const hasMutationFlags =
         options.endpoint !== undefined ||
+        options.scopes !== undefined ||
         options.name !== undefined ||
         options.longName !== undefined ||
         options.shortDescription !== undefined ||
@@ -317,6 +388,19 @@ export const appUpdateCommand = new Command('update')
             'VALIDATION_FORMAT',
             'webApplicationInfo resource URI must start with "api://" (e.g., api://botid-<your-bot-id>).'
           );
+        }
+      }
+      if (options.scopes !== undefined) {
+        const parsed = options.scopes.split(',').map((s) => s.trim()).filter(Boolean);
+        const invalid = parsed.filter((s) => !VALID_SCOPES.includes(s as BotScope));
+        if (invalid.length > 0) {
+          throw new CliError(
+            'VALIDATION_FORMAT',
+            `Invalid scope(s): ${invalid.join(', ')}. Valid scopes: ${VALID_SCOPES.join(', ')}`
+          );
+        }
+        if (parsed.length === 0) {
+          throw new CliError('VALIDATION_FORMAT', 'At least one scope is required.');
         }
       }
       if (options.endpoint !== undefined) {
@@ -467,6 +551,21 @@ export const appUpdateCommand = new Command('update')
         allUpdates.endpoint = options.endpoint;
       }
 
+      // --- Scopes ---
+      if (options.scopes !== undefined) {
+        if (!app.bots || app.bots.length === 0) {
+          throw new CliError('NOT_FOUND_BOT', 'This app has no bots.');
+        }
+
+        const parsed = options.scopes.split(',').map((s) => s.trim()).filter(Boolean) as BotScope[];
+        const currentDetails = detailsBefore ?? await fetchAppDetailsV2(token, appId);
+        const scopeUpdates = buildScopeUpdates(currentDetails, parsed);
+        const spinner = createSilentSpinner('Updating scopes...', silent).start();
+        await updateAppDetails(token, appId, scopeUpdates, { autoBumpVersion: false });
+        spinner.success({ text: `Scopes updated: ${(scopeUpdates.bots?.[0]?.scopes ?? []).join(', ')}` });
+        allUpdates.scopes = scopeUpdates.bots?.[0]?.scopes as string[];
+      }
+
       // --- Basic info fields (validation already done upfront) ---
       if (options.name !== undefined) allUpdates.shortName = options.name;
       if (options.longName !== undefined) allUpdates.longName = options.longName;
@@ -487,7 +586,7 @@ export const appUpdateCommand = new Command('update')
       }
 
       // Apply basic info updates (endpoint and icons use separate API calls)
-      const { endpoint: _ep, colorIcon: _ci, outlineIcon: _oi, ...basicInfoUpdates } = allUpdates;
+      const { endpoint: _ep, scopes: _sc, colorIcon: _ci, outlineIcon: _oi, ...basicInfoUpdates } = allUpdates;
       if (Object.keys(basicInfoUpdates).length > 0) {
         const spinner = createSilentSpinner('Updating app details...', silent).start();
         await updateAppDetails(token, appId, basicInfoUpdates, { autoBumpVersion: false });

--- a/packages/cli/tests/manifest-builder-icons.test.ts
+++ b/packages/cli/tests/manifest-builder-icons.test.ts
@@ -106,7 +106,9 @@ describe('createManifest copilotAgents', () => {
       botId: 'test-bot-id',
       botName: 'Test Bot',
       scopes: ['personal', 'team'],
-    }) as Record<string, unknown>;
+    }) as {
+      copilotAgents?: { customEngineAgents: Array<{ type: string; id: string }> };
+    };
 
     expect(manifest.copilotAgents).toBeUndefined();
   });

--- a/packages/cli/tests/manifest-builder-icons.test.ts
+++ b/packages/cli/tests/manifest-builder-icons.test.ts
@@ -83,6 +83,97 @@ describe('collectManifestCustomization icons', () => {
   });
 });
 
+describe('createManifest copilotAgents', () => {
+  it('adds copilotAgents block when copilot scope is selected', () => {
+    const manifest = createManifest({
+      botId: 'test-bot-id',
+      botName: 'Test Bot',
+      scopes: ['personal', 'copilot'],
+    }) as {
+      bots: Array<{ scopes: string[] }>;
+      copilotAgents: { customEngineAgents: Array<{ type: string; id: string }> };
+    };
+
+    expect(manifest.copilotAgents).toEqual({
+      customEngineAgents: [{ type: 'bot', id: 'test-bot-id' }],
+    });
+    expect(manifest.bots[0].scopes).toContain('copilot');
+    expect(manifest.bots[0].scopes).toContain('personal');
+  });
+
+  it('does not add copilotAgents block when copilot scope is not selected', () => {
+    const manifest = createManifest({
+      botId: 'test-bot-id',
+      botName: 'Test Bot',
+      scopes: ['personal', 'team'],
+    }) as Record<string, unknown>;
+
+    expect(manifest.copilotAgents).toBeUndefined();
+  });
+
+  it('auto-includes personal scope when copilot is selected without it', () => {
+    const manifest = createManifest({
+      botId: 'test-bot-id',
+      botName: 'Test Bot',
+      scopes: ['copilot'],
+    }) as { bots: Array<{ scopes: string[] }> };
+
+    expect(manifest.bots[0].scopes).toContain('personal');
+    expect(manifest.bots[0].scopes).toContain('copilot');
+  });
+});
+
+describe('buildScopeUpdates', () => {
+  const baseApp = {
+    teamsAppId: 'test-app-id',
+    appId: 'test-app-id',
+    shortName: 'Test',
+    longName: '',
+    shortDescription: '',
+    longDescription: '',
+    version: '1.0.0',
+    developerName: '',
+    websiteUrl: '',
+    privacyUrl: '',
+    termsOfUseUrl: '',
+    manifestVersion: '1.25',
+    webApplicationInfoId: '',
+    mpnId: '',
+    accentColor: '',
+    bots: [{ botId: 'test-bot-id', scopes: ['personal', 'team'] }],
+  };
+
+  it('adds copilotAgents block when copilot scope is added', async () => {
+    const { buildScopeUpdates } = await import('../src/commands/app/update.js');
+    const updates = buildScopeUpdates(baseApp, ['personal', 'copilot']);
+    expect(updates.copilotAgents).toEqual({
+      customEngineAgents: [{ type: 'bot', id: 'test-bot-id' }],
+    });
+    expect(updates.bots?.[0]?.scopes).toContain('copilot');
+    expect(updates.bots?.[0]?.scopes).toContain('personal');
+  });
+
+  it('removes copilotAgents block when copilot scope is removed', async () => {
+    const { buildScopeUpdates } = await import('../src/commands/app/update.js');
+    const updates = buildScopeUpdates(baseApp, ['personal', 'team']);
+    expect(updates.copilotAgents).toBeUndefined();
+  });
+
+  it('auto-includes personal when copilot is selected without it', async () => {
+    const { buildScopeUpdates } = await import('../src/commands/app/update.js');
+    const updates = buildScopeUpdates(baseApp, ['copilot']);
+    expect(updates.bots?.[0]?.scopes).toContain('personal');
+    expect(updates.bots?.[0]?.scopes).toContain('copilot');
+  });
+
+  it('returns empty object when app has no bots', async () => {
+    const { buildScopeUpdates } = await import('../src/commands/app/update.js');
+    const noBotApp = { ...baseApp, bots: undefined };
+    const updates = buildScopeUpdates(noBotApp, ['personal']);
+    expect(updates).toEqual({});
+  });
+});
+
 describe('createManifest validDomains', () => {
   it('includes *.botframework.com by default with no endpoint', () => {
     const manifest = createManifest({

--- a/teams.md/docs/cli/commands/app/create.md
+++ b/teams.md/docs/cli/commands/app/create.md
@@ -46,6 +46,19 @@ By default, the bot is Teams-managed (no Azure subscription needed). Use `--azur
 
 See [Bot Locations](../../concepts/bot-locations) for details on the trade-offs.
 
+### Scopes
+
+During interactive creation, you can customize which scopes the bot supports:
+
+| Scope | Description |
+|-------|-------------|
+| **Personal** | 1:1 chat with the bot (default) |
+| **Team** | Channel conversations (default) |
+| **Group Chat** | Group chat conversations (default) |
+| **Copilot** | Available as a custom engine agent in M365 Copilot |
+
+Selecting **Copilot** automatically adds the `copilotAgents.customEngineAgents` block to the manifest and ensures the **Personal** scope is included (required by M365 Copilot).
+
 ### Examples
 
 Create with defaults (Teams-managed, generated manifest):

--- a/teams.md/docs/cli/commands/app/update.md
+++ b/teams.md/docs/cli/commands/app/update.md
@@ -25,6 +25,7 @@ teams app update [appId] [options]
 | Flag | Description |
 |------|-------------|
 | `--endpoint <url>` | [OPTIONAL] Set the bot messaging endpoint URL |
+| `--scopes <scopes>` | [OPTIONAL] Set bot scopes (comma-separated: personal,team,groupChat,copilot) |
 | `--name <name>` | [OPTIONAL] Set the app short name (max 30 chars) |
 | `--long-name <name>` | [OPTIONAL] Set the app long name (max 100 chars) |
 | `--short-description <desc>` | [OPTIONAL] Set the short description (max 80 chars) |
@@ -66,6 +67,16 @@ Update multiple properties at once:
 ```bash
 teams app update <appId> --name "New Name" --version "2.0.0" --developer "My Team"
 ```
+
+### Scopes
+
+Update which scopes the bot supports. In interactive mode, select "Scopes" from the update menu. In scripted mode, use `--scopes`:
+
+```bash
+teams app update <appId> --scopes personal,team,copilot
+```
+
+Selecting **copilot** automatically adds the `copilotAgents.customEngineAgents` block to the manifest and ensures **personal** is included. Removing **copilot** removes the `copilotAgents` block.
 
 ### webApplicationInfo (SSO)
 


### PR DESCRIPTION
## Summary
- adds copilot as a scope option in `app create` (interactive checkbox) and generates the `copilotAgents.customEngineAgents` manifest block when selected
- adds scope editing to `app update` — both interactive menu ("Scopes" option) and `--scopes` CLI flag (e.g. `--scopes personal,copilot`)
- auto-includes `personal` scope when copilot is selected (M365 requirement), and removes `copilotAgents` block when copilot is deselected

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (7 new tests for manifest generation + scope updates)
- [ ] `teams app create` → customize scopes → select Copilot → verify manifest in TDP has `copilotAgents` block
- [ ] `teams app update <id> --scopes personal,copilot --json` → verify scopes and copilotAgents updated
- [ ] `teams app update` → interactive → Scopes → toggle copilot on/off → verify in TDP