### PR TITLE
docs: update dialog guides to current SDK patterns

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/python.incl.md
@@ -36,7 +36,11 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
 <!-- dialog-open-intro -->
 
-When a user clicks the button, Teams sends a `task/fetch` invoke to your app. Register a handler with `@app.on_dialog_open("dialog_id")` to handle a specific dialog, or `@app.on_dialog_open()` for a catch-all:
+When a user clicks the button, Teams sends a `task/fetch` invoke to your app. Register a handler with `@app.on_dialog_open("dialog_id")` to handle a specific dialog, or `@app.on_dialog_open()` for a catch-all.
+
+:::tip
+Use `@app.on_dialog_open("simple_form")` to handle specific dialogs directly, instead of a single catch-all handler with if-else logic. This keeps each handler focused and avoids routing boilerplate.
+:::
 
 <!-- dialog-open-code -->
 

--- a/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/python.incl.md
@@ -1,13 +1,13 @@
 <!-- entry-point-intro -->
 
-To open a dialog, you need to supply a special type of action as to the Adaptive Card. Once this button is clicked, the dialog will open and ask the application what to show.
+To open a dialog, add a button to your Adaptive Card using `OpenDialogData`. This sets up the `task/fetch` protocol and includes a `dialog_id` that the SDK uses to route to the correct handler.
 
 <!-- entry-point-code -->
 
 ```python
 from microsoft_teams.api import MessageActivity, MessageActivityInput, TypingActivityInput
 from microsoft_teams.apps import ActivityContext
-from microsoft_teams.cards import AdaptiveCard, TextBlock, TaskFetchAction
+from microsoft_teams.cards import AdaptiveCard, TextBlock, SubmitAction, OpenDialogData
 # ...
 
 @app.on_message
@@ -24,103 +24,104 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             )
         ]
     ).with_actions([
-        # Special type of action to open a dialog
-        TaskFetchAction(value={"OpenDialogType": "webpage_dialog"}).with_title("Webpage Dialog"),
-        # This data will be passed back in an event, so we can handle what to show in the dialog
-        TaskFetchAction(value={"OpenDialogType": "multi_step_form"}).with_title("Multi-step Form"),
-        TaskFetchAction(value={"OpenDialogType": "mixed_example"}).with_title("Mixed Example")
+        # OpenDialogData sets msteams.type = "task/fetch" and adds dialog_id for routing
+        SubmitAction(title="Simple form test").with_data(OpenDialogData("simple_form")),
+        SubmitAction(title="Webpage Dialog").with_data(OpenDialogData("webpage_dialog")),
+        SubmitAction(title="Multi-step Form").with_data(OpenDialogData("multi_step_form")),
     ])
-    # Send the card as an attachment
+
     message = MessageActivityInput(text="Enter this form").add_card(card)
     await ctx.send(message)
 ```
 
 <!-- dialog-open-intro -->
 
-Once an action is executed to open a dialog, the Teams client will send an event to the agent to request what the content of the dialog should be. Here is how to handle this event:
+When a user clicks the button, Teams sends a `task/fetch` invoke to your app. Register a handler with `@app.on_dialog_open("dialog_id")` to handle a specific dialog, or `@app.on_dialog_open()` for a catch-all:
 
 <!-- dialog-open-code -->
 
 ```python
-@app.on_dialog_open
-async def handle_dialog_open(ctx: ActivityContext[TaskFetchInvokeActivity]):
-    """Handle dialog open events for all dialog types."""
+from microsoft_teams.api import (
+    TaskFetchInvokeActivity, TaskModuleResponse,
+    TaskModuleContinueResponse, CardTaskModuleTaskInfo,
+    AdaptiveCardAttachment, card_attachment,
+)
+from microsoft_teams.apps import ActivityContext
+from microsoft_teams.cards import AdaptiveCard
+# ...
+
+# Handle a specific dialog by ID — no if-else needed
+@app.on_dialog_open("simple_form")
+async def handle_simple_form_open(ctx: ActivityContext[TaskFetchInvokeActivity]):
     card = AdaptiveCard(...)
 
-    # Return an object with the task value that renders a card
-    return InvokeResponse(
-                body=TaskModuleResponse(
-                    task=TaskModuleContinueResponse(
-                        value=CardTaskModuleTaskInfo(
-                            title="Title of Dialog",
-                            card=card_attachment(AdaptiveCardAttachment(content=card)),
-                        )
-                    )
-                )
+    return TaskModuleResponse(
+        task=TaskModuleContinueResponse(
+            value=CardTaskModuleTaskInfo(
+                title="Title of Dialog",
+                card=card_attachment(AdaptiveCardAttachment(content=card)),
             )
+        )
+    )
 ```
 
 <!-- rendering-card-code -->
 
 ```python
-from microsoft_teams.api import AdaptiveCardAttachment, TaskFetchInvokeActivity, InvokeResponse, card_attachment
-from microsoft_teams.api import CardTaskModuleTaskInfo, TaskModuleContinueResponse, TaskModuleResponse
+from microsoft_teams.api import (
+    TaskFetchInvokeActivity, TaskModuleResponse,
+    TaskModuleContinueResponse, CardTaskModuleTaskInfo,
+    AdaptiveCardAttachment, card_attachment,
+)
 from microsoft_teams.apps import ActivityContext
-from microsoft_teams.cards import AdaptiveCard, TextBlock, TextInput, SubmitAction, SubmitActionData
+from microsoft_teams.cards import AdaptiveCard, TextBlock, TextInput, SubmitAction, SubmitData
 # ...
 
-@app.on_dialog_open
-async def handle_dialog_open(ctx: ActivityContext[TaskFetchInvokeActivity]):
-    """Handle dialog open events for all dialog types."""
-    # Return an object with the task value that renders a card
+@app.on_dialog_open("simple_form")
+async def handle_simple_form_open(ctx: ActivityContext[TaskFetchInvokeActivity]):
     dialog_card = AdaptiveCard(
         schema="http://adaptivecards.io/schemas/adaptive-card.json",
         body=[
             TextBlock(text="This is a simple form", size="Large", weight="Bolder"),
             TextInput().with_label("Name").with_is_required(True).with_id("name").with_placeholder("Enter your name"),
         ],
+        # Use SubmitData to set the "action" field, which routes to @app.on_dialog_submit("action")
         actions=[
-            SubmitAction().with_title("Submit").with_data(SubmitActionData(ms_teams={"SubmissionDialogType": "simple_form"}))
+            SubmitAction().with_title("Submit").with_data(SubmitData("simple_form"))
         ]
     )
 
-
-    # Return an object with the task value that renders a card
-    return InvokeResponse(
-                body=TaskModuleResponse(
-                    task=TaskModuleContinueResponse(
-                        value=CardTaskModuleTaskInfo(
-                            title="Simple Form Dialog",
-                            card=card_attachment(AdaptiveCardAttachment(content=dialog_card)),
-                        )
-                    )
-                )
+    return TaskModuleResponse(
+        task=TaskModuleContinueResponse(
+            value=CardTaskModuleTaskInfo(
+                title="Simple Form Dialog",
+                card=card_attachment(AdaptiveCardAttachment(content=dialog_card)),
             )
+        )
+    )
 ```
 
 <!-- rendering-webpage-code -->
 
 ```python
 import os
-from microsoft_teams.api import InvokeResponse, TaskModuleContinueResponse, TaskModuleResponse, UrlTaskModuleTaskInfo
+from microsoft_teams.api import TaskModuleContinueResponse, TaskModuleResponse, UrlTaskModuleTaskInfo
 # ...
 
-return InvokeResponse(
-                body=TaskModuleResponse(
-                    task=TaskModuleContinueResponse(
-                        value=UrlTaskModuleTaskInfo(
-                            title="Webpage Dialog",
-                            # Here we are using a webpage that is hosted in the same
-                            # server as the agent. This server needs to be publicly accessible,
-                            # needs to set up teams.js client library (https://www.npmjs.com/package/@microsoft/teams-js)
-                            # and needs to be registered in the manifest.
-                            url=f"{os.getenv('BOT_ENDPOINT')}/tabs/dialog-webpage",
-                            width=1000,
-                            height=800,
-                        )
-                    )
-                )
+@app.on_dialog_open("webpage_dialog")
+async def handle_webpage_dialog_open(ctx):
+    return TaskModuleResponse(
+        task=TaskModuleContinueResponse(
+            value=UrlTaskModuleTaskInfo(
+                title="Webpage Dialog",
+                # The webpage must be publicly accessible, use the teams-js client library,
+                # and be registered in validDomains in the manifest.
+                url=f"{os.getenv('BOT_ENDPOINT')}/tabs/dialog-form",
+                width=1000,
+                height=800,
             )
+        )
+    )
 ```
 
 <!-- embedded-web-content -->

--- a/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/typescript.incl.md
@@ -1,6 +1,6 @@
 <!-- entry-point-intro -->
 
-To open a dialog, you need to supply a special type of action as to the Adaptive Card. Once this button is clicked, the dialog will open and ask the application what to show.
+To open a dialog, add a button to your Adaptive Card using `OpenDialogData`. This sets up the `task/fetch` protocol and includes a `dialog_id` that the SDK uses to route to the correct handler.
 
 <!-- entry-point-code -->
 
@@ -10,54 +10,39 @@ import { App } from '@microsoft/teams.apps';
 import {
   AdaptiveCard,
   IAdaptiveCard,
-  TaskFetchAction,
-  TaskFetchData,
+  OpenDialogData,
+  SubmitAction,
 } from '@microsoft/teams.cards';
 // ...
 
 app.on('message', async ({ send }) => {
   await send({ type: 'typing' });
 
-  // Create the launcher adaptive card
   const card: IAdaptiveCard = new AdaptiveCard({
     type: 'TextBlock',
     text: 'Select the examples you want to see!',
     size: 'Large',
     weight: 'Bolder',
   }).withActions(
-    // raw action
-    {
-      type: 'Action.Submit',
-      title: 'Simple form test',
-      data: {
-        msteams: {
-          type: 'task/fetch',
-        },
-        opendialogtype: 'simple_form',
-      },
-    },
-    // Special type of action to open a dialog
-    new TaskFetchAction({})
+    // OpenDialogData sets msteams.type = "task/fetch" and adds dialog_id for routing
+    new SubmitAction()
+      .withTitle('Simple form test')
+      .withData(new OpenDialogData('simple_form')),
+    new SubmitAction()
       .withTitle('Webpage Dialog')
-      // This data will be passed back in an event so we can
-      // handle what to show in the dialog
-      .withValue(new TaskFetchData({ opendialogtype: 'webpage_dialog' })),
-    new TaskFetchAction({})
+      .withData(new OpenDialogData('webpage_dialog')),
+    new SubmitAction()
       .withTitle('Multi-step Form')
-      .withValue(new TaskFetchData({ opendialogtype: 'multi_step_form' })),
-    new TaskFetchAction({})
-      .withTitle('Mixed Example')
-      .withValue(new TaskFetchData({ opendialogtype: 'mixed_example' }))
+      .withData(new OpenDialogData('multi_step_form'))
   );
 
-  // Send the card as an attachment
   await send(new MessageActivity('Enter this form').addCard('adaptive', card));
 });
 ```
 
 <!-- dialog-open-intro -->
 
-Once an action is executed to open a dialog, the Teams client will send an event to the agent to request what the content of the dialog should be. Here is how to handle this event:
+When a user clicks the button, Teams sends a `task/fetch` invoke to your app. Register a handler using `dialog.open.<dialog_id>` to handle a specific dialog, or `dialog.open` for a catch-all:
 
 <!-- dialog-open-code -->
 
@@ -67,10 +52,10 @@ import { App } from '@microsoft/teams.apps';
 import { AdaptiveCard, IAdaptiveCard } from '@microsoft/teams.cards';
 // ...
 
-app.on('dialog.open', async ({ activity }) => {
+// Handle a specific dialog by ID — no if-else needed
+app.on('dialog.open.simple_form', async ({ activity }) => {
   const card: IAdaptiveCard = new AdaptiveCard()...
 
-  // Return an object with the task value that renders a card
   return {
     task: {
       type: 'continue',
@@ -80,17 +65,17 @@ app.on('dialog.open', async ({ activity }) => {
       },
     },
   };
-}
+});
 ```
 
 <!-- rendering-card-code -->
 
 ```typescript
 import { cardAttachment } from '@microsoft/teams.api';
-import { AdaptiveCard, TextInput, SubmitAction } from '@microsoft/teams.cards';
+import { AdaptiveCard, TextInput, SubmitAction, SubmitData } from '@microsoft/teams.cards';
 // ...
 
-if (dialogType === 'simple_form') {
+app.on('dialog.open.simple_form', async () => {
   const dialogCard = new AdaptiveCard(
     {
       type: 'TextBlock',
@@ -104,13 +89,11 @@ if (dialogType === 'simple_form') {
       .withId('name')
       .withPlaceholder('Enter your name')
   )
-    // Inside the dialog, the card actions for submitting the card must be
-    // of type Action.Submit
+    // Use SubmitData to set the "action" field, which routes to dialog.submit.<action>
     .withActions(
-      new SubmitAction().withTitle('Submit').withData({ submissiondialogtype: 'simple_form' })
+      new SubmitAction().withTitle('Submit').withData(new SubmitData('simple_form'))
     );
 
-  // Return an object with the task value that renders a card
   return {
     task: {
       type: 'continue',
@@ -120,7 +103,7 @@ if (dialogType === 'simple_form') {
       },
     },
   };
-}
+});
 ```
 
 <!-- rendering-webpage-code -->
@@ -129,21 +112,21 @@ if (dialogType === 'simple_form') {
 import { App } from '@microsoft/teams.apps';
 // ...
 
-return {
-  task: {
-    type: 'continue',
-    value: {
-      title: 'Webpage Dialog',
-      // Here we are using a webpage that is hosted in the same
-      // server as the agent. This server needs to be publicly accessible,
-      // needs to set up teams.js client library (https://www.npmjs.com/package/@microsoft/teams-js)
-      // and needs to be registered in the manifest.
-      url: `${process.env['BOT_ENDPOINT']}/tabs/dialog-form`,
-      width: 1000,
-      height: 800,
+app.on('dialog.open.webpage_dialog', async () => {
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: 'Webpage Dialog',
+        // The webpage must be publicly accessible, use the teams-js client library,
+        // and be registered in validDomains in the manifest.
+        url: `${process.env['BOT_ENDPOINT']}/tabs/dialog-form`,
+        width: 1000,
+        height: 800,
+      },
     },
-  },
-};
+  };
+});
 ```
 
 <!-- embedded-web-content -->

--- a/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/creating-dialogs/typescript.incl.md
@@ -42,7 +42,11 @@ app.on('message', async ({ send }) => {
 
 <!-- dialog-open-intro -->
 
-When a user clicks the button, Teams sends a `task/fetch` invoke to your app. Register a handler using `dialog.open.<dialog_id>` to handle a specific dialog, or `dialog.open` for a catch-all:
+When a user clicks the button, Teams sends a `task/fetch` invoke to your app. Register a handler using `dialog.open.<dialog_id>` to handle a specific dialog, or `dialog.open` for a catch-all.
+
+:::tip
+Use sub-routes like `dialog.open.simple_form` to handle specific dialogs directly, instead of a single catch-all handler with if-else logic. This keeps each handler focused and avoids routing boilerplate.
+:::
 
 <!-- dialog-open-code -->
 

--- a/teams.md/src/components/include/in-depth-guides/dialogs/handling-dialog-submissions/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/handling-dialog-submissions/python.incl.md
@@ -1,48 +1,39 @@
 <!-- event-intro -->
 
-Dialogs have a specific `dialog_submit` event to handle submissions. When a user submits a form inside a dialog, the app is notified via this event, which is then handled to process the submission values, and can either send a response or proceed to more steps in the dialogs (see [Multi-step Dialogs](./handling-multi-step-forms)).
+When a user submits a form inside a dialog, your app receives a `dialog_submit` event. Use `@app.on_dialog_submit("action")` to handle a specific submission (where `action` matches the value passed via `SubmitData`), or `@app.on_dialog_submit()` for a catch-all. You can either send a response or proceed to more steps in the dialog (see [Multi-step Dialogs](./handling-multi-step-forms)).
 
 <!-- adaptive-card-example -->
 
 ```python
-from typing import Optional, Any
 from microsoft_teams.api import TaskSubmitInvokeActivity, TaskModuleResponse, TaskModuleMessageResponse
 from microsoft_teams.apps import ActivityContext
 # ...
 
-@app.on_dialog_submit
-async def handle_dialog_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
-    """Handle dialog submit events for all dialog types."""
-    data: Optional[Any] = ctx.activity.value.data
-    dialog_type = data.get("submissiondialogtype") if data else None
-
-    if dialog_type == "simple_form":
-        name = data.get("name") if data else None
-        await ctx.send(f"Hi {name}, thanks for submitting the form!")
-        return TaskModuleResponse(task=TaskModuleMessageResponse(value="Form was submitted"))
+# The "action" field in SubmitData("simple_form") routes here
+@app.on_dialog_submit("simple_form")
+async def handle_simple_form_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
+    data = ctx.activity.value.data
+    name = data.get("name")
+    await ctx.send(f"Hi {name}, thanks for submitting the form!")
+    return TaskModuleResponse(task=TaskModuleMessageResponse(value="Form was submitted"))
 ```
 
 <!-- webpage-example -->
 
 ```python
-from typing import Optional, Any
-from microsoft_teams.api import TaskSubmitInvokeActivity, InvokeResponse, TaskModuleResponse, TaskModuleMessageResponse
+from microsoft_teams.api import TaskSubmitInvokeActivity, TaskModuleResponse, TaskModuleMessageResponse
 from microsoft_teams.apps import ActivityContext
 # ...
 
-@app.on_dialog_submit
-async def handle_dialog_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
-    """Handle dialog submit events for all dialog types."""
-    data: Optional[Any] = ctx.activity.value.data
-    dialog_type = data.get("submissiondialogtype") if data else None
-
-    if dialog_type == "webpage_dialog":
-        name = data.get("name") if data else None
-        email = data.get("email") if data else None
-        await ctx.send(f"Hi {name}, thanks for submitting the form! We got that your email is {email}")
-        return InvokeResponse(
-            body=TaskModuleResponse(task=TaskModuleMessageResponse(value="Form submitted successfully"))
-        )
+# Webpage submissions route the same way — the webpage must include
+# the "action" field in the data passed to microsoftTeams.dialog.url.submit()
+@app.on_dialog_submit("webpage_dialog")
+async def handle_webpage_dialog_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
+    data = ctx.activity.value.data
+    name = data.get("name")
+    email = data.get("email")
+    await ctx.send(f"Hi {name}, thanks for submitting the form! We got that your email is {email}")
+    return TaskModuleResponse(task=TaskModuleMessageResponse(value="Form submitted successfully"))
 ```
 
 <!-- complete-example -->

--- a/teams.md/src/components/include/in-depth-guides/dialogs/handling-dialog-submissions/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/handling-dialog-submissions/typescript.incl.md
@@ -1,6 +1,6 @@
 <!-- event-intro -->
 
-Dialogs have a specific `dialog.submit` event to handle submissions. When a user submits a form inside a dialog, the app is notified via this event, which is then handled to process the submission values, and can either send a response or proceed to more steps in the dialogs (see [Multi-step Dialogs](./handling-multi-step-forms)).
+When a user submits a form inside a dialog, your app receives a `dialog.submit` event. Use `dialog.submit.<action>` to handle a specific submission (where `action` matches the value passed via `SubmitData`), or `dialog.submit` for a catch-all. You can either send a response or proceed to more steps in the dialog (see [Multi-step Dialogs](./handling-multi-step-forms)).
 
 <!-- adaptive-card-example -->
 
@@ -8,21 +8,17 @@ Dialogs have a specific `dialog.submit` event to handle submissions. When a user
 import { App } from '@microsoft/teams.apps';
 // ...
 
-app.on('dialog.submit', async ({ activity, send, next }) => {
-  const dialogType = activity.value.data?.submissiondialogtype;
-
-  if (dialogType === 'simple_form') {
-    // This is data from the form that was submitted
-    const name = activity.value.data.name;
-    await send(`Hi ${name}, thanks for submitting the form!`);
-    return {
-      task: {
-        type: 'message',
-        // This appears as a final message in the dialog
-        value: 'Form was submitted',
-      },
-    };
-  }
+// The "action" field in SubmitData('simple_form') routes here
+app.on('dialog.submit.simple_form', async ({ activity, send }) => {
+  const name = activity.value.data.name;
+  await send(`Hi ${name}, thanks for submitting the form!`);
+  return {
+    task: {
+      type: 'message',
+      // This appears as a final message in the dialog
+      value: 'Form was submitted',
+    },
+  };
 });
 ```
 
@@ -32,21 +28,16 @@ app.on('dialog.submit', async ({ activity, send, next }) => {
 import { App } from '@microsoft/teams.apps';
 // ...
 
-// The submission from a webpage happens via the microsoftTeams.tasks.submitTask(formData)
-// call.
-app.on('dialog.submit', async ({ activity, send, next }) => {
-  const dialogType = activity.value.data.submissiondialogtype;
-
-  if (dialogType === 'webpage_dialog') {
-    // This is data from the form that was submitted
-    const name = activity.value.data.name;
-    const email = activity.value.data.email;
-    await send(`Hi ${name}, thanks for submitting the form! We got that your email is ${email}`);
-    // You can also return a blank response
-    return {
-      status: 200,
-    };
-  }
+// Webpage submissions route the same way — the webpage must include
+// the "action" field in the data passed to microsoftTeams.tasks.submitTask()
+app.on('dialog.submit.webpage_dialog', async ({ activity, send }) => {
+  const name = activity.value.data.name;
+  const email = activity.value.data.email;
+  await send(`Hi ${name}, thanks for submitting the form! We got that your email is ${email}`);
+  // Return status 200 to close the dialog without showing a message
+  return {
+    status: 200,
+  };
 });
 ```
 

--- a/teams.md/src/components/include/in-depth-guides/dialogs/handling-multi-step-forms/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/handling-multi-step-forms/python.incl.md
@@ -1,102 +1,94 @@
 <!-- initial-setup -->
 
-Start off by sending an initial card in the `dialog_open` event.
+Start by returning the first step's card from the `dialog_open` handler.
 
 <!-- initial-card -->
 
 ```python
-dialog_card = AdaptiveCard.model_validate(
-            {
-                "type": "AdaptiveCard",
-                "version": "1.4",
-                "body": [
-                    {"type": "TextBlock", "text": "This is a multi-step form", "size": "Large", "weight": "Bolder"},
-                    {
-                        "type": "Input.Text",
-                        "id": "name",
-                        "label": "Name",
-                        "placeholder": "Enter your name",
-                        "isRequired": True,
-                    },
-                ],
-                "actions": [
-                    {
-                        "type": "Action.Submit",
-                        "title": "Submit",
-                        "data": {"submissiondialogtype": "webpage_dialog_step_1"},
-                    }
-                ],
-            }
+from microsoft_teams.api import (
+    TaskFetchInvokeActivity, TaskModuleResponse,
+    TaskModuleContinueResponse, CardTaskModuleTaskInfo,
+    AdaptiveCardAttachment, card_attachment,
+)
+from microsoft_teams.apps import ActivityContext
+from microsoft_teams.cards import AdaptiveCard, TextBlock, TextInput, SubmitAction, SubmitData
+# ...
+
+@app.on_dialog_open("multi_step_form")
+async def handle_multi_step_open(ctx: ActivityContext[TaskFetchInvokeActivity]):
+    dialog_card = AdaptiveCard(
+        schema="http://adaptivecards.io/schemas/adaptive-card.json",
+        body=[
+            TextBlock(text="This is a multi-step form", size="Large", weight="Bolder"),
+            TextInput().with_label("Name").with_is_required(True).with_id("name").with_placeholder("Enter your name"),
+        ],
+        # Route to a step-specific submit handler
+        actions=[
+            SubmitAction().with_title("Submit").with_data(SubmitData("multi_step_1"))
+        ]
+    )
+
+    return TaskModuleResponse(
+        task=TaskModuleContinueResponse(
+            value=CardTaskModuleTaskInfo(
+                title="Multi-step Form Dialog",
+                card=card_attachment(AdaptiveCardAttachment(content=dialog_card)),
+            )
         )
+    )
 ```
 
 <!-- submission-handler -->
 
-Then in the submission handler, you can choose to `continue` the dialog with a different card.
+Then in the submission handler, return `type: "continue"` with the next card to keep the dialog open. Pass state forward using `SubmitData`'s extra data parameter.
 
 ```python
+from microsoft_teams.api import (
+    TaskSubmitInvokeActivity, TaskModuleResponse, TaskModuleMessageResponse,
+    TaskModuleContinueResponse, CardTaskModuleTaskInfo,
+    AdaptiveCardAttachment, card_attachment,
+)
+from microsoft_teams.apps import ActivityContext
+from microsoft_teams.cards import AdaptiveCard, TextBlock, TextInput, SubmitAction, SubmitData
+# ...
 
-@app.on_dialog_submit
-async def handle_dialog_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
-    """Handle dialog submit events for all dialog types."""
-    data: Optional[Any] = ctx.activity.value.data
-    dialog_type = data.get("submissiondialogtype") if data else None
+# Step 1 submit — show step 2
+@app.on_dialog_submit("multi_step_1")
+async def handle_multi_step_1_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
+    data = ctx.activity.value.data
+    name = data.get("name")
 
-    if dialog_type == "webpage_dialog":
-        name = data.get("name") if data else None
-        email = data.get("email") if data else None
-        await ctx.send(f"Hi {name}, thanks for submitting the form! We got that your email is {email}")
-        return InvokeResponse(
-            body=TaskModuleResponse(task=TaskModuleMessageResponse(value="Form submitted successfully"))
-        )
+    next_step_card = AdaptiveCard(
+        schema="http://adaptivecards.io/schemas/adaptive-card.json",
+        body=[
+            TextBlock(text="Email", size="Large", weight="Bolder"),
+            TextInput().with_label("Email").with_is_required(True).with_id("email").with_placeholder("Enter your email"),
+        ],
+        actions=[
+            # Carry forward data from step 1 via extra data
+            SubmitAction().with_title("Submit").with_data(
+                SubmitData("multi_step_2", {"name": name})
+            )
+        ]
+    )
 
-    elif dialog_type == "webpage_dialog_step_1":
-        name = data.get("name") if data else None
-        next_step_card = AdaptiveCard.model_validate(
-            {
-                "type": "AdaptiveCard",
-                "version": "1.4",
-                "body": [
-                    {"type": "TextBlock", "text": "Email", "size": "Large", "weight": "Bolder"},
-                    {
-                        "type": "Input.Text",
-                        "id": "email",
-                        "label": "Email",
-                        "placeholder": "Enter your email",
-                        "isRequired": True,
-                    },
-                ],
-                "actions": [
-                    {
-                        "type": "Action.Submit",
-                        "title": "Submit",
-                        "data": {"submissiondialogtype": "webpage_dialog_step_2", "name": name},
-                    }
-                ],
-            }
-        )
-
-        return InvokeResponse(
-            body=TaskModuleResponse(
-                task=TaskModuleContinueResponse(
-                    value=CardTaskModuleTaskInfo(
-                        title=f"Thanks {name} - Get Email",
-                        card=card_attachment(AdaptiveCardAttachment(content=next_step_card)),
-                    )
-                )
+    return TaskModuleResponse(
+        task=TaskModuleContinueResponse(
+            value=CardTaskModuleTaskInfo(
+                title=f"Thanks {name} - Get Email",
+                card=card_attachment(AdaptiveCardAttachment(content=next_step_card)),
             )
         )
+    )
 
-    elif dialog_type == "webpage_dialog_step_2":
-        name = data.get("name") if data else None
-        email = data.get("email") if data else None
-        await ctx.send(f"Hi {name}, thanks for submitting the form! We got that your email is {email}")
-        return InvokeResponse(
-            body=TaskModuleResponse(task=TaskModuleMessageResponse(value="Multi-step form completed successfully"))
-        )
-
-    return TaskModuleResponse(task=TaskModuleMessageResponse(value="Unknown submission type"))
-
+# Step 2 submit — final step, close the dialog
+@app.on_dialog_submit("multi_step_2")
+async def handle_multi_step_2_submit(ctx: ActivityContext[TaskSubmitInvokeActivity]):
+    data = ctx.activity.value.data
+    name = data.get("name")
+    email = data.get("email")
+    await ctx.send(f"Hi {name}, thanks for submitting the form! We got that your email is {email}")
+    return TaskModuleResponse(task=TaskModuleMessageResponse(value="Multi-step form completed successfully"))
 ```
 
 <!-- complete-example -->

--- a/teams.md/src/components/include/in-depth-guides/dialogs/handling-multi-step-forms/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/dialogs/handling-multi-step-forms/typescript.incl.md
@@ -1,104 +1,95 @@
 <!-- initial-setup -->
 
-Start off by sending an initial card in the `dialog.open` event.
+Start by returning the first step's card from the `dialog.open` handler.
 
 <!-- initial-card -->
 
 ```typescript
 import { cardAttachment } from '@microsoft/teams.api';
-import { AdaptiveCard, TextInput, SubmitAction } from '@microsoft/teams.cards';
+import { AdaptiveCard, TextInput, SubmitAction, SubmitData } from '@microsoft/teams.cards';
 // ...
 
-const dialogCard = new AdaptiveCard(
-  {
-    type: 'TextBlock',
-    text: 'This is a multi-step form',
-    size: 'Large',
-    weight: 'Bolder',
-  },
-  new TextInput()
-    .withLabel('Name')
-    .withIsRequired()
-    .withId('name')
-    .withPlaceholder('Enter your name')
-)
-  // Inside the dialog, the card actions for submitting the card must be
-  // of type Action.Submit
-  .withActions(
+app.on('dialog.open.multi_step_form', async () => {
+  const dialogCard = new AdaptiveCard(
+    {
+      type: 'TextBlock',
+      text: 'This is a multi-step form',
+      size: 'Large',
+      weight: 'Bolder',
+    },
+    new TextInput()
+      .withLabel('Name')
+      .withIsRequired()
+      .withId('name')
+      .withPlaceholder('Enter your name')
+  ).withActions(
+    // Route to a step-specific submit handler
     new SubmitAction()
       .withTitle('Submit')
-      .withData({ submissiondialogtype: 'webpage_dialog_step_1' })
+      .withData(new SubmitData('multi_step_1'))
   );
 
-// Return an object with the task value that renders a card
-return {
-  task: {
-    type: 'continue',
-    value: {
-      title: 'Multi-step Form Dialog',
-      card: cardAttachment('adaptive', dialogCard),
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: 'Multi-step Form Dialog',
+        card: cardAttachment('adaptive', dialogCard),
+      },
     },
-  },
-};
+  };
+});
 ```
 
 <!-- submission-handler -->
 
-Then in the submission handler, you can choose to `continue` the dialog with a different card.
+Then in the submission handler, return `type: 'continue'` with the next card to keep the dialog open. Pass state forward using `SubmitData`'s extra data parameter.
 
 ```typescript
 import { cardAttachment } from '@microsoft/teams.api';
 import { App } from '@microsoft/teams.apps';
-import { AdaptiveCard, TextInput, SubmitAction } from '@microsoft/teams.cards';
+import { AdaptiveCard, TextInput, SubmitAction, SubmitData } from '@microsoft/teams.cards';
 // ...
 
-app.on('dialog.submit', async ({ activity, send, next }) => {
-  const dialogType = activity.value.data.submissiondialogtype;
+// Step 1 submit — show step 2
+app.on('dialog.submit.multi_step_1', async ({ activity }) => {
+  const name = activity.value.data.name;
+  const nextStepCard = new AdaptiveCard(
+    {
+      type: 'TextBlock',
+      text: 'Email',
+      size: 'Large',
+      weight: 'Bolder',
+    },
+    new TextInput()
+      .withLabel('Email')
+      .withIsRequired()
+      .withId('email')
+      .withPlaceholder('Enter your email')
+  ).withActions(
+    new SubmitAction().withTitle('Submit').withData(
+      // Carry forward data from step 1 via extra data
+      new SubmitData('multi_step_2', { name })
+    )
+  );
 
-  if (dialogType === 'webpage_dialog_step_1') {
-    // This is data from the form that was submitted
-    const name = activity.value.data.name;
-    const nextStepCard = new AdaptiveCard(
-      {
-        type: 'TextBlock',
-        text: 'Email',
-        size: 'Large',
-        weight: 'Bolder',
+  return {
+    task: {
+      type: 'continue',
+      value: {
+        title: `Thanks ${name} - Get Email`,
+        card: cardAttachment('adaptive', nextStepCard),
       },
-      new TextInput()
-        .withLabel('Email')
-        .withIsRequired()
-        .withId('email')
-        .withPlaceholder('Enter your email')
-    ).withActions(
-      new SubmitAction().withTitle('Submit').withData({
-        // This same handler will get called, so we need to identify the step
-        // in the returned data
-        submissiondialogtype: 'webpage_dialog_step_2',
-        // Carry forward data from previous step
-        name,
-      })
-    );
-    return {
-      task: {
-        // This indicates that the dialog flow should continue
-        type: 'continue',
-        value: {
-          // Here we customize the title based on the previous response
-          title: `Thanks ${name} - Get Email`,
-          card: cardAttachment('adaptive', nextStepCard),
-        },
-      },
-    };
-  } else if (dialogType === 'webpage_dialog_step_2') {
-    const name = activity.value.data.name;
-    const email = activity.value.data.email;
-    await send(`Hi ${name}, thanks for submitting the form! We got that your email is ${email}`);
-    // You can also return a blank response
-    return {
-      status: 200,
-    };
-  }
+    },
+  };
+});
+
+// Step 2 submit — final step, close the dialog
+app.on('dialog.submit.multi_step_2', async ({ activity, send }) => {
+  const name = activity.value.data.name;
+  const email = activity.value.data.email;
+  await send(`Hi ${name}, thanks for submitting the form! We got that your email is ${email}`);
+  return { status: 200 };
 });
 ```
 

--- a/teams.md/src/pages/templates/in-depth-guides/dialogs/creating-dialogs.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/dialogs/creating-dialogs.mdx
@@ -20,10 +20,6 @@ If you're not familiar with how to build Adaptive Cards, check out [the cards gu
 
 <LanguageInclude section="dialog-open-intro" />
 
-:::tip
-Register handlers for specific dialog IDs instead of a single catch-all with if-else logic. This keeps each handler focused and avoids routing boilerplate.
-:::
-
 <LanguageInclude section="dialog-open-code" />
 
 ### Rendering A Card

--- a/teams.md/src/pages/templates/in-depth-guides/dialogs/creating-dialogs.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/dialogs/creating-dialogs.mdx
@@ -20,6 +20,10 @@ If you're not familiar with how to build Adaptive Cards, check out [the cards gu
 
 <LanguageInclude section="dialog-open-intro" />
 
+:::tip
+Register handlers for specific dialog IDs instead of a single catch-all with if-else logic. This keeps each handler focused and avoids routing boilerplate.
+:::
+
 <LanguageInclude section="dialog-open-code" />
 
 ### Rendering A Card


### PR DESCRIPTION
## Summary
- replaced deprecated `TaskFetchAction`/`TaskFetchData` with `OpenDialogData` in TS and Python dialog docs
- switched from single catch-all handlers with if-else routing to per-dialog sub-routes (`dialog.open.simple_form` / `@app.on_dialog_open("simple_form")`)
- updated submit handling to use `SubmitData` for action-based routing instead of manual `submissiondialogtype` fields
- simplified Python examples by dropping unnecessary `InvokeResponse(body=...)` wrapping

## Test plan
- [x] `npm run generate:docs` in `teams.md/` generates cleanly
- [x] review TS dialog pages: creating-dialogs, handling-dialog-submissions, handling-multi-step-forms
- [x] review Python dialog pages: same three
- [x] code examples match actual SDK exports (`OpenDialogData`, `SubmitData` from `@microsoft/teams.cards` / `microsoft_teams.cards`)