### PR TITLE
ci: migrate pipeline to 1ES Official template

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -28,7 +28,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     pool:
       name: 1ES-Teams-Windows-2022-DomoreexpGithub


### PR DESCRIPTION
## Summary
- switches from `1ES.Unofficial.PipelineTemplate` to `1ES.Official.PipelineTemplate` to satisfy the org-level S360 drift management policy
- same repo (`1ESPipelineTemplates/1ESPipelineTemplates`), just the template name changes

## Test plan
- [x] internal release run passed on `fix/migrate-to-m365pt` branch