### PR TITLE
bump main to 3.0-beta

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teams.cli",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-beta.0",
   "description": "CLI for scaffolding Teams applications",
   "type": "module",
   "main": "dist/index.js",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1-beta.{height}",
+  "version": "3.0-beta.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/preview$"


### PR DESCRIPTION
## Summary
- `version.json`: `2.1-beta` → `3.0-beta` so future main builds produce `3.0.0-beta.N`
- `packages/cli/package.json`: `3.0.0-alpha.0` → `3.0.0-beta.0` to match convention