### PR TITLE
docs: change blog title, add CLI/skill intro links

### DIFF
--- a/teams.md/blog/2026-04-28-teams-cli-preview/index.md
+++ b/teams.md/blog/2026-04-28-teams-cli-preview/index.md
@@ -21,19 +21,19 @@ description: The Teams CLI v3 Preview takes the pain out of getting your agent i
 
 You want to build a Teams agent. Maybe it answers customer questions from a knowledge base. Maybe it runs your team's standups. The interesting part is the logic, the thing the agent actually *does*.
 
-But before you write a single line of that logic, you have to register it with Teams. And that's where the day goes sideways.
+But before you write a single line of that logic, you have to register it with Teams. That takes a number of steps. That's why we have updated the [Teams CLI](/cli/) in this latest iteration, along with a [`teams-dev` agent skill](/developer-tools/agent-skills) that lets your coding agent handle it too.
 
 <!-- truncate -->
 
-## The Setup Tax
+## How It Works Today
+
+Getting an agent into Teams requires configuring an identity, generating credentials, authoring a manifest, and wiring it all together. The process spans multiple surfaces:
 
 <div style={{textAlign: 'center'}}>
 <img src={require('./setup-steps.png').default} alt="The 9 steps required to register a Teams agent today" style={{maxHeight: '400px'}} />
 </div>
 
-That's a lot of steps across the Azure portal, Developer Portal, and your editor before your agent handles its first message. Each step is individually straightforward. The problem is the compound cost: too many portals, too many copy-pastes, and too many concepts between you and a working agent.
-
-At best, this takes 30 minutes. At worst, something doesn't work and you're left retracing every step to find the one that went wrong.
+These steps span the Azure portal, Developer Portal, and your editor. Each one is straightforward on its own, but the context-switching between them adds up.
 
 ## The Teams CLI Preview
 

--- a/teams.md/blog/2026-04-28-teams-cli-preview/index.md
+++ b/teams.md/blog/2026-04-28-teams-cli-preview/index.md
@@ -1,6 +1,6 @@
 ---
 slug: teams-cli-preview
-title: "Teams CLI v3 Preview: Skip the Setup, Ship the Agent"
+title: "From Prompt to Production: Teams Agent Setup, Simplified"
 date: 2026-04-28
 authors:
   - name: Aamir Jawaid
@@ -16,24 +16,22 @@ authors:
     url: https://github.com/umangsehgal
     image_url: https://github.com/umangsehgal.png
 tags: [teams-sdk, cli, preview, announcement, skills]
-description: The Teams CLI v3 Preview takes the pain out of getting your agent into Teams. One command to register, an installation link to deploy, and an agent skill to let your coding agent do it for you.
+description: Introducing the teams-dev agent skill and the Teams CLI v3 Preview for registering and building Teams agents.
 ---
 
 You want to build a Teams agent. Maybe it answers customer questions from a knowledge base. Maybe it runs your team's standups. The interesting part is the logic, the thing the agent actually *does*.
 
-But before you write a single line of that logic, you have to register it with Teams. That takes a number of steps. That's why we have updated the [Teams CLI](/cli/) in this latest iteration, along with a [`teams-dev` agent skill](/developer-tools/agent-skills) that lets your coding agent handle it too.
+But before you write a single line of that logic, you have to register it with Teams. That takes a number of steps.
 
 <!-- truncate -->
 
 ## How It Works Today
 
-Getting an agent into Teams requires configuring an identity, generating credentials, authoring a manifest, and wiring it all together. The process spans multiple surfaces:
+Getting an agent into Teams requires configuring an identity, generating credentials, authoring a manifest, and wiring it all together. These steps span the Azure portal, Developer Portal, and your editor. Each one is straightforward on its own, but the context-switching between them adds up.
 
 <div style={{textAlign: 'center'}}>
 <img src={require('./setup-steps.png').default} alt="The 9 steps required to register a Teams agent today" style={{maxHeight: '400px'}} />
 </div>
-
-These steps span the Azure portal, Developer Portal, and your editor. Each one is straightforward on its own, but the context-switching between them adds up.
 
 ## Let Your Coding Agent Handle It
 

--- a/teams.md/blog/2026-04-28-teams-cli-preview/index.md
+++ b/teams.md/blog/2026-04-28-teams-cli-preview/index.md
@@ -35,9 +35,21 @@ Getting an agent into Teams requires configuring an identity, generating credent
 
 These steps span the Azure portal, Developer Portal, and your editor. Each one is straightforward on its own, but the context-switching between them adds up.
 
-## The Teams CLI Preview
+## Let Your Coding Agent Handle It
 
-We updated our CLI (v3 preview) to make this simpler. Install it and log in:
+The [`teams-dev` agent skill](/developer-tools/agent-skills) works with AI coding agents like Copilot, Claude Code, and Cursor. Instead of learning the registration steps yourself, tell your coding agent:
+
+- *"Help me build a Teams agent that answers FAQs"*
+- *"Get my agent running in Teams"*
+- *"My agent isn't loading in Teams, can you help?"*
+
+![The teams-dev agent skill in action](./agent-skill.gif)
+
+The skill uses the CLI under the hood to handle the full infrastructure workflow, from login to a working agent in Teams, and troubleshooting when something breaks. Beyond infrastructure, it also helps your coding agent write application logic following best practices from the Teams SDK documentation.
+
+## Under the Hood: The Teams CLI
+
+For developers who want direct control, the skill is powered by the next iteration of our CLI. Install it and log in:
 
 ```bash
 npm install -g @microsoft/teams.cli@preview
@@ -64,21 +76,20 @@ Traditionally, getting an agent into Teams means building an app package, managi
 
 The CLI also includes a `teams app doctor` command that checks your agent's registration, credentials, endpoint, and manifest so when something breaks, you know exactly what to fix.
 
-## Let Your Coding Agent Handle It
-
-The CLI also ships with a [`teams-dev` agent skill](/developer-tools/agent-skills) for AI coding agents like Copilot, Claude Code, and Cursor. Instead of running commands yourself, tell your assistant:
-
-- *"Help me build a Teams agent that answers FAQs"*
-- *"Get my agent running in Teams"*
-- *"My agent isn't loading in Teams, can you help?"*
-
-![The teams-dev agent skill in action](./agent-skill.gif)
-
-The skill uses the CLI under the hood to handle the full infrastructure workflow, from login to a working agent in Teams, and troubleshooting when something breaks. Beyond infrastructure, it also helps your coding agent write application logic following best practices from the Teams SDK documentation.
-
 For CI pipelines and custom tooling, every CLI command supports `--json` output for programmatic consumption.
 
 ## Get Started
+
+Install the `teams-dev` agent skill (Copilot, Claude Code, Cursor):
+
+```
+/plugin marketplace add microsoft/teams-sdk
+/plugin install teams-sdk@teams-skills
+```
+
+See the [agent skills guide](/developer-tools/agent-skills) for VS Code and other editors.
+
+Install the CLI:
 
 ```bash
 npm install -g @microsoft/teams.cli@preview


### PR DESCRIPTION
## Summary
- Renamed "The Setup Tax" → "How It Works Today"
- Softened opening, removed time estimates and sharp criticism
- Added intro linking to Teams CLI and teams-dev agent skill docs

## Test plan
- [ ] Verify blog renders correctly locally with `npm start` in teams.md
- [ ] Check links to `/cli/` and `/developer-tools/agent-skills` resolve