### PR TITLE
feat(cli): add Client-Source header to TDP API requests

### DIFF
--- a/packages/cli/src/utils/http.ts
+++ b/packages/cli/src/utils/http.ts
@@ -7,5 +7,6 @@ const USER_AGENT = `teams-cli/${version}`;
 export function apiFetch(url: string, init?: RequestInit): Promise<Response> {
   const headers = new Headers(init?.headers);
   headers.set('User-Agent', USER_AGENT);
+  headers.set('Client-Source', USER_AGENT);
   return fetch(url, { ...init, headers });
 }


### PR DESCRIPTION
## Summary
- Adds `Client-Source` header (set to `teams-cli/<version>`) alongside the existing `User-Agent` on all `apiFetch` calls

## Test plan
- Build the CLI and verify outgoing TDP requests include the `Client-Source` header