### PR TITLE
Add GitHub issue templates directed to language-specific repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,12 +54,17 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: dropdown
     id: tested-languages
     attributes:
       label: Languages Affected
-      description: Which languages did you see this bug in? (TypeScript, .NET/C#, Python)
-      placeholder: e.g., TypeScript and Python
+      description: Which languages did you see this bug in?
+      multiple: true
+      options:
+        - TypeScript
+        - C#
+        - Python
+        - All
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: Report a bug or issue across all three languages of the Teams SDK
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! If you have only experienced the issue in one language, please use the language-specific repo to file your issue. Otherwise please fill out the information below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Install package '...'
+        2. Run code '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: SDK Version
+      description: Which version of the Teams SDK are you using?
+      placeholder: e.g., 1.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: tested-languages
+    attributes:
+      label: Languages Affected
+      description: Which languages did you see this bug in? (TypeScript, .NET/C#, Python)
+      placeholder: e.g., TypeScript and Python
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here (logs, screenshots, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,10 +3,10 @@ contact_links:
   - name: File an issue for TypeScript SDK
     url: https://github.com/microsoft/teams.ts/issues/new/choose
     about: Report a bug or issue specific to the TypeScript SDK
-  - name: File an Issue for .NET SDK
-    url: https://github.com/microsoft/teams.net/issues/new/choose
+  - name: File an issue for .NET SDK
+    url: https://github.com/microsoft/teams.net/issues
     about: Report a bug or issue specific to the .NET/C# SDK
-  - name: File an Issue for Python SDK
+  - name: File an issue for Python SDK
     url: https://github.com/microsoft/teams.py/issues/new/choose
     about: Report a bug or issue specific to the Python SDK
   - name: General Question or Feature Request

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,6 +12,3 @@ contact_links:
   - name: General Question or Feature Request
     url: https://github.com/microsoft/teams-sdk/discussions
     about: Please use GitHub Discussions for questions and feature requests
-
-
-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,10 +4,10 @@ contact_links:
     url: https://github.com/microsoft/teams.ts/issues/new/choose
     about: Report a bug or issue specific to the TypeScript SDK
   - name: File an Issue for .NET SDK
-    url: https://github.com/microsoft/teams.net/issues
+    url: https://github.com/microsoft/teams.net/issues/new/choose
     about: Report a bug or issue specific to the .NET/C# SDK
   - name: File an Issue for Python SDK
-    url: https://github.com/microsoft/teams.py/issues
+    url: https://github.com/microsoft/teams.py/issues/new/choose
     about: Report a bug or issue specific to the Python SDK
   - name: General Question or Feature Request
     url: https://github.com/microsoft/teams-sdk/discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: File an issue for TypeScript SDK
+    url: https://github.com/microsoft/teams.ts/issues/new/choose
+    about: Report a bug or issue specific to the TypeScript SDK
+  - name: File an Issue for .NET SDK
+    url: https://github.com/microsoft/teams.net/issues
+    about: Report a bug or issue specific to the .NET/C# SDK
+  - name: File an Issue for Python SDK
+    url: https://github.com/microsoft/teams.py/issues
+    about: Report a bug or issue specific to the Python SDK
+  - name: General Question or Feature Request
+    url: https://github.com/microsoft/teams-sdk/discussions
+    about: Please use GitHub Discussions for questions and feature requests
+
+
+


### PR DESCRIPTION
Adding GitHub issues template to the issues page to better triage developer issues to each language-specific repo as well as add more context/repro steps/versioning information to