### PR TITLE
docs: Python SDK is now GA

### DIFF
--- a/teams.md/src/components/include/getting-started/python.incl.md
+++ b/teams.md/src/components/include/getting-started/python.incl.md
@@ -1,7 +1,7 @@
 <!-- warning -->
 
 :::tip
-Teams SDK Python is now GA! 🎉
+Teams SDK for Python is now generally available (GA)! 🎉
 :::
 
 <!-- language-name -->

--- a/teams.md/src/components/include/getting-started/python.incl.md
+++ b/teams.md/src/components/include/getting-started/python.incl.md
@@ -1,7 +1,7 @@
 <!-- warning -->
 
-:::warning
-Our Python SDK is currently in Public Preview. We're going to do our best to not ship breaking changes, but breaking changes may happen from time to time
+:::tip
+Teams SDK Python is now GA! 🎉
 :::
 
 <!-- language-name -->


### PR DESCRIPTION
## Summary
- Updated the Python SDK getting-started banner from a "Public Preview" warning to a GA announcement
- Changed `:::warning` → `:::tip` with "Teams SDK Python is now GA! 🎉"

## Test plan
- [ ] Verify the docs site renders the new `:::tip` banner correctly on the Python getting-started page
- [ ] Confirm no other Python-specific preview mentions were affected