### PR TITLE
docs: Python GA site banner, remove inline tip

### DIFF
--- a/teams.md/docusaurus.config.ts
+++ b/teams.md/docusaurus.config.ts
@@ -268,8 +268,8 @@ const config: Config = {
             ],
         },
         announcementBar: {
-            id: 'teams-cli-preview',
-            content: `The new <a href="${baseUrl}cli/">Teams CLI</a> is in Preview — try it out and share feedback.`,
+            id: 'python-sdk-ga',
+            content: `Teams SDK for Python is now GA! 🎉`,
             isCloseable: true,
             backgroundColor: '#515cc6',
             textColor: '#fff'

--- a/teams.md/src/components/include/getting-started/python.incl.md
+++ b/teams.md/src/components/include/getting-started/python.incl.md
@@ -1,5 +1,7 @@
 <!-- warning -->
 
+N/A
+
 <!-- language-name -->
 
 Python

--- a/teams.md/src/components/include/getting-started/python.incl.md
+++ b/teams.md/src/components/include/getting-started/python.incl.md
@@ -1,9 +1,5 @@
 <!-- warning -->
 
-:::tip
-Teams SDK for Python is now generally available (GA)! 🎉
-:::
-
 <!-- language-name -->
 
 Python


### PR DESCRIPTION
## Summary
- Removed the inline `:::tip` GA banner from the Python getting-started page
- Updated the site-wide announcement bar to say "Teams SDK for Python is now GA! 🎉"

## Test plan
- [ ] Verify the announcement bar renders correctly on the docs site
- [ ] Confirm the Python getting-started page no longer has the inline tip