### PR TITLE
Docs: TS - note onStart hooks don't fire when self-managing the HTTP lifecycle

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/server/http-server/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/server/http-server/typescript.incl.md
@@ -48,6 +48,17 @@ await app.initialize();
 httpServer.listen(3978, () => console.log('Server ready on http://localhost:3978'));
 ```
 
+> **Note:** `app.initialize()` runs each plugin's `onInit` hook but not its `onStart` hook —
+> `onStart` only fires from `app.start()`. When you take over the HTTP lifecycle with a custom
+> adapter, plugins that do their setup in `onStart` won't run. If you're using such a plugin,
+> either call `app.start()` (and let it manage the server) or invoke that plugin's `onStart`
+> yourself after `app.initialize()`:
+>
+> ```ts
+> await app.initialize();
+> await myPlugin.onStart({ port: 3978 });
+> ```
+
 > See the full [Express adapter example](https://github.com/microsoft/teams.ts/tree/main/examples/http-adapters/express)
 
 <!-- custom-adapter -->


### PR DESCRIPTION
## Summary
- Adds a note to the TS "Self-Managing Your Server" doc clarifying that plugin `onStart` hooks do not fire when callers skip `app.start()` and run their own server lifecycle.
- Documents the workaround: invoke the plugin's `onStart` manually after `await app.initialize()`.

## Why
Surfaced by:
- https://github.com/microsoft/teams.ts/issues/512 - users adopting the `IHttpServerAdapter` pattern for non-Express frameworks (Fastify, Restify, etc.) skip `app.start()` and so silently lose any plugin setup that lives in `onStart`.
- https://github.com/microsoft/teams.ts/issues/544 - concrete repro: `DevToolsPlugin` registers its router inside `onStart`, so a self-managed `ExpressAdapter` setup leaves DevTools un-started until the user manually invokes `devToolsPlugin.onStart({ port })`.

The `IHttpServerAdapter` interface already supports this self-managed flow; this PR just makes the caveat explicit in the doc.

## Test plan
- [x] Verify the rendered doc page shows the new note in the right section (after the Express self-managed example, before the "See the full Express adapter example" link).
- [x] Sanity-check that the suggested `await myPlugin.onStart({ port: 3978 })` call shape matches the plugin lifecycle interface.