### PR TITLE
Share Teams app validation across create and update

### DIFF
--- a/packages/cli/src/apps/basic-info.ts
+++ b/packages/cli/src/apps/basic-info.ts
@@ -3,7 +3,12 @@ import pc from 'picocolors';
 import { createSpinner } from 'nanospinner';
 import type { AppDetails } from './types.js';
 import { updateAppDetails } from './api.js';
-import { validateAppMetadataField, type AppMetadataField } from './validation.js';
+import {
+  getAppMetadataFieldRule,
+  isAppMetadataField,
+  validateAppMetadataField,
+  type AppMetadataField,
+} from './validation.js';
 import { logger } from '../utils/logger.js';
 
 interface FieldConfig {
@@ -14,33 +19,32 @@ interface FieldConfig {
   validate?: (value: string) => string | true;
 }
 
-const FIELDS: FieldConfig[] = [
-  { key: 'shortName', label: 'Short name', maxLength: 30, required: true },
-  { key: 'longName', label: 'Long name', maxLength: 100, required: false },
-  { key: 'shortDescription', label: 'Short description', maxLength: 80, required: true },
-  { key: 'longDescription', label: 'Long description', maxLength: 4000, required: true },
-  { key: 'version', label: 'Version', required: true },
-  { key: 'developerName', label: 'Developer name', required: true },
-  { key: 'websiteUrl', label: 'Website URL', required: true },
-  { key: 'privacyUrl', label: 'Privacy URL', required: true },
-  { key: 'termsOfUseUrl', label: 'Terms of Use URL', required: true },
+const BASIC_INFO_FIELD_ORDER: AppMetadataField[] = [
+  'shortName',
+  'longName',
+  'shortDescription',
+  'longDescription',
+  'developerName',
+  'websiteUrl',
+  'privacyUrl',
+  'termsOfUseUrl',
 ];
 
-function isMetadataField(key: keyof AppDetails): key is AppMetadataField {
-  switch (key) {
-    case 'shortName':
-    case 'longName':
-    case 'shortDescription':
-    case 'longDescription':
-    case 'developerName':
-    case 'websiteUrl':
-    case 'privacyUrl':
-    case 'termsOfUseUrl':
-      return true;
-    default:
-      return false;
-  }
+function buildMetadataFieldConfig(field: AppMetadataField): FieldConfig {
+  const rule = getAppMetadataFieldRule(field);
+  return {
+    key: field,
+    label: rule.label,
+    maxLength: rule.maxLength,
+    required: rule.requiredIn.includes('manifest'),
+  };
 }
+
+const FIELDS: FieldConfig[] = [
+  ...BASIC_INFO_FIELD_ORDER.slice(0, 4).map(buildMetadataFieldConfig),
+  { key: 'version', label: 'Version', required: true },
+  ...BASIC_INFO_FIELD_ORDER.slice(4).map(buildMetadataFieldConfig),
+];
 
 function truncateValue(value: string | undefined | null, maxLength: number = 40): string {
   const str = value ?? '';
@@ -80,7 +84,7 @@ async function editField(
     message: `Enter new ${field.label.toLowerCase()}${maxLengthHint}:`,
     default: currentValue,
     validate: (value) => {
-      if (isMetadataField(field.key)) {
+      if (isAppMetadataField(field.key)) {
         return validateAppMetadataField(field.key, value, 'manifest') ?? true;
       }
 

--- a/packages/cli/src/apps/basic-info.ts
+++ b/packages/cli/src/apps/basic-info.ts
@@ -19,17 +19,6 @@ interface FieldConfig {
   validate?: (value: string) => string | true;
 }
 
-const BASIC_INFO_FIELD_ORDER: AppMetadataField[] = [
-  'shortName',
-  'longName',
-  'shortDescription',
-  'longDescription',
-  'developerName',
-  'websiteUrl',
-  'privacyUrl',
-  'termsOfUseUrl',
-];
-
 function buildMetadataFieldConfig(field: AppMetadataField): FieldConfig {
   const rule = getAppMetadataFieldRule(field);
   return {
@@ -41,9 +30,15 @@ function buildMetadataFieldConfig(field: AppMetadataField): FieldConfig {
 }
 
 const FIELDS: FieldConfig[] = [
-  ...BASIC_INFO_FIELD_ORDER.slice(0, 4).map(buildMetadataFieldConfig),
+  buildMetadataFieldConfig('shortName'),
+  buildMetadataFieldConfig('longName'),
+  buildMetadataFieldConfig('shortDescription'),
+  buildMetadataFieldConfig('longDescription'),
   { key: 'version', label: 'Version', required: true },
-  ...BASIC_INFO_FIELD_ORDER.slice(4).map(buildMetadataFieldConfig),
+  buildMetadataFieldConfig('developerName'),
+  buildMetadataFieldConfig('websiteUrl'),
+  buildMetadataFieldConfig('privacyUrl'),
+  buildMetadataFieldConfig('termsOfUseUrl'),
 ];
 
 function truncateValue(value: string | undefined | null, maxLength: number = 40): string {

--- a/packages/cli/src/apps/basic-info.ts
+++ b/packages/cli/src/apps/basic-info.ts
@@ -26,6 +26,22 @@ const FIELDS: FieldConfig[] = [
   { key: 'termsOfUseUrl', label: 'Terms of Use URL', required: true },
 ];
 
+function isMetadataField(key: keyof AppDetails): key is AppMetadataField {
+  switch (key) {
+    case 'shortName':
+    case 'longName':
+    case 'shortDescription':
+    case 'longDescription':
+    case 'developerName':
+    case 'websiteUrl':
+    case 'privacyUrl':
+    case 'termsOfUseUrl':
+      return true;
+    default:
+      return false;
+  }
+}
+
 function truncateValue(value: string | undefined | null, maxLength: number = 40): string {
   const str = value ?? '';
   if (str.length > maxLength) {
@@ -64,19 +80,8 @@ async function editField(
     message: `Enter new ${field.label.toLowerCase()}${maxLengthHint}:`,
     default: currentValue,
     validate: (value) => {
-      if (
-        field.key === 'shortName' ||
-        field.key === 'longName' ||
-        field.key === 'shortDescription' ||
-        field.key === 'longDescription' ||
-        field.key === 'developerName' ||
-        field.key === 'websiteUrl' ||
-        field.key === 'privacyUrl' ||
-        field.key === 'termsOfUseUrl'
-      ) {
-        return (
-          validateAppMetadataField(field.key as AppMetadataField, value, 'manifest') ?? true
-        );
+      if (isMetadataField(field.key)) {
+        return validateAppMetadataField(field.key, value, 'manifest') ?? true;
       }
 
       // Check required

--- a/packages/cli/src/apps/basic-info.ts
+++ b/packages/cli/src/apps/basic-info.ts
@@ -3,6 +3,7 @@ import pc from 'picocolors';
 import { createSpinner } from 'nanospinner';
 import type { AppDetails } from './types.js';
 import { updateAppDetails } from './api.js';
+import { validateAppMetadataField, type AppMetadataField } from './validation.js';
 import { logger } from '../utils/logger.js';
 
 interface FieldConfig {
@@ -13,18 +14,6 @@ interface FieldConfig {
   validate?: (value: string) => string | true;
 }
 
-const HTTPS_URL_REGEX = /^https:\/\/.+/i;
-
-function validateHttpsUrl(value: string): string | true {
-  if (!value.trim()) {
-    return true; // Empty is handled by required check
-  }
-  if (!HTTPS_URL_REGEX.test(value)) {
-    return 'URL must start with https://';
-  }
-  return true;
-}
-
 const FIELDS: FieldConfig[] = [
   { key: 'shortName', label: 'Short name', maxLength: 30, required: true },
   { key: 'longName', label: 'Long name', maxLength: 100, required: false },
@@ -32,9 +21,9 @@ const FIELDS: FieldConfig[] = [
   { key: 'longDescription', label: 'Long description', maxLength: 4000, required: true },
   { key: 'version', label: 'Version', required: true },
   { key: 'developerName', label: 'Developer name', required: true },
-  { key: 'websiteUrl', label: 'Website URL', required: true, validate: validateHttpsUrl },
-  { key: 'privacyUrl', label: 'Privacy URL', required: true, validate: validateHttpsUrl },
-  { key: 'termsOfUseUrl', label: 'Terms of Use URL', required: true, validate: validateHttpsUrl },
+  { key: 'websiteUrl', label: 'Website URL', required: true },
+  { key: 'privacyUrl', label: 'Privacy URL', required: true },
+  { key: 'termsOfUseUrl', label: 'Terms of Use URL', required: true },
 ];
 
 function truncateValue(value: string | undefined | null, maxLength: number = 40): string {
@@ -75,6 +64,21 @@ async function editField(
     message: `Enter new ${field.label.toLowerCase()}${maxLengthHint}:`,
     default: currentValue,
     validate: (value) => {
+      if (
+        field.key === 'shortName' ||
+        field.key === 'longName' ||
+        field.key === 'shortDescription' ||
+        field.key === 'longDescription' ||
+        field.key === 'developerName' ||
+        field.key === 'websiteUrl' ||
+        field.key === 'privacyUrl' ||
+        field.key === 'termsOfUseUrl'
+      ) {
+        return (
+          validateAppMetadataField(field.key as AppMetadataField, value, 'manifest') ?? true
+        );
+      }
+
       // Check required
       if (field.required && !value.trim()) {
         return `${field.label} is required`;

--- a/packages/cli/src/apps/index.ts
+++ b/packages/cli/src/apps/index.ts
@@ -9,3 +9,4 @@ export * from './basic-info.js';
 export * from './bot-location.js';
 export * from './bot-handler.js';
 export * from './links.js';
+export * from './validation.js';

--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -3,6 +3,15 @@ import pc from 'picocolors';
 import { isInteractive } from '../utils/interactive.js';
 import { logger } from '../utils/logger.js';
 import type { BotScope } from './manifest.js';
+import { validateAppMetadataField, type AppMetadataField } from './validation.js';
+
+/**
+ * Wraps `validateAppMetadataField` for inquirer's `validate` callback.
+ * Returns `true` when valid, or the error message string when invalid.
+ */
+function validateField(field: AppMetadataField, value: string): string | true {
+  return validateAppMetadataField(field, value, 'create') ?? true;
+}
 
 /**
  * Placeholder bot ID for manifest generation when no real bot ID is available.
@@ -43,8 +52,14 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
   const result: ManifestCustomization = {};
 
   if (customizeFields.includes('description')) {
-    const shortDesc = await input({ message: 'Short description:' });
-    const fullDesc = await input({ message: 'Full description (leave empty to use short):' });
+    const shortDesc = await input({
+      message: 'Short description:',
+      validate: (value) => validateField('shortDescription', value),
+    });
+    const fullDesc = await input({
+      message: 'Full description (leave empty to use short):',
+      validate: (value) => validateField('longDescription', value),
+    });
     result.description = { short: shortDesc, full: fullDesc || undefined };
   }
 
@@ -82,10 +97,22 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
   }
 
   if (customizeFields.includes('developer')) {
-    const devName = await input({ message: 'Developer name:' });
-    const websiteUrl = await input({ message: 'Website URL:' });
-    const privacyUrl = await input({ message: 'Privacy URL:' });
-    const termsUrl = await input({ message: 'Terms of use URL:' });
+    const devName = await input({
+      message: 'Developer name:',
+      validate: (value) => validateField('developerName', value),
+    });
+    const websiteUrl = await input({
+      message: 'Website URL:',
+      validate: (value) => validateField('websiteUrl', value),
+    });
+    const privacyUrl = await input({
+      message: 'Privacy URL:',
+      validate: (value) => validateField('privacyUrl', value),
+    });
+    const termsUrl = await input({
+      message: 'Terms of use URL:',
+      validate: (value) => validateField('termsOfUseUrl', value),
+    });
     result.developer = {
       name: devName,
       websiteUrl,

--- a/packages/cli/src/apps/validation.ts
+++ b/packages/cli/src/apps/validation.ts
@@ -17,12 +17,24 @@ export interface AppMetadataInput {
 
 export type AppMetadataField = keyof AppMetadataInput;
 
+export const APP_METADATA_FIELDS = [
+  'shortName',
+  'longName',
+  'shortDescription',
+  'longDescription',
+  'developerName',
+  'websiteUrl',
+  'privacyUrl',
+  'termsOfUseUrl',
+  'endpoint',
+] as const satisfies readonly AppMetadataField[];
+
 export interface ValidationIssue {
   field: AppMetadataField;
   message: string;
 }
 
-interface FieldRule {
+export interface AppMetadataFieldRule {
   label: string;
   maxLength?: number;
   requiredIn: ValidationMode[];
@@ -33,7 +45,7 @@ interface FieldRule {
 
 const HTTPS_URL_REGEX = /^https:\/\/\S+$/i;
 
-const FIELD_RULES: Record<AppMetadataField, FieldRule> = {
+const FIELD_RULES: Record<AppMetadataField, AppMetadataFieldRule> = {
   shortName: {
     label: 'Short name',
     maxLength: 30,
@@ -81,6 +93,14 @@ const FIELD_RULES: Record<AppMetadataField, FieldRule> = {
     validate: (value) => validateEndpoint(value),
   },
 };
+
+export function getAppMetadataFieldRule(field: AppMetadataField): AppMetadataFieldRule {
+  return FIELD_RULES[field];
+}
+
+export function isAppMetadataField(field: PropertyKey): field is AppMetadataField {
+  return typeof field === 'string' && APP_METADATA_FIELDS.some((candidate) => candidate === field);
+}
 
 export function normalizeAppMetadata(input: AppMetadataInput): AppMetadataInput {
   return {
@@ -133,7 +153,7 @@ export function validateAppMetadata(
   const normalized = normalizeAppMetadata(input);
   const issues: ValidationIssue[] = [];
 
-  for (const field of Object.keys(FIELD_RULES) as AppMetadataField[]) {
+  for (const field of APP_METADATA_FIELDS) {
     const value = normalized[field];
     if (mode === 'update' && value === undefined) {
       continue;

--- a/packages/cli/src/apps/validation.ts
+++ b/packages/cli/src/apps/validation.ts
@@ -1,0 +1,163 @@
+import type { TeamsManifest } from './api.js';
+import { validateEndpoint } from './manifest.js';
+
+export type ValidationMode = 'create' | 'update' | 'manifest';
+
+export interface AppMetadataInput {
+  shortName?: string;
+  longName?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  developerName?: string;
+  websiteUrl?: string;
+  privacyUrl?: string;
+  termsOfUseUrl?: string;
+  endpoint?: string;
+}
+
+export type AppMetadataField = keyof AppMetadataInput;
+
+export interface ValidationIssue {
+  field: AppMetadataField;
+  message: string;
+}
+
+interface FieldRule {
+  label: string;
+  maxLength?: number;
+  requiredIn: ValidationMode[];
+  allowEmpty?: boolean;
+  emptyMessage?: string;
+  validate?: (value: string) => string | null;
+}
+
+const HTTPS_URL_REGEX = /^https:\/\/\S+$/i;
+
+const FIELD_RULES: Record<AppMetadataField, FieldRule> = {
+  shortName: {
+    label: 'Short name',
+    maxLength: 30,
+    requiredIn: ['create', 'manifest'],
+  },
+  longName: {
+    label: 'Long name',
+    maxLength: 100,
+    requiredIn: [],
+    allowEmpty: true,
+  },
+  shortDescription: {
+    label: 'Short description',
+    maxLength: 80,
+    requiredIn: ['create', 'manifest'],
+  },
+  longDescription: {
+    label: 'Long description',
+    maxLength: 4000,
+    requiredIn: ['create', 'manifest'],
+  },
+  developerName: {
+    label: 'Developer name',
+    requiredIn: ['create', 'manifest'],
+  },
+  websiteUrl: {
+    label: 'Website URL',
+    requiredIn: ['create', 'manifest'],
+    validate: (value) => validateHttpsUrl(value, 'Website URL'),
+  },
+  privacyUrl: {
+    label: 'Privacy URL',
+    requiredIn: ['create', 'manifest'],
+    validate: (value) => validateHttpsUrl(value, 'Privacy URL'),
+  },
+  termsOfUseUrl: {
+    label: 'Terms of use URL',
+    requiredIn: ['create', 'manifest'],
+    validate: (value) => validateHttpsUrl(value, 'Terms of use URL'),
+  },
+  endpoint: {
+    label: 'Endpoint URL',
+    requiredIn: [],
+    emptyMessage: 'Endpoint URL cannot be empty.',
+    validate: (value) => validateEndpoint(value),
+  },
+};
+
+export function normalizeAppMetadata(input: AppMetadataInput): AppMetadataInput {
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? value.trim() : value,
+    ])
+  ) as AppMetadataInput;
+}
+
+export function validateAppMetadataField(
+  field: AppMetadataField,
+  value: string | undefined,
+  mode: ValidationMode
+): string | null {
+  const rule = FIELD_RULES[field];
+  const normalizedValue = typeof value === 'string' ? value.trim() : value;
+  const isRequired = rule.requiredIn.includes(mode);
+
+  if (normalizedValue === undefined) {
+    return isRequired ? `${rule.label} is required.` : null;
+  }
+
+  if (!normalizedValue) {
+    if (isRequired) {
+      return `${rule.label} is required.`;
+    }
+    if (rule.allowEmpty) {
+      return null;
+    }
+    return rule.emptyMessage ?? `${rule.label} is required.`;
+  }
+
+  if (rule.maxLength && normalizedValue.length > rule.maxLength) {
+    return `${rule.label} must be ${rule.maxLength} characters or less.`;
+  }
+
+  return rule.validate?.(normalizedValue) ?? null;
+}
+
+export function validateAppMetadata(
+  input: AppMetadataInput,
+  mode: ValidationMode
+): ValidationIssue[] {
+  const normalized = normalizeAppMetadata(input);
+  const issues: ValidationIssue[] = [];
+
+  for (const field of Object.keys(FIELD_RULES) as AppMetadataField[]) {
+    const value = normalized[field];
+    if (mode === 'update' && value === undefined) {
+      continue;
+    }
+
+    const error = validateAppMetadataField(field, value, mode);
+    if (error) {
+      issues.push({ field, message: error });
+    }
+  }
+
+  return issues;
+}
+
+export function appMetadataFromManifest(manifest: TeamsManifest): AppMetadataInput {
+  return {
+    shortName: manifest.name?.short,
+    longName: manifest.name?.full,
+    shortDescription: manifest.description?.short,
+    longDescription: manifest.description?.full,
+    developerName: manifest.developer?.name,
+    websiteUrl: manifest.developer?.websiteUrl,
+    privacyUrl: manifest.developer?.privacyUrl,
+    termsOfUseUrl: manifest.developer?.termsOfUseUrl,
+  };
+}
+
+function validateHttpsUrl(value: string, label: string): string | null {
+  return HTTPS_URL_REGEX.test(value)
+    ? null
+    : `${label} must start with https:// and include a domain.`;
+}

--- a/packages/cli/src/apps/validation.ts
+++ b/packages/cli/src/apps/validation.ts
@@ -83,12 +83,17 @@ const FIELD_RULES: Record<AppMetadataField, FieldRule> = {
 };
 
 export function normalizeAppMetadata(input: AppMetadataInput): AppMetadataInput {
-  return Object.fromEntries(
-    Object.entries(input).map(([key, value]) => [
-      key,
-      typeof value === 'string' ? value.trim() : value,
-    ])
-  ) as AppMetadataInput;
+  return {
+    shortName: normalizeString(input.shortName),
+    longName: normalizeString(input.longName),
+    shortDescription: normalizeString(input.shortDescription),
+    longDescription: normalizeString(input.longDescription),
+    developerName: normalizeString(input.developerName),
+    websiteUrl: normalizeString(input.websiteUrl),
+    privacyUrl: normalizeString(input.privacyUrl),
+    termsOfUseUrl: normalizeString(input.termsOfUseUrl),
+    endpoint: normalizeString(input.endpoint),
+  };
 }
 
 export function validateAppMetadataField(
@@ -154,6 +159,10 @@ export function appMetadataFromManifest(manifest: TeamsManifest): AppMetadataInp
     privacyUrl: manifest.developer?.privacyUrl,
     termsOfUseUrl: manifest.developer?.termsOfUseUrl,
   };
+}
+
+function normalizeString(value: string | undefined): string | undefined {
+  return typeof value === 'string' ? value.trim() : value;
 }
 
 function validateHttpsUrl(value: string, label: string): string | null {

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -12,6 +12,7 @@ import {
   type BotScope,
   createTdpBotHandler,
   createAzureBotHandler,
+  normalizeAppMetadata,
   validateAppMetadata,
   validateEndpoint,
   type AzureContext,
@@ -188,23 +189,38 @@ export const appCreateCommand = new Command('create')
         ? (earlyOutlineIcon ?? readAndValidateIcon(outlineIconPath, 32))
         : undefined;
 
-      const validationIssues = validateAppMetadata(
-        {
-          shortName: name,
-          longName: name,
-          shortDescription: descriptionOpts?.short ?? name,
-          longDescription: descriptionOpts?.full ?? descriptionOpts?.short ?? name,
-          developerName: developerOpts?.name ?? 'Developer',
-          websiteUrl: developerOpts?.websiteUrl ?? 'https://www.example.com',
-          privacyUrl: developerOpts?.privacyUrl ?? 'https://www.example.com/privacy',
-          termsOfUseUrl: developerOpts?.termsOfUseUrl ?? 'https://www.example.com/terms',
-          endpoint,
-        },
-        'create'
-      );
+      const createMetadata = normalizeAppMetadata({
+        shortName: name,
+        longName: name,
+        shortDescription: descriptionOpts?.short ?? name,
+        longDescription: descriptionOpts?.full ?? descriptionOpts?.short ?? name,
+        developerName: developerOpts?.name ?? 'Developer',
+        websiteUrl: developerOpts?.websiteUrl ?? 'https://www.example.com',
+        privacyUrl: developerOpts?.privacyUrl ?? 'https://www.example.com/privacy',
+        termsOfUseUrl: developerOpts?.termsOfUseUrl ?? 'https://www.example.com/terms',
+        endpoint,
+      });
+      const validationIssues = validateAppMetadata(createMetadata, 'create');
       if (validationIssues.length > 0) {
         throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
       }
+
+      const normalizedName = createMetadata.shortName!;
+      const normalizedEndpoint = createMetadata.endpoint;
+      const normalizedDescriptionOpts = descriptionOpts
+        ? {
+            short: createMetadata.shortDescription!,
+            full: createMetadata.longDescription!,
+          }
+        : undefined;
+      const normalizedDeveloperOpts = developerOpts
+        ? {
+            name: createMetadata.developerName!,
+            websiteUrl: createMetadata.websiteUrl!,
+            privacyUrl: createMetadata.privacyUrl!,
+            termsOfUseUrl: createMetadata.termsOfUseUrl!,
+          }
+        : undefined;
 
       const account = await getAccount();
       if (!account) {
@@ -254,17 +270,17 @@ export const appCreateCommand = new Command('create')
       }
 
       // ===== All inputs gathered — confirm before proceeding =====
-      const summaryLines: [string, string][] = [['App name', name]];
+      const summaryLines: [string, string][] = [['App name', normalizedName]];
       if (azureContext) {
         summaryLines.push(['Subscription', azureContext.subscription]);
         summaryLines.push(['Resource group', azureContext.resourceGroup]);
       }
-      if (endpoint) summaryLines.push(['Endpoint', endpoint]);
-      if (descriptionOpts?.short.trim())
-        summaryLines.push(['Description', descriptionOpts.short.trim()]);
+      if (normalizedEndpoint) summaryLines.push(['Endpoint', normalizedEndpoint]);
+      if (normalizedDescriptionOpts?.short)
+        summaryLines.push(['Description', normalizedDescriptionOpts.short]);
       if (scopeChoices && scopeChoices.length > 0)
         summaryLines.push(['Scopes', scopeChoices.join(', ')]);
-      if (developerOpts?.name.trim()) summaryLines.push(['Developer', developerOpts.name.trim()]);
+      if (normalizedDeveloperOpts?.name) summaryLines.push(['Developer', normalizedDeveloperOpts.name]);
       if (colorIconPath) summaryLines.push(['Color icon', colorIconPath]);
       if (outlineIconPath) summaryLines.push(['Outline icon', outlineIconPath]);
       if (!generateSecret) summaryLines.push(['Secret', 'Skipped']);
@@ -312,18 +328,18 @@ export const appCreateCommand = new Command('create')
 
       // Create AAD app via TDP (creates service principal server-side)
       spinner = createSilentSpinner('Creating Azure AD app...', silent).start();
-      const aadApp = await createAadAppViaTdp(tdpToken, name!);
+      const aadApp = await createAadAppViaTdp(tdpToken, normalizedName);
       const clientId = aadApp.appId;
       spinner.success({ text: `Created Azure AD app (${clientId})` });
 
       // Generate manifest
       const manifestOpts: ManifestOptions = {
         botId: clientId,
-        botName: name!,
-        endpoint,
-        description: descriptionOpts,
+        botName: normalizedName,
+        endpoint: normalizedEndpoint,
+        description: normalizedDescriptionOpts,
         scopes: scopeChoices,
-        developer: developerOpts,
+        developer: normalizedDeveloperOpts,
         colorIconBuffer: colorIcon?.buffer,
         outlineIconBuffer: outlineIcon?.buffer,
       };
@@ -361,7 +377,7 @@ export const appCreateCommand = new Command('create')
       spinner = createSilentSpinner('Registering bot...', silent).start();
       const handler =
         location === 'tm' ? createTdpBotHandler(tdpToken) : createAzureBotHandler(azureContext!);
-      await handler.createBot({ botId: clientId, name: name!, endpoint });
+      await handler.createBot({ botId: clientId, name: normalizedName, endpoint: normalizedEndpoint });
       spinner.success({ text: 'Bot registered' });
 
       // Output results
@@ -385,10 +401,10 @@ export const appCreateCommand = new Command('create')
         }
 
         const result: AppCreateOutput = {
-          appName: name!,
+          appName: normalizedName,
           teamsAppId,
           botId: clientId,
-          endpoint: endpoint ?? null,
+          endpoint: normalizedEndpoint ?? null,
           installLink: install,
           portalLink: portal,
           botLocation: location === 'tm' ? 'teams-managed' : 'azure',
@@ -400,11 +416,11 @@ export const appCreateCommand = new Command('create')
         outputJson(result);
       } else {
         logger.info(pc.bold(pc.green('\nApp created successfully!')));
-        logger.info(`${pc.dim('Name:')} ${name!}`);
+        logger.info(`${pc.dim('Name:')} ${normalizedName}`);
         logger.info(`${pc.dim('Teams App ID:')} ${teamsAppId}`);
         logger.info(`${pc.dim('Bot ID:')} ${clientId}`);
-        if (endpoint) {
-          logger.info(`${pc.dim('Endpoint:')} ${endpoint}`);
+        if (normalizedEndpoint) {
+          logger.info(`${pc.dim('Endpoint:')} ${normalizedEndpoint}`);
         }
         logger.info('');
         printLinkBanner('Install in Teams', install);

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -12,6 +12,7 @@ import {
   type BotScope,
   createTdpBotHandler,
   createAzureBotHandler,
+  validateAppMetadata,
   validateEndpoint,
   type AzureContext,
   type BotLocation,
@@ -109,53 +110,6 @@ export const appCreateCommand = new Command('create')
       const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
       const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
 
-      const account = await getAccount();
-      if (!account) {
-        throw new CliError('AUTH_REQUIRED', 'Not logged in.', 'Run `teams login` first.');
-      }
-
-      // Resolve bot location: explicit flag > config > default (teams-managed)
-      let location: BotLocation;
-      if (options.azure) location = 'azure';
-      else if (options.teamsManaged) location = 'tm';
-      else location = ((await getConfig('default-bot-location')) as BotLocation) ?? 'tm';
-
-      // Gather Azure context if needed
-      let azureContext: AzureContext | undefined;
-      if (location === 'azure') {
-        await ensureAz();
-        await ensureTenantMatch(account.tenantId);
-        const subscription = await resolveSubscription(options.subscription);
-        const resourceGroup = await resolveResourceGroup(subscription, options.resourceGroup);
-
-        if (options.createResourceGroup) {
-          const rgRegion = options.region ?? 'westus2';
-          const rgSpinner = createSilentSpinner(
-            `Creating resource group ${resourceGroup}...`,
-            silent
-          ).start();
-          await runAz([
-            'group',
-            'create',
-            '--name',
-            resourceGroup,
-            '--location',
-            rgRegion,
-            '--subscription',
-            subscription,
-          ]);
-          rgSpinner.success({ text: `Resource group ${resourceGroup} ready` });
-        }
-
-        // Bot Service location is always "global"
-        azureContext = {
-          subscription,
-          resourceGroup,
-          region: 'global',
-          tenantId: account.tenantId,
-        };
-      }
-
       // ===== Gather all inputs upfront =====
       const interactive = isInteractive();
 
@@ -233,6 +187,71 @@ export const appCreateCommand = new Command('create')
       const outlineIcon = outlineIconPath
         ? (earlyOutlineIcon ?? readAndValidateIcon(outlineIconPath, 32))
         : undefined;
+
+      const validationIssues = validateAppMetadata(
+        {
+          shortName: name,
+          longName: name,
+          shortDescription: descriptionOpts?.short ?? name,
+          longDescription: descriptionOpts?.full ?? descriptionOpts?.short ?? name,
+          developerName: developerOpts?.name ?? 'Developer',
+          websiteUrl: developerOpts?.websiteUrl ?? 'https://www.example.com',
+          privacyUrl: developerOpts?.privacyUrl ?? 'https://www.example.com/privacy',
+          termsOfUseUrl: developerOpts?.termsOfUseUrl ?? 'https://www.example.com/terms',
+          endpoint,
+        },
+        'create'
+      );
+      if (validationIssues.length > 0) {
+        throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
+      }
+
+      const account = await getAccount();
+      if (!account) {
+        throw new CliError('AUTH_REQUIRED', 'Not logged in.', 'Run `teams login` first.');
+      }
+
+      // Resolve bot location: explicit flag > config > default (teams-managed)
+      let location: BotLocation;
+      if (options.azure) location = 'azure';
+      else if (options.teamsManaged) location = 'tm';
+      else location = ((await getConfig('default-bot-location')) as BotLocation) ?? 'tm';
+
+      // Gather Azure context if needed
+      let azureContext: AzureContext | undefined;
+      if (location === 'azure') {
+        await ensureAz();
+        await ensureTenantMatch(account.tenantId);
+        const subscription = await resolveSubscription(options.subscription);
+        const resourceGroup = await resolveResourceGroup(subscription, options.resourceGroup);
+
+        if (options.createResourceGroup) {
+          const rgRegion = options.region ?? 'westus2';
+          const rgSpinner = createSilentSpinner(
+            `Creating resource group ${resourceGroup}...`,
+            silent
+          ).start();
+          await runAz([
+            'group',
+            'create',
+            '--name',
+            resourceGroup,
+            '--location',
+            rgRegion,
+            '--subscription',
+            subscription,
+          ]);
+          rgSpinner.success({ text: `Resource group ${resourceGroup} ready` });
+        }
+
+        // Bot Service location is always "global"
+        azureContext = {
+          subscription,
+          resourceGroup,
+          region: 'global',
+          tenantId: account.tenantId,
+        };
+      }
 
       // ===== All inputs gathered — confirm before proceeding =====
       const summaryLines: [string, string][] = [['App name', name]];

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -14,6 +14,7 @@ import {
   createAzureBotHandler,
   normalizeAppMetadata,
   validateAppMetadata,
+  validateAppMetadataField,
   validateEndpoint,
   type AzureContext,
   type BotLocation,
@@ -110,7 +111,13 @@ export const appCreateCommand = new Command('create')
       // Get name
       const name =
         options.name ??
-        (interactive && !hasFlags ? await input({ message: 'App name:' }) : undefined);
+        (interactive && !hasFlags
+          ? await input({
+              message: 'App name:',
+              validate: (value) =>
+                validateAppMetadataField('shortName', value, 'create') ?? true,
+            })
+          : undefined);
 
       if (!name?.trim()) {
         throw new CliError('VALIDATION_MISSING', 'App name cannot be empty.');

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -94,20 +94,6 @@ export const appCreateCommand = new Command('create')
           'Cannot specify both --azure and --teams-managed.'
         );
       }
-      if (options.endpoint !== undefined) {
-        const trimmedEndpoint = options.endpoint.trim();
-        if (!trimmedEndpoint) {
-          throw new CliError(
-            'VALIDATION_FORMAT',
-            'Bot messaging endpoint URL cannot be empty.'
-          );
-        }
-        const endpointError = validateEndpoint(trimmedEndpoint);
-        if (endpointError) {
-          throw new CliError('VALIDATION_FORMAT', endpointError);
-        }
-        options.endpoint = trimmedEndpoint;
-      }
       const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
       const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
 

--- a/packages/cli/src/commands/app/manifest/actions.ts
+++ b/packages/cli/src/commands/app/manifest/actions.ts
@@ -3,7 +3,13 @@ import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import pc from 'picocolors';
 import { confirm } from '@inquirer/prompts';
-import { downloadAppPackage, uploadManifest, type TeamsManifest } from '../../../apps/index.js';
+import {
+  appMetadataFromManifest,
+  downloadAppPackage,
+  uploadManifest,
+  validateAppMetadata,
+  type TeamsManifest,
+} from '../../../apps/index.js';
 import { CliError } from '../../../utils/errors.js';
 import { isAutoConfirm } from '../../../utils/interactive.js';
 import { logger } from '../../../utils/logger.js';
@@ -115,6 +121,11 @@ export async function uploadManifestFromFile(
       const proceed = await confirm({ message: 'Upload anyway?', default: false });
       if (!proceed) return undefined;
     }
+  }
+
+  const validationIssues = validateAppMetadata(appMetadataFromManifest(manifest), 'manifest');
+  if (validationIssues.length > 0) {
+    throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
   }
 
   // Auto-bump version if enabled and version is parseable

--- a/packages/cli/src/commands/app/manifest/actions.ts
+++ b/packages/cli/src/commands/app/manifest/actions.ts
@@ -101,12 +101,6 @@ export async function uploadManifestFromFile(
   if (!manifest.id) missing.push('id');
   if (!manifest.version) missing.push('version');
   if (!manifest.manifestVersion) missing.push('manifestVersion');
-  if (!manifest.name?.short) missing.push('name.short');
-  if (!manifest.description?.short) missing.push('description.short');
-  if (!manifest.developer?.name) missing.push('developer.name');
-  if (!manifest.developer?.websiteUrl) missing.push('developer.websiteUrl');
-  if (!manifest.developer?.privacyUrl) missing.push('developer.privacyUrl');
-  if (!manifest.developer?.termsOfUseUrl) missing.push('developer.termsOfUseUrl');
 
   if (missing.length > 0) {
     if (silent) {
@@ -125,7 +119,21 @@ export async function uploadManifestFromFile(
 
   const validationIssues = validateAppMetadata(appMetadataFromManifest(manifest), 'manifest');
   if (validationIssues.length > 0) {
-    throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
+    if (silent) {
+      throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
+    }
+
+    logger.warn(
+      pc.yellow(
+        `Manifest metadata validation failed: ${validationIssues
+          .map((issue) => issue.message)
+          .join('; ')}`
+      )
+    );
+    if (!isAutoConfirm()) {
+      const proceed = await confirm({ message: 'Upload anyway?', default: false });
+      if (!proceed) return undefined;
+    }
   }
 
   // Auto-bump version if enabled and version is parseable

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -14,6 +14,7 @@ import {
   createAzureBotHandler,
   discoverAzureBot,
   extractDomain,
+  normalizeAppMetadata,
   validateAppMetadata,
   validateEndpoint,
   uploadIcon,
@@ -417,23 +418,30 @@ export const appUpdateCommand = new Command('update')
           throw new CliError('VALIDATION_FORMAT', 'At least one scope is required.');
         }
       }
-      const validationIssues = validateAppMetadata(
-        {
-          endpoint: options.endpoint,
-          shortName: options.name,
-          longName: options.longName,
-          shortDescription: options.shortDescription,
-          longDescription: options.longDescription,
-          developerName: options.developer,
-          websiteUrl: options.website,
-          privacyUrl: options.privacyUrl,
-          termsOfUseUrl: options.termsUrl,
-        },
-        'update'
-      );
+      const normalizedMetadata = normalizeAppMetadata({
+        endpoint: options.endpoint,
+        shortName: options.name,
+        longName: options.longName,
+        shortDescription: options.shortDescription,
+        longDescription: options.longDescription,
+        developerName: options.developer,
+        websiteUrl: options.website,
+        privacyUrl: options.privacyUrl,
+        termsOfUseUrl: options.termsUrl,
+      });
+      const validationIssues = validateAppMetadata(normalizedMetadata, 'update');
       if (validationIssues.length > 0) {
         throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
       }
+      options.endpoint = normalizedMetadata.endpoint;
+      options.name = normalizedMetadata.shortName;
+      options.longName = normalizedMetadata.longName;
+      options.shortDescription = normalizedMetadata.shortDescription;
+      options.longDescription = normalizedMetadata.longDescription;
+      options.developer = normalizedMetadata.developerName;
+      options.website = normalizedMetadata.websiteUrl;
+      options.privacyUrl = normalizedMetadata.privacyUrl;
+      options.termsUrl = normalizedMetadata.termsOfUseUrl;
 
       // Interactive mode (no appId, no mutation flags): picker loop
       if (!appIdArg && !hasMutationFlags) {

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -14,6 +14,7 @@ import {
   createAzureBotHandler,
   discoverAzureBot,
   extractDomain,
+  validateAppMetadata,
   validateEndpoint,
   uploadIcon,
 } from '../../apps/index.js';
@@ -416,38 +417,22 @@ export const appUpdateCommand = new Command('update')
           throw new CliError('VALIDATION_FORMAT', 'At least one scope is required.');
         }
       }
-      if (options.endpoint !== undefined) {
-        const trimmedEndpoint = options.endpoint.trim();
-        if (!trimmedEndpoint) {
-          throw new CliError('VALIDATION_FORMAT', 'Endpoint URL cannot be empty.');
-        }
-        const endpointError = validateEndpoint(trimmedEndpoint);
-        if (endpointError) {
-          throw new CliError('VALIDATION_FORMAT', endpointError);
-        }
-        options.endpoint = trimmedEndpoint;
-      }
-      if (options.name !== undefined && options.name.length > 30) {
-        throw new CliError('VALIDATION_FORMAT', 'Short name must be 30 characters or less.');
-      }
-      if (options.longName !== undefined && options.longName.length > 100) {
-        throw new CliError('VALIDATION_FORMAT', 'Long name must be 100 characters or less.');
-      }
-      if (options.shortDescription !== undefined && options.shortDescription.length > 80) {
-        throw new CliError('VALIDATION_FORMAT', 'Short description must be 80 characters or less.');
-      }
-      if (options.longDescription !== undefined && options.longDescription.length > 4000) {
-        throw new CliError('VALIDATION_FORMAT', 'Long description must be 4000 characters or less.');
-      }
-      const httpsUrlRegex = /^https:\/\/\S+$/i;
-      if (options.website !== undefined && !httpsUrlRegex.test(options.website)) {
-        throw new CliError('VALIDATION_FORMAT', 'Website URL must start with https:// and include a domain.');
-      }
-      if (options.privacyUrl !== undefined && !httpsUrlRegex.test(options.privacyUrl)) {
-        throw new CliError('VALIDATION_FORMAT', 'Privacy URL must start with https:// and include a domain.');
-      }
-      if (options.termsUrl !== undefined && !httpsUrlRegex.test(options.termsUrl)) {
-        throw new CliError('VALIDATION_FORMAT', 'Terms of use URL must start with https:// and include a domain.');
+      const validationIssues = validateAppMetadata(
+        {
+          endpoint: options.endpoint,
+          shortName: options.name,
+          longName: options.longName,
+          shortDescription: options.shortDescription,
+          longDescription: options.longDescription,
+          developerName: options.developer,
+          websiteUrl: options.website,
+          privacyUrl: options.privacyUrl,
+          termsOfUseUrl: options.termsUrl,
+        },
+        'update'
+      );
+      if (validationIssues.length > 0) {
+        throw new CliError('VALIDATION_FORMAT', validationIssues[0]!.message);
       }
 
       // Interactive mode (no appId, no mutation flags): picker loop

--- a/packages/cli/tests/app-command-validation.test.ts
+++ b/packages/cli/tests/app-command-validation.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+
+vi.mock('../src/apps/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/apps/index.js')>();
+  return {
+    ...actual,
+    fetchApp: vi.fn(),
+    fetchBot: vi.fn(),
+    updateBot: vi.fn(),
+    updateAppDetails: vi.fn(),
+    fetchAppDetailsV2: vi.fn(),
+    showBasicInfoEditor: vi.fn(),
+    getBotLocation: vi.fn(),
+    createTdpBotHandler: vi.fn().mockReturnValue({
+      createBot: vi.fn().mockResolvedValue(undefined),
+    }),
+    createAzureBotHandler: vi.fn().mockReturnValue({
+      createBot: vi.fn().mockResolvedValue(undefined),
+    }),
+    discoverAzureBot: vi.fn(),
+    uploadIcon: vi.fn(),
+    createAadAppViaTdp: vi.fn().mockResolvedValue({
+      id: 'aad-object-id',
+      appId: 'fake-client-id',
+      displayName: 'TestAadApp',
+    }),
+    createClientSecret: vi.fn().mockResolvedValue({ secretText: 'fake-secret-text' }),
+    getAadAppByClientId: vi.fn().mockResolvedValue({ id: 'aad-object-id' }),
+    createManifestZip: vi.fn().mockReturnValue(Buffer.from('fake-zip')),
+    importAppPackage: vi.fn().mockResolvedValue({ teamsAppId: 'fake-teams-app-id' }),
+    installLink: vi.fn((id: string, tenantId: string) =>
+      `https://teams.microsoft.com/l/app/${id}?installAppPackage=true&appTenantId=${tenantId}`
+    ),
+    portalLink: vi.fn((id: string) => `https://dev.teams.microsoft.com/apps/${id}`),
+  };
+});
+
+const mockGetAccount = vi.fn().mockResolvedValue({ tenantId: 'fake-tenant-id' });
+vi.mock('../src/auth/index.js', () => ({
+  getAccount: mockGetAccount,
+  getTokenSilent: vi.fn().mockResolvedValue('fake-token'),
+  graphScopes: ['https://graph.microsoft.com/.default'],
+  teamsDevPortalScopes: ['https://dev.teams.microsoft.com/.default'],
+}));
+
+vi.mock('../src/utils/spinner.js', () => ({
+  createSilentSpinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/utils/interactive.js', () => ({
+  confirmAction: vi.fn().mockResolvedValue(true),
+  isInteractive: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../src/utils/config.js', () => ({
+  getConfig: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../src/utils/browser.js', () => ({
+  printLinkBanner: vi.fn(),
+  openInBrowser: vi.fn(),
+}));
+
+vi.mock('../src/utils/az.js', () => ({
+  ensureAz: vi.fn(),
+  runAz: vi.fn(),
+}));
+
+vi.mock('../src/utils/az-prompts.js', () => ({
+  resolveSubscription: vi.fn(),
+  resolveResourceGroup: vi.fn(),
+  ensureTenantMatch: vi.fn(),
+}));
+
+let jsonOutput: unknown = null;
+vi.mock('../src/utils/json-output.js', () => ({
+  outputJson: vi.fn((data: unknown) => {
+    jsonOutput = data;
+  }),
+}));
+
+const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+  throw new Error(`process.exit(${code})`);
+});
+
+afterAll(() => {
+  mockExit.mockRestore();
+});
+
+describe('shared command validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jsonOutput = null;
+    mockGetAccount.mockResolvedValue({ tenantId: 'fake-tenant-id' });
+  });
+
+  it('rejects app create names that exceed the short-name limit before auth', async () => {
+    const { appCreateCommand } = await import('../src/commands/app/create.js');
+
+    await expect(
+      appCreateCommand.parseAsync(['--name', 'x'.repeat(31), '--json'], { from: 'user' })
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(jsonOutput).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_FORMAT',
+        message: 'Short name must be 30 characters or less.',
+      },
+    });
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects app update names that exceed the short-name limit before auth', async () => {
+    const { appUpdateCommand } = await import('../src/commands/app/update.js');
+
+    await expect(
+      appUpdateCommand.parseAsync(['some-app-id', '--name', 'x'.repeat(31), '--json'], {
+        from: 'user',
+      })
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(jsonOutput).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_FORMAT',
+        message: 'Short name must be 30 characters or less.',
+      },
+    });
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/tests/app-command-validation.test.ts
+++ b/packages/cli/tests/app-command-validation.test.ts
@@ -1,32 +1,38 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 
+const mockFetchApp = vi.fn();
+const mockFetchBot = vi.fn();
+const mockUpdateBot = vi.fn();
+const mockUpdateAppDetails = vi.fn();
+const mockFetchAppDetailsV2 = vi.fn();
+const mockCreateBot = vi.fn();
+const mockCreateAadAppViaTdp = vi.fn();
+const mockCreateManifestZip = vi.fn();
+
 vi.mock('../src/apps/index.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/apps/index.js')>();
   return {
     ...actual,
-    fetchApp: vi.fn(),
-    fetchBot: vi.fn(),
-    updateBot: vi.fn(),
-    updateAppDetails: vi.fn(),
-    fetchAppDetailsV2: vi.fn(),
+    fetchApp: mockFetchApp,
+    fetchBot: mockFetchBot,
+    updateBot: mockUpdateBot,
+    updateAppDetails: mockUpdateAppDetails,
+    fetchAppDetailsV2: mockFetchAppDetailsV2,
     showBasicInfoEditor: vi.fn(),
-    getBotLocation: vi.fn(),
+    getBotLocation: vi.fn().mockResolvedValue('tm'),
     createTdpBotHandler: vi.fn().mockReturnValue({
-      createBot: vi.fn().mockResolvedValue(undefined),
+      createBot: mockCreateBot,
     }),
     createAzureBotHandler: vi.fn().mockReturnValue({
       createBot: vi.fn().mockResolvedValue(undefined),
+      updateEndpoint: vi.fn().mockResolvedValue(undefined),
     }),
     discoverAzureBot: vi.fn(),
     uploadIcon: vi.fn(),
-    createAadAppViaTdp: vi.fn().mockResolvedValue({
-      id: 'aad-object-id',
-      appId: 'fake-client-id',
-      displayName: 'TestAadApp',
-    }),
+    createAadAppViaTdp: mockCreateAadAppViaTdp,
     createClientSecret: vi.fn().mockResolvedValue({ secretText: 'fake-secret-text' }),
     getAadAppByClientId: vi.fn().mockResolvedValue({ id: 'aad-object-id' }),
-    createManifestZip: vi.fn().mockReturnValue(Buffer.from('fake-zip')),
+    createManifestZip: mockCreateManifestZip,
     importAppPackage: vi.fn().mockResolvedValue({ teamsAppId: 'fake-teams-app-id' }),
     installLink: vi.fn((id: string, tenantId: string) =>
       `https://teams.microsoft.com/l/app/${id}?installAppPackage=true&appTenantId=${tenantId}`
@@ -106,6 +112,51 @@ describe('shared command validation', () => {
     vi.clearAllMocks();
     jsonOutput = null;
     mockGetAccount.mockResolvedValue({ tenantId: 'fake-tenant-id' });
+    mockCreateBot.mockResolvedValue(undefined);
+    mockCreateAadAppViaTdp.mockResolvedValue({
+      id: 'aad-object-id',
+      appId: 'fake-client-id',
+      displayName: 'TestAadApp',
+    });
+    mockCreateManifestZip.mockReturnValue(Buffer.from('fake-zip'));
+    mockFetchApp.mockResolvedValue({
+      appId: 'aad-object-id',
+      appName: 'Test App',
+      teamsAppId: 'some-app-id',
+      version: '1.0.0',
+      updatedAt: null,
+      bots: [{ botId: 'bot-id' }],
+    });
+    mockFetchBot.mockResolvedValue({
+      botId: 'bot-id',
+      name: 'Test Bot',
+      messagingEndpoint: '',
+      callingEndpoint: null,
+      description: '',
+      configuredChannels: ['msteams'],
+      isSingleTenant: true,
+    });
+    mockUpdateBot.mockResolvedValue(undefined);
+    mockUpdateAppDetails.mockResolvedValue(undefined);
+    mockFetchAppDetailsV2.mockResolvedValue({
+      teamsAppId: 'some-app-id',
+      appId: 'aad-object-id',
+      shortName: 'Existing Name',
+      longName: '',
+      shortDescription: 'Existing short description',
+      longDescription: 'Existing long description',
+      version: '1.0.0',
+      developerName: 'Existing Developer',
+      websiteUrl: 'https://existing.example.com',
+      privacyUrl: 'https://existing.example.com/privacy',
+      termsOfUseUrl: 'https://existing.example.com/terms',
+      manifestVersion: '1.25',
+      webApplicationInfoId: '',
+      mpnId: '',
+      accentColor: '#FFFFFF',
+      validDomains: ['*.botframework.com'],
+      bots: [{ botId: 'bot-id', scopes: ['personal'] }],
+    });
   });
 
   it('rejects app create names that exceed the short-name limit before auth', async () => {
@@ -142,5 +193,82 @@ describe('shared command validation', () => {
       },
     });
     expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+
+  it('uses normalized values throughout app create', async () => {
+    const { appCreateCommand } = await import('../src/commands/app/create.js');
+
+    await appCreateCommand.parseAsync(
+      [
+        '--name',
+        '  Test App  ',
+        '--endpoint',
+        '  https://example.com/api/messages  ',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith('fake-token', 'Test App');
+    expect(mockCreateManifestZip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botName: 'Test App',
+        endpoint: 'https://example.com/api/messages',
+      })
+    );
+    expect(mockCreateBot).toHaveBeenCalledWith({
+      botId: 'fake-client-id',
+      name: 'Test App',
+      endpoint: 'https://example.com/api/messages',
+    });
+    expect(jsonOutput).toEqual(
+      expect.objectContaining({
+        appName: 'Test App',
+        endpoint: 'https://example.com/api/messages',
+      })
+    );
+  });
+
+  it('uses normalized values throughout app update', async () => {
+    const { appUpdateCommand } = await import('../src/commands/app/update.js');
+
+    await appUpdateCommand.parseAsync(
+      [
+        'some-app-id',
+        '--name',
+        '  Trimmed Name  ',
+        '--endpoint',
+        '  https://example.com/api/messages  ',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockUpdateBot).toHaveBeenCalledWith(
+      'fake-token',
+      expect.objectContaining({
+        messagingEndpoint: 'https://example.com/api/messages',
+      })
+    );
+    expect(mockUpdateAppDetails).toHaveBeenCalledWith(
+      'fake-token',
+      'some-app-id',
+      { validDomains: ['*.botframework.com', 'example.com'] },
+      { autoBumpVersion: false }
+    );
+    expect(mockUpdateAppDetails).toHaveBeenCalledWith(
+      'fake-token',
+      'some-app-id',
+      { shortName: 'Trimmed Name' },
+      { autoBumpVersion: false }
+    );
+    expect(jsonOutput).toEqual(
+      expect.objectContaining({
+        updated: expect.objectContaining({
+          endpoint: 'https://example.com/api/messages',
+          shortName: 'Trimmed Name',
+        }),
+      })
+    );
   });
 });

--- a/packages/cli/tests/env-flag-json.test.ts
+++ b/packages/cli/tests/env-flag-json.test.ts
@@ -16,29 +16,33 @@ const FAKE_TEAMS_APP_ID = 'fake-teams-app-id';
 
 // ─── mocks (top-level, as vitest requires) ───────────────────────────
 
-vi.mock('../src/apps/index.js', () => ({
-  fetchApp: vi.fn().mockResolvedValue({
-    bots: [{ botId: 'fake-client-id' }],
-  }),
-  getAadAppByClientId: vi.fn().mockResolvedValue({
-    id: 'aad-object-id',
-    appId: 'fake-client-id',
-    displayName: 'TestAadApp',
-  }),
-  createClientSecret: vi.fn().mockResolvedValue({ secretText: 'fake-secret-text' }),
-  createAadAppViaTdp: vi.fn().mockResolvedValue({
-    id: 'aad-object-id',
-    appId: 'fake-client-id',
-    displayName: 'TestAadApp',
-  }),
-  createManifestZip: vi.fn().mockReturnValue(Buffer.from('fake-zip')),
-  importAppPackage: vi.fn().mockResolvedValue({ teamsAppId: 'fake-teams-app-id' }),
-  createTdpBotHandler: vi.fn().mockReturnValue({
-    createBot: vi.fn().mockResolvedValue(undefined),
-  }),
-  installLink: vi.fn((id: string, tenantId: string) => `https://teams.microsoft.com/l/app/${id}?installAppPackage=true&appTenantId=${tenantId}`),
-  portalLink: vi.fn((id: string) => `https://dev.teams.microsoft.com/apps/${id}`),
-}));
+vi.mock('../src/apps/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/apps/index.js')>();
+  return {
+    ...actual,
+    fetchApp: vi.fn().mockResolvedValue({
+      bots: [{ botId: 'fake-client-id' }],
+    }),
+    getAadAppByClientId: vi.fn().mockResolvedValue({
+      id: 'aad-object-id',
+      appId: 'fake-client-id',
+      displayName: 'TestAadApp',
+    }),
+    createClientSecret: vi.fn().mockResolvedValue({ secretText: 'fake-secret-text' }),
+    createAadAppViaTdp: vi.fn().mockResolvedValue({
+      id: 'aad-object-id',
+      appId: 'fake-client-id',
+      displayName: 'TestAadApp',
+    }),
+    createManifestZip: vi.fn().mockReturnValue(Buffer.from('fake-zip')),
+    importAppPackage: vi.fn().mockResolvedValue({ teamsAppId: 'fake-teams-app-id' }),
+    createTdpBotHandler: vi.fn().mockReturnValue({
+      createBot: vi.fn().mockResolvedValue(undefined),
+    }),
+    installLink: vi.fn((id: string, tenantId: string) => `https://teams.microsoft.com/l/app/${id}?installAppPackage=true&appTenantId=${tenantId}`),
+    portalLink: vi.fn((id: string) => `https://dev.teams.microsoft.com/apps/${id}`),
+  };
+});
 
 vi.mock('../src/auth/index.js', () => ({
   getAccount: vi.fn().mockResolvedValue({ tenantId: 'fake-tenant-id' }),

--- a/packages/cli/tests/manifest-validation.test.ts
+++ b/packages/cli/tests/manifest-validation.test.ts
@@ -80,4 +80,41 @@ describe('manifest upload shared validation', () => {
     ).rejects.toThrow('Short name must be 30 characters or less.');
     expect(mockUploadManifest).not.toHaveBeenCalled();
   });
+
+  it('allows interactive upload to proceed when metadata validation fails and auto-confirm is enabled', async () => {
+    const file = path.join(
+      os.tmpdir(),
+      `teams-cli-manifest-${Date.now()}-${Math.random().toString(36).slice(2)}.json`
+    );
+    files.push(file);
+
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        id: 'test-app-id',
+        version: '1.0.0',
+        manifestVersion: '1.25',
+        name: { short: 'Valid short name', full: 'Valid full name' },
+        description: { short: 'Short description' },
+        developer: {
+          name: 'Developer',
+          websiteUrl: 'https://example.com',
+          privacyUrl: 'https://example.com/privacy',
+          termsOfUseUrl: 'https://example.com/terms',
+        },
+      })
+    );
+
+    const { uploadManifestFromFile } = await import('../src/commands/app/manifest/actions.js');
+
+    await expect(uploadManifestFromFile('token', 'teams-app-id', file, false)).resolves.toEqual({
+      version: '1.0.0',
+      versionBumped: false,
+    });
+    expect(mockUploadManifest).toHaveBeenCalledWith(
+      'token',
+      'teams-app-id',
+      expect.stringContaining('"manifestVersion": "1.25"')
+    );
+  });
 });

--- a/packages/cli/tests/manifest-validation.test.ts
+++ b/packages/cli/tests/manifest-validation.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const mockUploadManifest = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../src/apps/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/apps/index.js')>();
+  return {
+    ...actual,
+    downloadAppPackage: vi.fn(),
+    uploadManifest: mockUploadManifest,
+  };
+});
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../src/utils/spinner.js', () => ({
+  createSilentSpinner: () => ({
+    start: vi.fn().mockReturnThis(),
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/utils/interactive.js', () => ({
+  isAutoConfirm: vi.fn().mockReturnValue(true),
+}));
+
+describe('manifest upload shared validation', () => {
+  const files: string[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const file of files) {
+      if (fs.existsSync(file)) fs.unlinkSync(file);
+    }
+    files.length = 0;
+  });
+
+  it('rejects manifest short names over 30 characters before upload', async () => {
+    const file = path.join(
+      os.tmpdir(),
+      `teams-cli-manifest-${Date.now()}-${Math.random().toString(36).slice(2)}.json`
+    );
+    files.push(file);
+
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        id: 'test-app-id',
+        version: '1.0.0',
+        manifestVersion: '1.25',
+        name: { short: 'x'.repeat(31), full: 'Valid full name' },
+        description: { short: 'Short description', full: 'Long description' },
+        developer: {
+          name: 'Developer',
+          websiteUrl: 'https://example.com',
+          privacyUrl: 'https://example.com/privacy',
+          termsOfUseUrl: 'https://example.com/terms',
+        },
+      })
+    );
+
+    const { uploadManifestFromFile } = await import('../src/commands/app/manifest/actions.js');
+
+    await expect(
+      uploadManifestFromFile('token', 'teams-app-id', file, true)
+    ).rejects.toThrow('Short name must be 30 characters or less.');
+    expect(mockUploadManifest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/tests/validation.test.ts
+++ b/packages/cli/tests/validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  appMetadataFromManifest,
+  validateAppMetadata,
+  validateAppMetadataField,
+} from '../src/apps/validation.js';
+
+describe('shared app metadata validation', () => {
+  it('rejects short name over 30 characters in create mode', () => {
+    const issues = validateAppMetadata(
+      {
+        shortName: 'x'.repeat(31),
+        longName: 'Valid Long Name',
+        shortDescription: 'Short description',
+        longDescription: 'Long description',
+        developerName: 'Developer',
+        websiteUrl: 'https://example.com',
+        privacyUrl: 'https://example.com/privacy',
+        termsOfUseUrl: 'https://example.com/terms',
+      },
+      'create'
+    );
+
+    expect(issues).toEqual([
+      {
+        field: 'shortName',
+        message: 'Short name must be 30 characters or less.',
+      },
+    ]);
+  });
+
+  it('skips undefined fields in update mode', () => {
+    const issues = validateAppMetadata({}, 'update');
+    expect(issues).toEqual([]);
+  });
+
+  it('rejects empty endpoint when explicitly provided in update mode', () => {
+    const issues = validateAppMetadata({ endpoint: '   ' }, 'update');
+    expect(issues).toEqual([
+      {
+        field: 'endpoint',
+        message: 'Endpoint URL cannot be empty.',
+      },
+    ]);
+  });
+
+  it('reuses the same field validation for edit prompts', () => {
+    expect(validateAppMetadataField('shortName', 'x'.repeat(31), 'manifest')).toBe(
+      'Short name must be 30 characters or less.'
+    );
+    expect(validateAppMetadataField('websiteUrl', 'http://example.com', 'manifest')).toBe(
+      'Website URL must start with https:// and include a domain.'
+    );
+  });
+
+  it('validates manifest metadata through the shared adapter', () => {
+    const issues = validateAppMetadata(
+      appMetadataFromManifest({
+        id: 'app-id',
+        manifestVersion: '1.25',
+        version: '1.0.0',
+        name: { short: 'x'.repeat(31), full: 'Valid full name' },
+        description: { short: 'Short description', full: 'Long description' },
+        developer: {
+          name: 'Developer',
+          websiteUrl: 'https://example.com',
+          privacyUrl: 'https://example.com/privacy',
+          termsOfUseUrl: 'https://example.com/terms',
+        },
+      }),
+      'manifest'
+    );
+
+    expect(issues[0]).toEqual({
+      field: 'shortName',
+      message: 'Short name must be 30 characters or less.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared app metadata validator for short name, descriptions, URLs, and endpoint checks
- reuse the shared validation in app create, app update, basic-info editing, and manifest upload
- add tests covering shared validation plus create/update and manifest validation flows

## Test plan
- cd packages/cli && npm run build
- cd packages/cli && npm test
