### PR TITLE
docs(sso-setup): add user-consent fields to oauth2PermissionScopes

### DIFF
--- a/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
+++ b/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
@@ -98,8 +98,10 @@ az rest \
       \"requestedAccessTokenVersion\": 2,
       \"oauth2PermissionScopes\": [{
         \"id\": \"$scopeId\",
-        \"adminConsentDescription\": \"Access as user\",
+        \"adminConsentDescription\": \"Allow the application to access the bot on behalf of the signed-in user.\",
         \"adminConsentDisplayName\": \"Access as user\",
+        \"userConsentDescription\": \"Allow the application to access the bot on your behalf.\",
+        \"userConsentDisplayName\": \"Access as user\",
         \"isEnabled\": true,
         \"type\": \"User\",
         \"value\": \"access_as_user\"
@@ -124,8 +126,10 @@ az rest \
     \"api\": {
       \"oauth2PermissionScopes\": [{
         \"id\": \"$scopeId\",
-        \"adminConsentDescription\": \"Access as user\",
+        \"adminConsentDescription\": \"Allow the application to access the bot on behalf of the signed-in user.\",
         \"adminConsentDisplayName\": \"Access as user\",
+        \"userConsentDescription\": \"Allow the application to access the bot on your behalf.\",
+        \"userConsentDisplayName\": \"Access as user\",
         \"isEnabled\": true,
         \"type\": \"User\",
         \"value\": \"access_as_user\"


### PR DESCRIPTION
## Summary

The Step 3 and Step 4 `oauth2PermissionScopes` payloads in `sso-setup.mdx` were missing two fields:

- `userConsentDescription`
- `userConsentDisplayName`

When the scope is `type: "User"` (which it is here), these fields are what end users see at the consent prompt. Without them, the prompt falls back to the admin text or default strings — a degraded UX.

This PR also expands `adminConsentDescription` from `"Access as user"` (which was identical to the display name) to an actual descriptive sentence.

## Context

[PR #2705](https://github.com/microsoft/teams-sdk/pull/2705) opened by @hggzm originally added these fields against the pre-rewrite `sso-setup.md`. That file was renamed to `sso-setup.mdx` and substantially rewritten in #2719, leaving #2705 with an unresolvable rebase conflict (modify/delete). This PR re-applies the contribution against the current file. Closes the gap; #2705 can be closed as superseded.

Refs: #2670, #2705
