### PR TITLE
Rename Teams CLI to Teams Developer CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "teams-sdk",
-      "description": "Create and manage Microsoft Teams bots using the Teams CLI. Covers bot application development (scaffolding bot code), infrastructure setup (bot registration, credentials), SSO configuration, and troubleshooting.",
+      "description": "Create and manage Microsoft Teams bots using the Teams Developer CLI. Covers bot application development (scaffolding bot code), infrastructure setup (bot registration, credentials), SSO configuration, and troubleshooting.",
       "category": "development",
       "source": "./plugins/teams-sdk",
       "homepage": "https://github.com/microsoft/teams-sdk"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find a set of open-source agent accelerator templates in the [Teams Agen
 
 ### Quick start
 
-The Teams SDK CLI makes it easy to bootstrap your first agent. First, install the CLI via NPM:
+The Teams Developer CLI makes it easy to bootstrap your first agent. First, install the CLI via NPM:
 
 ```sh
 npm install -g @microsoft/teams.cli@preview

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @microsoft/teams.cli
 
-CLI for managing Microsoft Teams apps.
+Teams Developer CLI for managing Microsoft Teams apps.
 
 ## Install
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams.cli",
   "version": "3.0.0-beta.0",
-  "description": "CLI for scaffolding Teams applications",
+  "description": "Teams Developer CLI for scaffolding Teams applications",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,8 +36,8 @@ function teamsColor(text: string): string {
 
 program
   .name('teams')
-  .description('CLI for managing Microsoft Teams apps')
-  .addHelpText('beforeAll', `${pc.bold(teamsColor('Teams CLI'))} ${pc.bold(pc.yellow('[Beta]'))}\n`)
+  .description('Teams Developer CLI for managing Microsoft Teams apps')
+  .addHelpText('beforeAll', `${pc.bold(teamsColor('Teams Developer CLI'))} ${pc.bold(pc.yellow('[Beta]'))}\n`)
   .version(version)
   .option('-v, --verbose', '[OPTIONAL] Enable verbose logging')
   .option('-y, --yes', '[OPTIONAL] Auto-confirm prompts (for CI/agent use)')

--- a/plugins/teams-sdk/.claude-plugin/plugin.json
+++ b/plugins/teams-sdk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "teams-sdk",
   "version": "1.2.0",
-  "description": "Create and manage Microsoft Teams bots using the Teams CLI. Covers bot application development (scaffolding bot code), infrastructure setup (bot registration, credentials), SSO configuration, and troubleshooting.",
+  "description": "Create and manage Microsoft Teams bots using the Teams Developer CLI. Covers bot application development (scaffolding bot code), infrastructure setup (bot registration, credentials), SSO configuration, and troubleshooting.",
   "author": {
     "name": "Microsoft"
   },

--- a/plugins/teams-sdk/.claude-plugin/plugin.json
+++ b/plugins/teams-sdk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "teams-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Create and manage Microsoft Teams bots using the Teams Developer CLI. Covers bot application development (scaffolding bot code), infrastructure setup (bot registration, credentials), SSO configuration, and troubleshooting.",
   "author": {
     "name": "Microsoft"

--- a/plugins/teams-sdk/skills/teams-dev/SKILL.md
+++ b/plugins/teams-sdk/skills/teams-dev/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: teams-dev
-description: Use this skill whenever the user mentions Microsoft Teams in a development context — whether they're building, integrating, configuring, debugging, or just asking questions. Covers bots, message extensions, embedded web apps, Adaptive Cards, dialogs, SSO, infrastructure, the Teams CLI/SDK, and general Teams platform queries. If the word "Teams" appears, err on the side of invoking this skill.
+description: Use this skill whenever the user mentions Microsoft Teams in a development context — whether they're building, integrating, configuring, debugging, or just asking questions. Covers bots, message extensions, embedded web apps, Adaptive Cards, dialogs, SSO, infrastructure, the Teams Developer CLI/SDK, and general Teams platform queries. If the word "Teams" appears, err on the side of invoking this skill.
 teams_cli_version: 3.0.0-preview.*
 ---
 
 # Teams Bot Development & Infrastructure
 
-This skill helps you create and manage Microsoft Teams bots using the Teams CLI. Covers both bot application development (creating bot code) and infrastructure management (bot registration, SSO, credentials).
+This skill helps you create and manage Microsoft Teams bots using the Teams Developer CLI. Covers both bot application development (creating bot code) and infrastructure management (bot registration, SSO, credentials).
 
 **IMPORTANT:** Use information and guidance provided within this skill and its reference guides. You may also use external public documentation only when it is explicitly linked from this skill or those guides. Do NOT perform arbitrary web searches or rely on unlisted external sources.
 
@@ -82,9 +82,9 @@ teams app update <teamsAppId> --endpoint "https://new-endpoint-url/api/messages"
 
 > **Note:** If the endpoint domain changed (not just the path), the CLI automatically updates `validDomains` in the manifest. This requires the user to reinstall the app in Teams for the change to take effect.
 
-### Update Teams CLI
+### Update Teams Developer CLI
 
-**Use case:** Update the Teams CLI to the latest version (recommended to stay current with new features and bug fixes)
+**Use case:** Update the Teams Developer CLI to the latest version (recommended to stay current with new features and bug fixes)
 
 **Command:**
 

--- a/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-app.md
+++ b/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-app.md
@@ -19,7 +19,7 @@ The Teams SDK handles the webhook plumbing, authentication, and message parsing 
 
 ## Prerequisites
 
-### Step 1: Verify Teams CLI Installation
+### Step 1: Verify Teams Developer CLI Installation
 
 ```bash
 teams --version

--- a/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-infra.md
+++ b/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-infra.md
@@ -8,9 +8,9 @@ This guide walks through setting up the infrastructure for a Microsoft Teams bot
 
 Before creating a Teams bot, verify these prerequisites:
 
-### Step 1: Check Teams CLI Installation
+### Step 1: Check Teams Developer CLI Installation
 
-Verify the Teams CLI is installed:
+Verify the Teams Developer CLI is installed:
 
 ```bash
 teams --version
@@ -20,7 +20,7 @@ teams --version
 
 **If not installed:**
 
-Install the Teams CLI using npm:
+Install the Teams Developer CLI using npm:
 
 ```bash
 npm install -g @microsoft/teams.cli@preview
@@ -30,7 +30,7 @@ npm install -g @microsoft/teams.cli@preview
 - Verify: Run `teams --version` to confirm installation
 - You should see the version number
 
-**Checkpoint:** Teams CLI is installed.
+**Checkpoint:** Teams Developer CLI is installed.
 
 ### Step 2: Check Authentication
 

--- a/teams.md/blog/2026-04-17-bring-your-agent-to-teams/index.md
+++ b/teams.md/blog/2026-04-17-bring-your-agent-to-teams/index.md
@@ -275,7 +275,7 @@ All three scenarios share the same registration step.
 
 Teams needs to reach your bot over HTTPS. For local development, [Dev tunnels](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/overview) is the recommended option — it's built into VS Code and the Azure CLI. [ngrok](https://ngrok.com) works too. Either way, you'll get a URL like `https://abc123.devtunnels.ms` that forwards to your local port.
 
-**Step 2: Register your bot using the Teams SDK CLI.**
+**Step 2: Register your bot using the Teams Developer CLI.**
 
 ```bash
 npm install -g @microsoft/teams.cli@preview

--- a/teams.md/blog/2026-04-28-teams-cli-preview/index.md
+++ b/teams.md/blog/2026-04-28-teams-cli-preview/index.md
@@ -16,7 +16,7 @@ authors:
     url: https://github.com/umangsehgal
     image_url: https://github.com/umangsehgal.png
 tags: [teams-sdk, cli, preview, announcement, skills]
-description: Introducing the teams-dev agent skill and the Teams CLI v3 Preview for registering and building Teams agents.
+description: Introducing the teams-dev agent skill and the Teams Developer CLI v3 Preview for registering and building Teams agents.
 ---
 
 :::info
@@ -49,7 +49,7 @@ The [`teams-dev` agent skill](/developer-tools/agent-skills) works with AI codin
 
 The skill uses the CLI under the hood to handle the full infrastructure workflow, from login to a working agent in Teams, and troubleshooting when something breaks. Beyond infrastructure, it also helps your coding agent write application logic following best practices from the Teams SDK documentation.
 
-## Under the Hood: The Teams CLI
+## Under the Hood: The Teams Developer CLI
 
 For developers who want direct control, the skill is powered by the next iteration of our CLI. Install it and log in:
 

--- a/teams.md/docs/cli/guides/user-authentication-setup.md
+++ b/teams.md/docs/cli/guides/user-authentication-setup.md
@@ -18,7 +18,7 @@ teams app bot migrate <appId> --subscription <id> --resource-group <your-resourc
 
 ### Required Tools and Authentication
 
-1. **Teams CLI** — Log in with `teams login`
+1. **Teams Developer CLI** — Log in with `teams login`
 2. **Azure CLI** — Install and authenticate with `az login`
 3. **Bot Context** — You'll need these values for all operations:
    - `botId` — Your bot's client ID

--- a/teams.md/docs/cli/index.md
+++ b/teams.md/docs/cli/index.md
@@ -1,15 +1,15 @@
 ---
-title: Teams CLI
+title: Teams Developer CLI
 slug: /
 ---
 
-# Teams CLI
+# Teams Developer CLI
 
 :::warning[Preview]
-The Teams CLI v3 is currently in **preview**. Commands, options, and behavior may change between releases.
+The Teams Developer CLI v3 is currently in **preview**. Commands, options, and behavior may change between releases.
 :::
 
-CLI for managing Microsoft Teams apps. Create, manage, and configure Teams apps from the command line.
+Teams Developer CLI for managing Microsoft Teams apps. Create, manage, and configure Teams apps from the command line.
 
 ## Features
 

--- a/teams.md/docs/main/developer-tools/README.md
+++ b/teams.md/docs/main/developer-tools/README.md
@@ -1,15 +1,15 @@
 ---
 sidebar_position: 4
-summary: Overview of developer tools in Teams SDK including the CLI for project management and DevTools for testing and debugging agents.
+summary: Overview of developer tools in Teams SDK including the Teams Developer CLI for project management and DevTools for testing and debugging agents.
 ---
 
 # Developer Tools
 
-One of the main motivations for Teams SDK is to provide excellent tools that simplify and speed up building and testing agents. Because of this, we created the CLI for speedy agent initiation and project management, and DevTools as an accessible way to test your agent's behavior without jumping through deployment hoops. DevTools also provides crucial insight on activity payloads on the Activities page.
+One of the main motivations for Teams SDK is to provide excellent tools that simplify and speed up building and testing agents. Because of this, we created the Teams Developer CLI for speedy agent initiation and project management, and DevTools as an accessible way to test your agent's behavior without jumping through deployment hoops. DevTools also provides crucial insight on activity payloads on the Activities page.
 
 Learn more about the developer tools that come with Teams SDK.
 
-1. [Teams CLI](./cli)
+1. [Teams Developer CLI](./cli)
 2. [Agent Skills](./agent-skills) — give AI coding assistants context for Teams development
 3. [llms.txt](./llms-txt) — documentation files optimized for AI coding assistants
 4. [DevTools](./devtools)

--- a/teams.md/docs/main/developer-tools/agent-skills.md
+++ b/teams.md/docs/main/developer-tools/agent-skills.md
@@ -99,7 +99,7 @@ You: Help me create a Teams bot that echoes what I'm saying back to me
 
 Agent: I'll create an echo bot for you.
 
-       [checks teams developer CLI installation and authentication]
+       [checks Teams Developer CLI installation and authentication]
        [creates development tunnel: https://abc123.ngrok.io]
        [runs teams app create with endpoint]
        ✓ Bot registered, credentials saved to .env

--- a/teams.md/docs/main/developer-tools/agent-skills.md
+++ b/teams.md/docs/main/developer-tools/agent-skills.md
@@ -5,7 +5,7 @@ summary: Give AI coding assistants (Claude Code, Cursor, GitHub Copilot) relevan
 
 # Agent Skills
 
-[Agent Skills](https://aka.ms/teams-agent-skills) give AI coding assistants relevant context for specific development tasks. The `teams-dev` skill is the go-to agent skill for Teams bot development. It gives AI coding assistants (Claude Code, Cursor, GitHub Copilot, and others) relevant context to assist in developing Teams bots and use the Teams CLI to manage your bot infrastructure. Instead of running CLI commands manually, you describe what you want and your AI assistant handles the rest.
+[Agent Skills](https://aka.ms/teams-agent-skills) give AI coding assistants relevant context for specific development tasks. The `teams-dev` skill is the go-to agent skill for Teams bot development. It gives AI coding assistants (Claude Code, Cursor, GitHub Copilot, and others) relevant context to assist in developing Teams bots and use the Teams Developer CLI to manage your bot infrastructure. Instead of running CLI commands manually, you describe what you want and your AI assistant handles the rest.
 
 :::note Alternative: Use llms.txt directly
 If you'd rather not install a skill, you can provide the same context by pointing your AI tool to the llms.txt URL:
@@ -99,7 +99,7 @@ You: Help me create a Teams bot that echoes what I'm saying back to me
 
 Agent: I'll create an echo bot for you.
 
-       [checks teams CLI installation and authentication]
+       [checks teams developer CLI installation and authentication]
        [creates development tunnel: https://abc123.ngrok.io]
        [runs teams app create with endpoint]
        ✓ Bot registered, credentials saved to .env
@@ -116,7 +116,7 @@ Agent: I'll create an echo bot for you.
 
 ## Requirements
 
-- Teams CLI installed (`npm install -g @microsoft/teams.cli@preview`)
+- Teams Developer CLI installed (`npm install -g @microsoft/teams.cli@preview`)
 - Node.js 20 or later
 - Microsoft 365 account with sideloading enabled
 

--- a/teams.md/docs/main/developer-tools/cli.md
+++ b/teams.md/docs/main/developer-tools/cli.md
@@ -2,8 +2,8 @@
 sidebar_position: 1
 ---
 
-# Teams CLI
+# Teams Developer CLI
 
-The Teams CLI documentation has moved to its own section.
+The Teams Developer CLI documentation has moved to its own section.
 
 **[Go to CLI Documentation](/cli)**

--- a/teams.md/docs/main/get-started/quickstart-build.md
+++ b/teams.md/docs/main/get-started/quickstart-build.md
@@ -141,4 +141,4 @@ Continue with the [Python guide](/python/getting-started) for events, sending me
 
 - **Essentials** — events, activities, sending messages, authentication: [TypeScript](/typescript/essentials) · [C#](/csharp/essentials) · [Python](/python/essentials)
 - **In-depth guides** — Adaptive Cards, AI, MCP, dialogs, tabs, and more: [TypeScript](/typescript/in-depth-guides) · [C#](/csharp/in-depth-guides) · [Python](/python/in-depth-guides)
-- [Quickstart: Register your app](./quickstart-register) — set up bot infrastructure with the Teams CLI
+- [Quickstart: Register your app](./quickstart-register) — set up bot infrastructure with the Teams Developer CLI

--- a/teams.md/docs/main/get-started/quickstart-register.md
+++ b/teams.md/docs/main/get-started/quickstart-register.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Quickstart: Register your app"
-summary: Register a Teams app and bot using the Teams CLI, then sideload into Teams.
+summary: Register a Teams app and bot using the Teams Developer CLI, then sideload into Teams.
 ---
 
 # Quickstart: Register your app
 
-Register a Teams app and its bot infrastructure with the [Teams CLI](/cli/) (`@microsoft/teams.cli`). At the end you'll have a running agent installed in Teams.
+Register a Teams app and its bot infrastructure with the [Teams Developer CLI](/cli/) (`@microsoft/teams.cli`). At the end you'll have a running agent installed in Teams.
 
 If you don't have an agent yet, step 3 scaffolds one using the Teams SDK. If you already have a server, skip step 3 and pass your endpoint to step 4.
 

--- a/teams.md/docs/main/teams/azure-configuration.mdx
+++ b/teams.md/docs/main/teams/azure-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-summary: Manually create the Entra App Registration and Azure Bot Service resource for cases where the Teams CLI is not the right fit.
+summary: Manually create the Entra App Registration and Azure Bot Service resource for cases where the Teams Developer CLI is not the right fit.
 sidebar_class_name: 'sidebar-hidden'
 ---
 
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 This page walks through creating the Entra App Registration and Azure Bot Service resource by hand. As described in [Core Concepts](./core-concepts), those two pieces are what every Azure-managed Teams bot needs.
 
-:::tip Most readers should use the Teams CLI instead
+:::tip Most readers should use the Teams Developer CLI instead
 For almost everything, `teams app create --azure --subscription <id> --resource-group <rg>` is the right answer — it provisions the Entra app, the Azure Bot resource, the Teams channel, and writes credentials in one command. See the [Quickstart: Register your app](../get-started/quickstart-register).
 
 Or use the [`teams-dev` agent skill](/developer-tools/agent-skills) — tell your AI assistant to set up your Teams bot and it handles everything automatically.
@@ -138,6 +138,6 @@ For C# projects, write the credentials to `appsettings.json` under a `Teams` sec
 
 ## Resources
 
-- [Quickstart: Register your app](../get-started/quickstart-register) — automated setup with the Teams CLI
-- [Teams CLI: app create](/cli/commands/app/create)
+- [Quickstart: Register your app](../get-started/quickstart-register) — automated setup with the Teams Developer CLI
+- [Teams Developer CLI: app create](/cli/commands/app/create)
 - [Teams App Publishing overview](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview)

--- a/teams.md/docs/main/teams/core-concepts.md
+++ b/teams.md/docs/main/teams/core-concepts.md
@@ -5,7 +5,7 @@ summary: Understand Teams app architecture including app registration, Azure Bot
 
 # Teams Core Concepts
 
-Running an agent on Teams involves several moving pieces — an app registration, an Azure or Teams-managed bot, a public messaging endpoint, and a sideloaded app package. Understanding these components helps you debug and deploy your agent confidently. The [Teams CLI](/cli/) automates all of them with a single `teams app create` command, but it's worth knowing what it sets up underneath.
+Running an agent on Teams involves several moving pieces — an app registration, an Azure or Teams-managed bot, a public messaging endpoint, and a sideloaded app package. Understanding these components helps you debug and deploy your agent confidently. The [Teams Developer CLI](/cli/) automates all of them with a single `teams app create` command, but it's worth knowing what it sets up underneath.
 
 ## Basic Flow
 
@@ -97,7 +97,7 @@ Before your agent can interact with Teams, it needs to be properly registered an
 
 - Creates an App ID (i.e. Client ID) in the Teams platform
 - Sets up a bot registration with the Bot Framework
-- Creates a client secret that your agent can use to authenticate to send and receive messages. The [Teams CLI](/cli/) writes this value to `.env` (or `appsettings.json` for C#) automatically when you run `teams app create`.
+- Creates a client secret that your agent can use to authenticate to send and receive messages. The [Teams Developer CLI](/cli/) writes this value to `.env` (or `appsettings.json` for C#) automatically when you run `teams app create`.
 
 ### Azure Bot
 

--- a/teams.md/docs/main/teams/enabling-in-copilot.md
+++ b/teams.md/docs/main/teams/enabling-in-copilot.md
@@ -7,7 +7,7 @@ summary: Learn how to enable your Teams app to work in M365 Copilot by updating 
 
 If you've built a Teams app or agent and want to make it available in M365 Copilot, you can do so with a single CLI command that handles the manifest update automatically.
 
-## Using the Teams CLI
+## Using the Teams Developer CLI
 
 ```bash
 teams app update <appId> --scopes personal,team,copilot
@@ -34,7 +34,7 @@ Once the updated app is installed:
 
 ## Manual Manifest Editing
 
-If you are not using the Teams CLI, you can update the manifest by hand. Add the following to your `manifest.json`:
+If you are not using the Teams Developer CLI, you can update the manifest by hand. Add the following to your `manifest.json`:
 
 ```json
 "bots": [

--- a/teams.md/docs/main/teams/manifest.md
+++ b/teams.md/docs/main/teams/manifest.md
@@ -17,7 +17,7 @@ Sideloading is the ability to install and test your app before it is published t
 
 To sideload, ensure the manifest includes all required information (such as the app ID, tenant details, and permissions). Place the manifest and icons at the root of a zip file.
 
-The [Teams CLI](/cli/) handles manifest scaffolding, validation, and updates as part of `teams app create`. To work with the manifest directly:
+The [Teams Developer CLI](/cli/) handles manifest scaffolding, validation, and updates as part of `teams app create`. To work with the manifest directly:
 
 - [`teams app manifest download`](/cli/commands/app/manifest-download) — pull the current manifest from a registered app
 - [`teams app manifest upload`](/cli/commands/app/manifest-upload) — apply a local manifest.json to an existing app

--- a/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
+++ b/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
@@ -19,7 +19,7 @@ The [`teams-dev` skill](/developer-tools/agent-skills) can orchestrate the full 
 Before starting SSO configuration, ensure you have:
 
 - An **Azure-managed** Azure Bot Service resource and its associated Entra App Registration (Application ID / Client ID and Tenant ID).
-- To setup using CLIs: the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and the [Teams CLI](/cli/getting-started/installation) installed and authenticated.
+- To setup using CLIs: the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and the [Teams Developer CLI](/cli/getting-started/installation) installed and authenticated.
 
   :::note CLI users: migrate first if your bot is Teams-managed
   SSO requires an Azure-managed bot because the OAuth connection lives in Azure Bot Service. If you registered with `teams app create` (default Teams-managed), migrate your bot first:
@@ -53,7 +53,7 @@ You need an Entra ID App Registration to configure the OAuth Connection in Azure
 </TabItem>
 <TabItem value="cli" label="Azure CLI">
 
-The full SSO setup involves several steps the Teams CLI doesn't handle directly (creating the `access_as_user` scope, pre-authorizing Teams clients, configuring the OAuth connection in Azure Bot Service, updating `webApplicationInfo` in the manifest). The [`teams-dev` skill](/developer-tools/agent-skills) orchestrates all of this for you — install it in your AI coding assistant and say *"set up SSO for my Teams bot"*.
+The full SSO setup involves several steps the Teams Developer CLI doesn't handle directly (creating the `access_as_user` scope, pre-authorizing Teams clients, configuring the OAuth connection in Azure Bot Service, updating `webApplicationInfo` in the manifest). The [`teams-dev` skill](/developer-tools/agent-skills) orchestrates all of this for you — install it in your AI coding assistant and say *"set up SSO for my Teams bot"*.
 
 ### Step 1: Look Up the AAD App Object ID
 
@@ -212,10 +212,10 @@ Add `*.botframework.com` to `validDomains` and add the `webApplicationInfo` sect
 ```
 
 </TabItem>
-<TabItem value="cli" label="Teams CLI">
+<TabItem value="cli" label="Teams Developer CLI">
 
 :::note
-This option is available if your app was created using the Teams CLI.
+This option is available if your app was created using the Teams Developer CLI.
 :::
 
 You can set the `webApplicationInfo` fields directly without downloading and re-uploading the manifest:

--- a/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
+++ b/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
@@ -19,7 +19,7 @@ The [`teams-dev` skill](/developer-tools/agent-skills) can orchestrate the full 
 Before starting SSO configuration, ensure you have:
 
 - An **Azure-managed** Azure Bot Service resource and its associated Entra App Registration (Application ID / Client ID and Tenant ID).
-- To setup using CLIs: the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and the [Teams Developer CLI](/cli/getting-started/installation) installed and authenticated.
+- To set up using CLIs: the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and the [Teams Developer CLI](/cli/getting-started/installation) installed and authenticated.
 
   :::note CLI users: migrate first if your bot is Teams-managed
   SSO requires an Azure-managed bot because the OAuth connection lives in Azure Bot Service. If you registered with `teams app create` (default Teams-managed), migrate your bot first:
@@ -192,8 +192,8 @@ To include additional permissions (Graph, SharePoint, etc.), space-delimit them:
 
 The Teams application manifest needs to be updated to include `webApplicationInfo` with the `Application Id` and `Application ID URI`.
 
-<Tabs groupId="sso-setup">
-<TabItem value="portal" label="Manifest JSON">
+<Tabs groupId="sso-manifest">
+<TabItem value="manifest" label="Manifest JSON">
 
 Add `*.botframework.com` to `validDomains` and add the `webApplicationInfo` section to your `manifest.json`:
 
@@ -212,7 +212,7 @@ Add `*.botframework.com` to `validDomains` and add the `webApplicationInfo` sect
 ```
 
 </TabItem>
-<TabItem value="cli" label="Teams Developer CLI">
+<TabItem value="teams-cli" label="Teams Developer CLI">
 
 :::note
 This option is available if your app was created using the Teams Developer CLI.

--- a/teams.md/docs/main/welcome.mdx
+++ b/teams.md/docs/main/welcome.mdx
@@ -12,7 +12,7 @@ Teams SDK is a suite of packages for building agents and applications on Microso
 
 ## Get started
 
-The fastest path is the [Teams CLI](/cli/) (in Preview):
+The fastest path is the [Teams Developer CLI](/cli/) (in Preview):
 
 1. **[Register your app](/get-started/quickstart-register)** — install the CLI, register a bot, sideload into Teams.
 2. **[Build your first bot](/get-started/quickstart-build)** — write a message handler in TypeScript, C#, or Python.

--- a/teams.md/src/components/include/in-depth-guides/message-extensions/settings/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/message-extensions/settings/typescript.incl.md
@@ -90,7 +90,7 @@ app.on('message.ext.query-settings-url', async ({ activity }) => {
           {
             type: 'openUrl',
             title: 'Settings',
-            // ensure BOT_ENDPOINT is set in your .env (Teams CLI does not populate it by default).
+            // ensure BOT_ENDPOINT is set in your .env (Teams Developer CLI does not populate it by default).
             value: `${process.env.BOT_ENDPOINT}/tabs/settings?selectedOption=${escapedSelectedOption}`,
           },
         ],

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
@@ -1,6 +1,6 @@
 <!-- create-project -->
 
-The Teams CLI doesn't ship a `graph` template for C# yet (tracked in [microsoft/teams-sdk#2736](https://github.com/microsoft/teams-sdk/issues/2736)). Scaffold the `echo` template and add the OAuth wiring shown below by hand:
+The Teams Developer CLI doesn't ship a `graph` template for C# yet (tracked in [microsoft/teams-sdk#2736](https://github.com/microsoft/teams-sdk/issues/2736)). Scaffold the `echo` template and add the OAuth wiring shown below by hand:
 
 ```sh
 teams project new csharp oauth-app

--- a/teams.md/src/pages/templates/getting-started/code-basics.mdx
+++ b/teams.md/src/pages/templates/getting-started/code-basics.mdx
@@ -59,7 +59,7 @@ This code initializes your application server and, when configured for Teams, al
 
 ## Next Steps
 
-Now that you understand the basic structure of your Teams application, you're ready to [run it in Teams](running-in-teams). You'll use the Teams CLI to register your bot and sideload it into Teams.
+Now that you understand the basic structure of your Teams application, you're ready to [run it in Teams](running-in-teams). You'll use the Teams Developer CLI to register your bot and sideload it into Teams.
 
 After that, you can:
 

--- a/teams.md/src/pages/templates/getting-started/quickstart.mdx
+++ b/teams.md/src/pages/templates/getting-started/quickstart.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 1
 sidebar_label: Quickstart
 title: Quickstart
-summary: Quick start guide for Teams SDK using the Teams CLI to create and run your first agent.
+summary: Quick start guide for Teams SDK using the Teams Developer CLI to create and run your first agent.
 ---
 
 # Quickstart
 
-Get started with Teams SDK quickly using the Teams CLI.
+Get started with Teams SDK quickly using the Teams Developer CLI.
 
 ## Set up a new project
 
@@ -17,7 +17,7 @@ Get started with Teams SDK quickly using the Teams CLI.
 
 ## Instructions
 
-### Install the Teams CLI
+### Install the Teams Developer CLI
 
 Install `teams` globally:
 
@@ -27,7 +27,7 @@ teams --version
 ```
 
 :::info
-The [Teams CLI](/cli/) is the command-line tool for scaffolding, registering, and managing Teams apps. It's currently in Preview.
+The [Teams Developer CLI](/cli/) is the command-line tool for scaffolding, registering, and managing Teams apps. It's currently in Preview.
 :::
 
 ## Creating Your First Agent
@@ -74,6 +74,6 @@ Otherwise, if you want to run your agent in Teams, you can check out the [Runnin
 
 ## Resources
 
-- [Teams CLI documentation](/cli/)
+- [Teams Developer CLI documentation](/cli/)
 - [Teams manifest schema](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema)
 - [Teams sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload)

--- a/teams.md/src/pages/templates/getting-started/running-in-teams/README.mdx
+++ b/teams.md/src/pages/templates/getting-started/running-in-teams/README.mdx
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 3
 title: 'Running in Teams'
-summary: Register and sideload your locally running agent into Microsoft Teams using the Teams CLI.
+summary: Register and sideload your locally running agent into Microsoft Teams using the Teams Developer CLI.
 llms: ignore
 ---
 
 # Running In Teams
 
-Now that you completed [the quickstart](../quickstart) and your agent is running locally, let's install it in Microsoft Teams. The fastest path is the [Teams CLI](/cli/).
+Now that you completed [the quickstart](../quickstart) and your agent is running locally, let's install it in Microsoft Teams. The fastest path is the [Teams Developer CLI](/cli/).
 
 ## Prerequisites
 
@@ -79,6 +79,6 @@ Continue with [essential concepts](../../essentials) to build more complex agent
 
 ## Resources
 
-- [Teams CLI](/cli/)
+- [Teams Developer CLI](/cli/)
 - [Quickstart: Register your app](/get-started/quickstart-register)
 - [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview)

--- a/teams.md/src/pages/templates/in-depth-guides/tabs/getting-started.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/tabs/getting-started.mdx
@@ -8,11 +8,11 @@ suppressLanguageIncludeWarning: true
 
 # Getting started
 
-To use this package, you can either set up a new project using the Teams CLI, or add it to an existing tab app project.
+To use this package, you can either set up a new project using the Teams Developer CLI, or add it to an existing tab app project.
 
 ## Setting up a new project
 
-The Teams CLI ships a `tab` template that scaffolds a new tab app with a callable remote function. First install the Teams CLI as outlined in the [Quickstart](../../getting-started/quickstart) guide, then create the app:
+The Teams Developer CLI ships a `tab` template that scaffolds a new tab app with a callable remote function. First install the Teams Developer CLI as outlined in the [Quickstart](../../getting-started/quickstart) guide, then create the app:
 
 ```sh
 teams project new typescript my-first-tab-app --template tab


### PR DESCRIPTION
## Summary
Product rename: **Teams CLI** → **Teams Developer CLI** across the repo.

What got touched:
- **Package**: `packages/cli/package.json` description + the `Teams Developer CLI [Beta]` help banner in `packages/cli/src/index.ts`. (The npm name `@microsoft/teams.cli` is left alone — renaming that is a whole different beast.)
- **Docs**: every "Teams CLI" mention across `teams.md/docs/**`, `teams.md/src/**`, and `teams.md/static/llms_docs/**`.
- **Blog**: `2026-04-28-teams-cli-preview/index.md` body. Slug + folder kept the same to avoid breaking the live URL.
- **Plugin / skill**: `plugins/teams-sdk/**`, `.claude-plugin/marketplace.json`, root `README.md`, `packages/cli/README.md`.

Left intentionally untouched:
- Internal identifiers (`teams-cli` keychain serviceName, envPaths, USER_AGENT, tmpdir prefix, test resource group defaults) — changing these would invalidate caches/configs.
- Unrelated terms like "Teams client", `@microsoft/teams.client`, "Teams Developer Portal".
- Generic "the CLI" phrases that read fine in context.

## Test plan
- `npm run build --workspace=@microsoft/teams.cli` — confirm clean build
- Run `node packages/cli/dist/index.js --help` and check the banner says `Teams Developer CLI [Beta]`
- Skim the docs site preview to confirm headings/links still resolve