### PR TITLE
fix(cli): surface real cause when discoverAzureBot fails

### DIFF
--- a/packages/cli/src/apps/bot-handler.ts
+++ b/packages/cli/src/apps/bot-handler.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { createSilentSpinner } from '../utils/spinner.js';
 import { registerBot, fetchBot, updateBot } from './tdp.js';
 import { runAz } from '../utils/az.js';
+import { CliError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
 
 export interface CreateBotOpts {
@@ -237,9 +238,15 @@ export async function discoverAzureBot(
       tenantId: account.tenantId,
       name: bot.name,
     };
-  } catch {
+  } catch (error) {
     spinner.stop();
-    return null;
+    const err = error as { stderr?: unknown; message?: unknown };
+    const stderr = typeof err.stderr === 'string' ? err.stderr.trim() : '';
+    const message =
+      stderr ||
+      (typeof err.message === 'string' && err.message) ||
+      'Unknown error discovering Azure bot.';
+    throw new CliError('API_ARM_ERROR', `Failed to discover Azure bot: ${message}`);
   }
 }
 
@@ -261,19 +268,15 @@ function subscriptionFromArmId(id: string): string | undefined {
 
 /** Fast path: assume Azure resource name == MicrosoftAppId. */
 async function findBotByName(botId: string): Promise<BotResource | null> {
-  try {
-    const results = await runAz<BotResource[]>([
-      'resource',
-      'list',
-      '--resource-type',
-      'Microsoft.BotService/botServices',
-      '--name',
-      botId,
-    ]);
-    return results[0] ?? null;
-  } catch {
-    return null;
-  }
+  const results = await runAz<BotResource[]>([
+    'resource',
+    'list',
+    '--resource-type',
+    'Microsoft.BotService/botServices',
+    '--name',
+    botId,
+  ]);
+  return results[0] ?? null;
 }
 
 /**
@@ -322,35 +325,31 @@ async function findBotByMsaAppIdViaGraph(botId: string): Promise<BotResource | n
 }
 
 async function findBotByMsaAppIdViaList(botId: string): Promise<BotResource | null> {
-  try {
-    const all = await runAz<BotResource[]>([
-      'resource',
-      'list',
-      '--resource-type',
-      'Microsoft.BotService/botServices',
-    ]);
-    // Bounded concurrency + early exit: walk the list in small batches and
-    // stop as soon as a match is found. Avoids spawning N `az` processes at
-    // once for users with many bots.
-    const BATCH = 5;
-    for (let i = 0; i < all.length; i += BATCH) {
-      const batch = all.slice(i, i + BATCH);
-      const results = await Promise.all(
-        batch.map(async (bot) => {
-          try {
-            const full = await runAz<BotResource>(['resource', 'show', '--ids', bot.id]);
-            return { ...bot, properties: full.properties };
-          } catch {
-            return null;
-          }
-        })
-      );
-      for (const b of results) {
-        if (b && b.properties?.msaAppId === botId) return b;
-      }
+  const all = await runAz<BotResource[]>([
+    'resource',
+    'list',
+    '--resource-type',
+    'Microsoft.BotService/botServices',
+  ]);
+  // Bounded concurrency + early exit: walk the list in small batches and
+  // stop as soon as a match is found. Avoids spawning N `az` processes at
+  // once for users with many bots.
+  const BATCH = 5;
+  for (let i = 0; i < all.length; i += BATCH) {
+    const batch = all.slice(i, i + BATCH);
+    const results = await Promise.all(
+      batch.map(async (bot) => {
+        try {
+          const full = await runAz<BotResource>(['resource', 'show', '--ids', bot.id]);
+          return { ...bot, properties: full.properties };
+        } catch {
+          return null;
+        }
+      })
+    );
+    for (const b of results) {
+      if (b && b.properties?.msaAppId === botId) return b;
     }
-    return null;
-  } catch {
-    return null;
   }
+  return null;
 }

--- a/packages/cli/src/commands/app/doctor.ts
+++ b/packages/cli/src/commands/app/doctor.ts
@@ -217,7 +217,18 @@ async function checkBotRegistration(
         detail: 'Run az login',
       });
     } else {
-      azure = await discoverAzureBot(botId, silent);
+      let discoveryFailed = false;
+      try {
+        azure = await discoverAzureBot(botId, silent);
+      } catch (e) {
+        discoveryFailed = true;
+        results.push({
+          category: cat,
+          label: 'Could not discover Azure bot',
+          status: 'fail',
+          detail: e instanceof Error ? e.message : undefined,
+        });
+      }
       if (azure) {
         results.push({
           category: cat,
@@ -288,7 +299,7 @@ async function checkBotRegistration(
             detail: e instanceof Error ? e.message : undefined,
           });
         }
-      } else {
+      } else if (!discoveryFailed) {
         results.push({
           category: cat,
           label: 'Azure bot not found',

--- a/packages/cli/tests/discover-azure-bot.test.ts
+++ b/packages/cli/tests/discover-azure-bot.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CliError } from '../src/utils/errors.js';
 
 const mockRunAz = vi.fn();
 
@@ -215,11 +216,51 @@ describe('discoverAzureBot', () => {
     expect(ctx).toBeNull();
   });
 
-  it('returns null when az CLI throws', async () => {
-    mockRunAz.mockRejectedValue(new Error('az exploded'));
+  it('throws CliError when the fast-path az call fails (no silent null)', async () => {
+    const azError = Object.assign(new Error('Command failed: az resource list ...'), {
+      stderr: "ERROR: Please run 'az login' to setup account.",
+      code: 1,
+    });
+    mockRunAz.mockRejectedValueOnce(azError);
 
-    const ctx = await discoverAzureBot(BOT_ID, true);
+    await expect(discoverAzureBot(BOT_ID, true)).rejects.toBeInstanceOf(CliError);
+  });
 
-    expect(ctx).toBeNull();
+  it('preserves the underlying stderr in the thrown error message', async () => {
+    const azError = Object.assign(new Error('Command failed: az resource list ...'), {
+      stderr: "ERROR: Please run 'az login' to setup account.",
+      code: 1,
+    });
+    mockRunAz.mockRejectedValueOnce(azError);
+
+    try {
+      await discoverAzureBot(BOT_ID, true);
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CliError);
+      const cliError = error as CliError;
+      expect(cliError.code).toBe('API_ARM_ERROR');
+      expect(cliError.message).toContain('az login');
+    }
+  });
+
+  it('throws when the list-fallback az call fails (graph caught, list propagates)', async () => {
+    mockRunAz.mockImplementation((args: string[]) => {
+      if (args[0] === 'resource' && args[1] === 'list' && args.includes('--name')) {
+        return Promise.resolve([]); // fast-path: empty, fall through
+      }
+      if (args[0] === 'graph') return Promise.reject(new Error('extension blocked'));
+      if (args[0] === 'resource' && args[1] === 'list') {
+        return Promise.reject(
+          Object.assign(new Error('Command failed'), {
+            stderr: 'ERROR: (AuthorizationFailed) ...',
+            code: 1,
+          })
+        );
+      }
+      throw new Error(`unexpected az call: ${args.join(' ')}`);
+    });
+
+    await expect(discoverAzureBot(BOT_ID, true)).rejects.toBeInstanceOf(CliError);
   });
 });


### PR DESCRIPTION
Fixes #2830.

`discoverAzureBot` and its helpers collapsed every az failure into `null`, indistinguishable from a real "bot not found." `app update --json` then returned a misleading `NOT_FOUND_AZURE_BOT`; under `--yes`, an agent could try to recreate a bot that already exists but couldn't be read.

Rebased on top of #2825's fallback chain. Only the bug-shaped catches are removed; the two structural ones are kept:

- `findBotByName` outer catch — **removed** (pure suppression).
- `findBotByMsaAppIdViaList` outer catch — **removed** (pure suppression).
- `findBotByMsaAppIdViaList` per-bot catch — **kept** (per-element resilience inside `Promise.all`).
- `findBotByMsaAppIdViaGraph` outer catch — **kept** (intentional fallback signal: routes "graph extension unavailable" to the list path; pinned by #2825's tests).

`discoverAzureBot` rewraps the surviving catch as `CliError('API_ARM_ERROR', 'Failed to discover Azure bot: <stderr>')` — preferring `error.stderr` over `error.message` so the real az diagnostic surfaces instead of `Command failed: cmd /c az.cmd ...`. `app doctor` wraps the call so a throw becomes a `fail` entry instead of terminating the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)