### PR TITLE
docs(blog): add Python SDK GA devblogs entry

### DIFF
--- a/teams.md/blog/2026-05-01-python-support-for-the-microsoft-teams-sdk-is-now-/index.mdx
+++ b/teams.md/blog/2026-05-01-python-support-for-the-microsoft-teams-sdk-is-now-/index.mdx
@@ -1,0 +1,15 @@
+---
+slug: python-support-for-the-microsoft-teams-sdk-is-now-generally-available
+title: "Python support for the Microsoft Teams SDK is now generally available"
+external_url: https://devblogs.microsoft.com/microsoft365dev/python-support-for-the-microsoft-teams-sdk-is-now-generally-available/
+date: 2026-05-01
+authors:
+  - name: Microsoft 365 Dev
+    title: Microsoft
+tags: [teams-sdk, python, announcement, teams-ai-library]
+description: Python developers can now build Teams-native apps and agents using the same SDK surface that powers modern Teams experiences across our TypeScript and .NET stacks.
+---
+
+import ExternalRedirect from '@site/src/components/ExternalRedirect';
+
+<ExternalRedirect to="https://devblogs.microsoft.com/microsoft365dev/python-support-for-the-microsoft-teams-sdk-is-now-generally-available/" />

--- a/teams.md/src/data/externalBlogUrls.ts
+++ b/teams.md/src/data/externalBlogUrls.ts
@@ -8,4 +8,5 @@ export const externalBlogUrls: Record<string, string> = {
     'the-present-and-future-of-copilot-extensibility-top-10-takeaways-from-build-2024': 'https://devblogs.microsoft.com/microsoft365dev/the-present-and-future-of-copilot-extensibility-top-10-takeaways-from-build-2024/',
     'join-the-microsoft-365-copilot-developer-camp': 'https://devblogs.microsoft.com/microsoft365dev/join-the-microsoft-365-copilot-developer-camp/',
     'announcing-the-updated-teams-ai-library-and-mcp-support': 'https://devblogs.microsoft.com/microsoft365dev/announcing-the-updated-teams-ai-library-and-mcp-support/',
+    'python-support-for-the-microsoft-teams-sdk-is-now-generally-available': 'https://devblogs.microsoft.com/microsoft365dev/python-support-for-the-microsoft-teams-sdk-is-now-generally-available/',
 };


### PR DESCRIPTION
## Summary
- Adds an external-redirect entry for [Python support for the Microsoft Teams SDK is now generally available](https://devblogs.microsoft.com/microsoft365dev/python-support-for-the-microsoft-teams-sdk-is-now-generally-available/) so it shows up in the docs blog listing
- Mirrors the format used by the existing Nov 18 entry and follows `BLOGGING.md`
- The auto-sync script (`scripts/sync-devblogs.ts`) didn't catch this post because it isn't tagged `teams-ai-library` on devblogs

## Test plan
- [ ] `npm run docs:dev` shows the post in `/teams-sdk/blog`
- [ ] Clicking through redirects to the devblogs URL
- [ ] `npx tsx scripts/sync-devblogs.ts --dry-run` reports no new posts to add (i.e. no duplicate would be created on next sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)