### PR TITLE
Lead announcement post with what changes for the reader

### DIFF
--- a/teams.md/blog/2026-05-12-announcing-teams-sdk-dotnet-2-1-preview/index.mdx
+++ b/teams.md/blog/2026-05-12-announcing-teams-sdk-dotnet-2-1-preview/index.mdx
@@ -11,7 +11,20 @@ tags: [teams-sdk, dotnet, preview, announcement]
 description: Teams SDK for .NET 2.1 preview brings native ASP.NET Core integration, typed activity routing, and agentic identity support to Teams bot development.
 ---
 
-Teams SDK for .NET 2.1 preview is here. Building on the [v2.0 foundation](https://microsoft.github.io/teams-sdk/csharp/getting-started/quickstart), this release brings deeper ASP.NET Core integration, a layered architecture, and first-class support for agentic identities. If you're building bots for Microsoft Teams in .NET, this is the SDK designed to feel native to how you already write ASP.NET Core applications.
+Teams SDK for .NET 2.1 preview is available today:
+
+```bash
+dotnet add package Microsoft.Teams.Apps --prerelease
+```
+
+Here's what changes for you:
+
+- **[Your bot is just an ASP.NET Core app.](#native-aspnet-core-integration)** Standard DI, `ILogger`, and `IConfiguration` throughout, with typed activity handlers and a rich context object that replaces `OnTurn` + activity-type switching. A working bot is 15 lines.
+- **[Authenticate the way your infrastructure already does.](#msal-authentication)** MSAL replaces the legacy auth stack — client secrets, managed identities, and federated identity credentials all work from a single `AzureAd` config block, with no code changes between them.
+- **[Act on behalf of users — including AI teammates — without writing a line of token plumbing.](/blog/bring-agentic-identities-to-teams-sdk-dotnet-2-1)** The SDK reads the agentic identity off each incoming activity and asks MSAL for the right token, so your handler code looks the same whether you're acting as the bot or as a user.
+- **[Migrate your existing Bot Framework v4 bot in two lines.](#migration-from-bot-framework-v4)** A compatibility package runs your existing `IBot` implementation on the new infrastructure unchanged, so you can adopt native handlers at your own pace.
+
+The rest of this post walks through each of these.
 
 <!-- truncate -->
 


### PR DESCRIPTION
Stacked on top of #2829 (`rido/blog-21preview`). Rewrites the lede of the .NET 2.1 announcement post so the value lands before the reader has to scroll.

## Before
The original opener said the release "brings deeper ASP.NET Core integration, a layered architecture, and first-class support for agentic identities" — a feature-bucket sentence that requires reading the whole post to figure out what changes for *you* the reader.

## After
Adopts the Next.js-style version-announcement pattern:
1. One-sentence headline + install command up top
2. Four value-bullets, each a journey beat (what you can DO), each anchored to the section that proves the claim
3. Handoff line into the deep-dive sections

Bullet 3 keeps the framing flexible (\"users — including AI teammates\") so we can sharpen the AI-teammate vs OBO emphasis later without rewriting the lede.

## Reference patterns reviewed
- Next.js 15 — 1-line opener → upgrade command → bulleted what's-new with section anchors
- Bun 1.0 — emotional hook + one-liner + scope (rejected: that pattern fits a brand launch, not an incremental version)
- Vercel AI SDK 5 — narrative-heavy with social proof (rejected: not needed for a first-party Microsoft SDK)

## Test plan
- [ ] Pull the branch, `cd teams.md && npm run start:simple`, open `/teams-sdk/blog/announcing-teams-sdk-dotnet-2-1-preview`
- [ ] Verify the four anchor links resolve (`#native-aspnet-core-integration`, `#msal-authentication`, `/blog/bring-agentic-identities-to-teams-sdk-dotnet-2-1`, `#migration-from-bot-framework-v4`)
- [ ] Sanity-check the install command at the top matches the one at the bottom of the post

🤖 Generated with [Claude Code](https://claude.com/claude-code)