### PR TITLE
Drop .NET opt-in tip from reactions guide

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/message-reactions/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/message-reactions/csharp.incl.md
@@ -1,15 +1,5 @@
 <!-- adding-reaction -->
 
-:::tip[.NET]
-The reaction APIs are marked with `[Experimental("ExperimentalTeamsReactions")]` and produce a compiler error until you opt in. Suppress the diagnostic inline with `#pragma warning disable ExperimentalTeamsReactions` or project-wide in your `.csproj`:
-
-```xml
-<PropertyGroup>
-  <NoWarn>$(NoWarn);ExperimentalTeamsReactions</NoWarn>
-</PropertyGroup>
-```
-:::
-
 ```csharp
 app.OnMessage(async (context, cancellationToken) =>
 {


### PR DESCRIPTION
## Summary

Removes the `:::tip[.NET]` callout block from the reactions in-depth guide's C# include. The block instructed readers to suppress `ExperimentalTeamsReactions` via `#pragma` or `<NoWarn>` — that's no longer applicable now that the `[Experimental]` attribute is being removed from teams.net (sibling PR).

## Cross-SDK coordination

Part of the cross-SDK Reactions-GA pass. Sibling PRs:
- microsoft/teams.ts#575 — Mark reactions API as GA
- microsoft/teams.py#427 — Mark reactions API as GA
- microsoft/teams.net#509 — Mark reactions API as GA (Libraries + core)

## Test plan

- [x] `npm start` regenerates docs cleanly with no content gaps
- [x] C# in-depth guide renders without the opt-in callout (verified in local dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)