### PR TITLE
Fix C# project name normalization

### DIFF
--- a/packages/cli/src/commands/project/new/csharp.ts
+++ b/packages/cli/src/commands/project/new/csharp.ts
@@ -32,7 +32,7 @@ export const projectNewCsharpCommand = new Command('csharp')
   .option('--json', '[OPTIONAL] Output as JSON')
   .action(
     wrapAction(async (rawName: string, options: ProjectNewCsOptions) => {
-      const name = pascalCase(rawName.trim(), { delimiter: '.' });
+      const name = pascalCase(rawName.trim());
 
       if (!templates.includes(options.template)) {
         throw new CliError(

--- a/packages/cli/tests/project-new-csharp.test.ts
+++ b/packages/cli/tests/project-new-csharp.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/utils/interactive.js', () => ({
+  confirmAction: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../src/project/scaffold.js', () => ({
+  listTemplates: vi.fn().mockReturnValue(['echo']),
+  scaffoldProject: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('project new csharp', () => {
+  let originalCwd: string;
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    originalCwd = process.cwd();
+    tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teams-cli-csharp-')));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('converts app names to PascalCase without inserting dots', async () => {
+    const { projectNewCsharpCommand } = await import('../src/commands/project/new/csharp.js');
+    const { scaffoldProject } = await import('../src/project/scaffold.js');
+
+    await projectNewCsharpCommand.parseAsync(['PmAgent', '--template', 'echo'], { from: 'user' });
+
+    expect(scaffoldProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'PmAgent',
+        language: 'csharp',
+        template: 'echo',
+        targetDir: path.join(tempDir, 'PmAgent'),
+      })
+    );
+  });
+
+  it.each([
+    ['pm-agent', 'PmAgent'],
+    ['pm agent', 'PmAgent'],
+    ['PM Agent', 'PmAgent'],
+    ['MyURLBot', 'MyUrlBot'],
+  ])('normalizes %s to %s', async (rawName, expectedName) => {
+    const { projectNewCsharpCommand } = await import('../src/commands/project/new/csharp.js');
+    const { scaffoldProject } = await import('../src/project/scaffold.js');
+
+    await projectNewCsharpCommand.parseAsync([rawName, '--template', 'echo'], { from: 'user' });
+
+    expect(scaffoldProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expectedName,
+        targetDir: path.join(tempDir, expectedName),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Stop inserting dots into C# project names during scaffold
- Add tests so `PmAgent` stays `PmAgent` instead of becoming `Pm.Agent`
- Historically, it looks like this was accidentally added.


Fixes https://github.com/microsoft/teams.ts/issues/137
Fixes https://github.com/microsoft/teams.ts/issues/371

## Test plan
- `npm --prefix packages/cli test -- project-new-csharp.test.ts`
- `npm --prefix packages/cli run check-types`
- Manually scaffolded `project new csharp PmAgent --template echo --json`