### PR TITLE
Prepare stable Teams CLI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can find a set of open-source agent accelerator templates in the [Teams Agen
 The Teams Developer CLI makes it easy to bootstrap your first agent. First, install the CLI via NPM:
 
 ```sh
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 Next, use the CLI to create your agent:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,74 +4,64 @@ This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.Gi
 
 ## How Versioning Works
 
-- Versions are computed automatically from git history based on `version.json`
-- **Main branch**: `2.1.X-beta` (early development, published with `beta` npm tag)
-- **Preview branch**: `2.1.X-preview` (vetted previews, published with `preview` npm tag)
+Versions are computed automatically from git history based on `version.json`.
 
-## Creating a Release
+- **Main branch**: active development.
+- **Preview branch**: preview releases.
+- **Release branch**: stable releases.
+- Versions without a prerelease suffix are stable releases, for example `3.0.{height}`.
+- Versions with a prerelease suffix are prereleases, for example `3.1-beta.{height}`.
 
-1. **Create a branch from `preview`** and merge `main` into it:
+The publish pipeline determines the npm tag from the computed version:
+
+- `*-beta*` → `beta`
+- `*-preview*` → `preview`
+- any other prerelease → `next`
+- stable versions → `latest`
+
+## Creating a Stable Release
+
+1. **Prepare the release branch:**
+
+   - Create or update the `release` branch from the commit you want to ship.
+   - Set `version.json` to the stable version line, for example `"3.0.{height}"`.
+   - Update package metadata if it still has a prerelease placeholder version.
+   - Update docs and install instructions to use the stable package:
+
+     ```bash
+     npm install -g @microsoft/teams.cli
+     ```
+
+   - Make sure CLI self-update points at npm `latest`.
+
+2. **Create a PR to `release`**, get approval, and merge.
+
+3. **Trigger the publish pipeline** for `release` with **Public** publish type.
+
+   The pipeline stamps versions, packs packages, signs them, and publishes stable packages to npm with the `latest` tag.
+
+4. **Verify the release:**
+
    ```bash
-   git checkout -b prep-preview/<next-version> preview
-   git merge origin/main
-   ```
-   - Set `version.json` to `"2.1-preview.{height}"` (change `-beta` to `-preview`)
-   - Commit and push
-
-2. **Create a PR to `preview`** (base: `preview`, compare: `prep-preview/<next-version>`):
-   - The PR will include all changes from main plus the version suffix change
-   - Get teammate approval and merge
-
-3. **Trigger the publish pipeline** for the `preview` branch with **Public** publish type
-
-4. **Bump the version on main** for the next release cycle (if needed):
-   - Edit `version.json` on main
-   - Increment the minor version (e.g. `"2.1-beta.{height}"` → `"2.2-beta.{height}"`)
-   - Commit and push (or PR)
-
-## Hotfixes
-
-To fix a bug in a released version without including new beta changes:
-
-1. **Consider if a normal preview would work instead** - merging main to preview includes all updates and is simpler. Only use a hotfix if you need to exclude beta changes from main.
-
-2. **Create a branch from `preview`**:
-   ```bash
-   git checkout preview
-   git checkout -b hotfix/fix-description
+   npm view @microsoft/teams.cli dist-tags
+   npm view @microsoft/teams.cli@latest version
    ```
 
-3. **Make your fix and commit**
-
-4. **Create a PR to `preview`**, get approval, and merge
-
-5. **Trigger the publish pipeline**
-
-6. **Cherry-pick the fix back to main**:
-   ```bash
-   git checkout main
-   git cherry-pick <commit-sha>
-   git push origin main
-   ```
+5. **Bump `main` for the next development cycle** if needed:
+   - Edit `version.json` on `main`.
+   - For example, move from `"3.0.{height}"` to `"3.1-beta.{height}"`.
+   - Commit and push via PR.
 
 ## Publishing
 
 The publish pipeline (`.azdo/publish.yml`) is manually triggered and requires selecting a **Publish Type**: `Internal` or `Public`.
 
-1. Go to the pipeline in ADO
-2. Click **Run pipeline**
-3. Select the branch to build from
+1. Go to the pipeline in ADO.
+2. Click **Run pipeline**.
+3. Select the branch to build from.
 4. Choose a **Publish Type**:
    - **Internal** — publishes unsigned packages to the Azure Artifacts `TeamsSDKPreviews` npm feed. No approval required.
    - **Public** — signs and publishes packages to npm via ESRP. Requires approval via the ADO pipeline environment.
-5. Pipeline runs: Build > Test > Stamp versions > Pack > Publish
+5. Pipeline runs: Build > Test > Stamp versions > Pack > Publish.
 
 The pipeline packs all non-private packages from `packages/`. Packages with `"private": true` in their `package.json` are skipped.
-
-## Bumping Major/Minor Version
-
-To bump from `2.1.x` to `2.2.x` or `3.0.x`:
-
-1. Edit `version.json` on main branch
-2. Update the version (e.g. `"2.1-beta.{height}"` → `"2.2-beta.{height}"`)
-3. Commit and push

--- a/package-lock.json
+++ b/package-lock.json
@@ -21507,7 +21507,7 @@
     },
     "packages/cli": {
       "name": "@microsoft/teams.cli",
-      "version": "3.0.0-beta.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.0.4",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,7 @@ Teams Developer CLI for managing Microsoft Teams apps.
 ## Install
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 ## Usage
@@ -43,12 +43,12 @@ teams self-update                    # Update to the latest version
 
 ## Global Options
 
-| Flag | Description |
-|------|-------------|
-| `-v, --verbose` | Enable verbose logging |
-| `--json` | Output results as JSON (structured output, recommended for agents) |
-| `--yes` / `-y` | Skip confirmation prompts (CI/agent use) |
-| `--disable-auto-update` | Disable automatic update checks |
+| Flag                    | Description                                                        |
+| ----------------------- | ------------------------------------------------------------------ |
+| `-v, --verbose`         | Enable verbose logging                                             |
+| `--json`                | Output results as JSON (structured output, recommended for agents) |
+| `--yes` / `-y`          | Skip confirmation prompts (CI/agent use)                           |
+| `--disable-auto-update` | Disable automatic update checks                                    |
 
 ## AI Agent Skills
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teams.cli",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "description": "Teams Developer CLI for scaffolding Teams applications",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/teams-sdk/skills/teams-dev/SKILL.md
+++ b/plugins/teams-sdk/skills/teams-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: teams-dev
 description: Use this skill whenever the user mentions Microsoft Teams in a development context — whether they're building, integrating, configuring, debugging, or just asking questions. Covers bots, message extensions, embedded web apps, Adaptive Cards, dialogs, SSO, infrastructure, the Teams Developer CLI/SDK, and general Teams platform queries. If the word "Teams" appears, err on the side of invoking this skill.
-teams_cli_version: 3.0.0-preview.*
+teams_cli_version: 3.0.*
 ---
 
 # Teams Bot Development & Infrastructure
@@ -17,23 +17,28 @@ Based on the user's request, route to the appropriate guide or handle directly:
 ### Complex Workflows (Use References)
 
 **Creating bot application code:**
+
 - Read and follow the **[Bot Application Development guide](references/guide-create-bot-app.md)**
 - This covers: Scaffolding a new bot project with `teams project new` (TypeScript/C#/Python, templates, connecting to infrastructure)
 
 **Integrating Teams into an existing server:**
+
 - Read and follow the **[Integrate Existing Server guide](references/guide-integrate-existing-server.md)**
 - This covers: Adding Teams bot functionality to an existing server using built-in adapters (ExpressAdapter for TypeScript, FastAPIAdapter for Python) or a custom adapter for any framework
 
 **Setting up bot infrastructure (Teams-managed bot & credentials):**
+
 - Read and follow the **[Bot Infrastructure Setup guide](references/guide-create-bot-infra.md)**
 - This covers: Prerequisites → Create Teams-managed bot → Save credentials → Verify
 
 **Setting up SSO authentication:**
+
 - Read and follow the **[SSO Setup guide](references/guide-setup-sso.md)**
 - This covers: Bot migration → AAD app configuration → OAuth connection → Manifest update → Verification
 - Prerequisites: Existing bot (teamsAppId, botId), az CLI authenticated
 
 **Troubleshooting errors:**
+
 - Read the **[Troubleshooting guide](references/troubleshooting.md)**
 - Covers: Sideloading issues, auth errors, SSO problems, migration issues
 
@@ -42,21 +47,25 @@ Based on the user's request, route to the appropriate guide or handle directly:
 For simple queries and updates, handle directly using the commands below:
 
 **List all apps:**
+
 ```bash
 teams app list
 ```
 
 **View app details:**
+
 ```bash
 teams app get <teamsAppId> --json
 ```
 
 **Check authentication status:**
+
 ```bash
 teams status
 ```
 
 **Update CLI to latest version:**
+
 ```bash
 teams self-update
 ```
@@ -76,6 +85,7 @@ teams app update <teamsAppId> --endpoint "https://new-endpoint-url/api/messages"
 ```
 
 **When to use:**
+
 - Ngrok URL changed (new session)
 - Devtunnels URL changed
 - Switching between different local development tunnels
@@ -93,6 +103,7 @@ teams self-update
 ```
 
 **When to use:**
+
 - Periodically update to get latest features
 - After bug reports or known issues
 - When new CLI features are announced
@@ -119,10 +130,10 @@ teams app list
 
 **Use case:** See all Teams apps you've created
 
-
 ## Resources
 
 **Teams SDK Documentation (llms.txt — optimized for LLM consumption):**
+
 - TypeScript: https://microsoft.github.io/teams-sdk/llms_docs/llms_typescript.txt
 - Python: https://microsoft.github.io/teams-sdk/llms_docs/llms_python.txt
 - C#: https://microsoft.github.io/teams-sdk/llms_docs/llms_csharp.txt

--- a/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-app.md
+++ b/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-app.md
@@ -9,6 +9,7 @@ This guide walks through creating a new Microsoft Teams bot application using th
 A Teams bot is a web application that receives messages from Teams via webhooks. When a user messages your bot, Teams sends an HTTP POST to your application's endpoint. Your app processes the message and responds.
 
 Three things need to exist:
+
 1. **Your web application** — runs locally or deployed, listening for HTTP requests
 2. **A bot registration** — an app identity in Azure with a client ID/secret, pointing to your application's URL
 3. **A public HTTPS endpoint** — so Teams can reach your app (use a dev tunnel for local development)
@@ -25,7 +26,7 @@ The Teams SDK handles the webhook plumbing, authentication, and message parsing 
 teams --version
 ```
 
-**Expected:** Version number displayed (e.g., `2.1.0-preview.3` or similar)
+**Expected:** Version number displayed (e.g., `3.0.0` or later)
 
 **If not installed:** See [Bot Infrastructure Setup guide](guide-create-bot-infra.md) for installation instructions.
 
@@ -46,16 +47,19 @@ Have your credentials ready before proceeding (`.env` for TypeScript/Python, `ap
 The `teams project new` command supports three languages:
 
 **TypeScript:**
+
 ```bash
 teams project new ts <name>
 ```
 
 **Python:**
+
 ```bash
 teams project new py <name>
 ```
 
 **C#:**
+
 ```bash
 teams project new cs <name>
 ```
@@ -68,15 +72,16 @@ All languages support the same template options via `-t, --template <template>`:
 
 **Available Templates:**
 
-| Template | Description | Use Case |
-|----------|-------------|----------|
-| `echo` | Simple echo bot (default) | Learning, testing, basic message handling |
-| `ai` | AI-powered bot with LLM integration | Intelligent responses, chat completion, AI features |
-| `graph` | Microsoft Graph integration | Access user data, calendar, mail, SharePoint |
+| Template | Description                         | Use Case                                            |
+| -------- | ----------------------------------- | --------------------------------------------------- |
+| `echo`   | Simple echo bot (default)           | Learning, testing, basic message handling           |
+| `ai`     | AI-powered bot with LLM integration | Intelligent responses, chat completion, AI features |
+| `graph`  | Microsoft Graph integration         | Access user data, calendar, mail, SharePoint        |
 
 **Note:** Template availability varies by language. Check `teams project new <language> --help` for the actual list of available templates for each language.
 
 **Recommendations:**
+
 - **First bot?** Start with `echo` to learn the basics
 - **AI features?** Use `ai` for LLM-powered responses
 - **Microsoft 365 data?** Use `graph` for accessing user/org data
@@ -90,6 +95,7 @@ teams project new typescript MyBot -t echo
 ```
 
 Copy credentials from the [Bot Infrastructure Setup guide](guide-create-bot-infra.md) into the project:
+
 - **TypeScript / Python:** Copy the `.env` file into the project root
 - **C#:** Add a `Teams` section to `appsettings.json` with `ClientId`, `ClientSecret`, and `TenantId` (the `--env appsettings.json` flag does this automatically during infrastructure setup)
 
@@ -104,11 +110,13 @@ Follow the instructions printed by `teams project new` to install dependencies a
 Your bot needs to be accessible from the internet for Teams to send messages to it.
 
 **For tunnel setup instructions**, see the [Bot Infrastructure Setup guide - Step 3: Set Up Bot Endpoint](guide-create-bot-infra.md#step-3-set-up-bot-endpoint). This covers:
+
 - Creating a persistent devtunnel (recommended)
 - Alternative options (ngrok, existing endpoints)
 - Proper configuration (port 3978, protocol auto, anonymous access)
 
 **Update your bot endpoint** (if you already created infrastructure):
+
 ```bash
 teams app update <teamsAppId> --endpoint "https://<tunnel-id>.devtunnels.ms/api/messages"
 ```
@@ -122,6 +130,7 @@ teams app update <teamsAppId> --endpoint "https://<tunnel-id>.devtunnels.ms/api/
 If you completed [Bot Infrastructure Setup guide](guide-create-bot-infra.md), you have an install link.
 
 **Get the install link:**
+
 ```bash
 teams app get <teamsAppId> --json
 ```
@@ -143,6 +152,7 @@ Look for `installLink` in the output and open it in your browser.
 The scaffolded project's entry point (`src/index.ts` for TypeScript, `src/main.py` for Python) contains inline message handlers. Customize your bot by editing these handlers directly.
 
 For code patterns, API reference, and advanced features (adaptive cards, AI integration, dialogs, proactive messaging, etc.), refer to the SDK docs:
+
 - TypeScript: https://microsoft.github.io/teams-sdk/llms_docs/llms_typescript.txt
 - Python: https://microsoft.github.io/teams-sdk/llms_docs/llms_python.txt
 - C#: https://microsoft.github.io/teams-sdk/llms_docs/llms_csharp.txt

--- a/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-infra.md
+++ b/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-infra.md
@@ -16,17 +16,18 @@ Verify the Teams Developer CLI is installed:
 teams --version
 ```
 
-**Expected output:** Shows version number (e.g., `2.1.0-preview.3` or similar)
+**Expected output:** Shows version number (e.g., `3.0.0` or later)
 
 **If not installed:**
 
 Install the Teams Developer CLI using npm:
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 **After installation:**
+
 - Verify: Run `teams --version` to confirm installation
 - You should see the version number
 
@@ -43,6 +44,7 @@ teams status
 **Expected output:** Shows authenticated user information.
 
 **If not authenticated:**
+
 1. Run: `teams login`
 2. Follow the authentication flow
 3. Verify: Run `teams status` again and confirm you see your authenticated account
@@ -79,6 +81,7 @@ Replace `my-teams-bot` with your preferred tunnel name.
 **Important:** Port `3978` is the default Teams SDK port. Protocol `auto` allows both HTTP and HTTPS. The `--allow-anonymous` flag allows Teams to connect without authentication.
 
 **Expected output:**
+
 ```
 Created tunnel: my-teams-bot (<tunnel-id>)
 Hosting port: 3978
@@ -94,6 +97,7 @@ devtunnel host my-teams-bot
 Your persistent tunnel URL remains: `https://<tunnel-id>.devtunnels.ms`
 
 **Format your endpoint URL:**
+
 ```
 https://<tunnel-id>.devtunnels.ms/api/messages
 ```
@@ -190,6 +194,7 @@ teams app get <teamsAppId> --json
 ```
 
 **Expected output:** Returns app details matching what was created:
+
 - `teamsAppId` matches
 - `botId` matches
 - `endpoint` matches (or is empty if not configured)

--- a/teams.md/docs/cli/getting-started/installation.md
+++ b/teams.md/docs/cli/getting-started/installation.md
@@ -11,7 +11,7 @@
 Install `teams` globally from npm:
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 ## Verify

--- a/teams.md/docs/cli/index.md
+++ b/teams.md/docs/cli/index.md
@@ -5,10 +5,6 @@ slug: /
 
 # Teams Developer CLI
 
-:::warning[Preview]
-The Teams Developer CLI v3 is currently in **preview**. Commands, options, and behavior may change between releases.
-:::
-
 Teams Developer CLI for managing Microsoft Teams apps. Create, manage, and configure Teams apps from the command line.
 
 ## Features

--- a/teams.md/docs/main/developer-tools/agent-skills.md
+++ b/teams.md/docs/main/developer-tools/agent-skills.md
@@ -13,6 +13,7 @@ If you'd rather not install a skill, you can provide the same context by pointin
 ```
 https://microsoft.github.io/teams-sdk/llms_docs/llms.txt
 ```
+
 :::
 
 ## Install the `teams-dev` skill
@@ -24,11 +25,13 @@ import TabItem from '@theme/TabItem';
 <TabItem value="copilot" label="GitHub Copilot CLI">
 
 Add the marketplace (first time only):
+
 ```
 /plugin marketplace add microsoft/teams-sdk
 ```
 
 Install the skill:
+
 ```
 /plugin install teams-sdk@teams-skills
 ```
@@ -39,11 +42,13 @@ After installing, restart GitHub Copilot for the skills to load.
 <TabItem value="claude" label="Claude Code">
 
 Add the marketplace (first time only):
+
 ```
 /plugin marketplace add microsoft/teams-sdk
 ```
 
 Install the skill:
+
 ```
 /plugin install teams-sdk@teams-skills
 ```
@@ -67,18 +72,19 @@ See [Cursor Skills documentation](https://cursor.com/docs/skills#installing-skil
 
 The `teams-dev` skill guides your AI assistant through:
 
-| Task | What it does |
-|---|---|
-| **Manage bot infrastructure** | Register your bot with Teams, manage credentials, and update configuration |
-| **Develop Teams bot** | Build bot applications from scratch or add Teams capabilities to existing servers |
-| **Set up SSO** | Enable Single Sign-On so users can authenticate seamlessly without login prompts |
-| **Troubleshoot** | Diagnose and resolve common bot setup and configuration issues |
+| Task                          | What it does                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| **Manage bot infrastructure** | Register your bot with Teams, manage credentials, and update configuration        |
+| **Develop Teams bot**         | Build bot applications from scratch or add Teams capabilities to existing servers |
+| **Set up SSO**                | Enable Single Sign-On so users can authenticate seamlessly without login prompts  |
+| **Troubleshoot**              | Diagnose and resolve common bot setup and configuration issues                    |
 
 The skill does **not** cover hosting or deployment — it focuses on bot registration, development, and configuration.
 
 ## Invoke the skill
 
 **Using natural language:**
+
 - "I need a chatbot for my team's standup meetings"
 - "Help me build a Teams bot that can answer FAQs"
 - "My bot won't load in Teams, can you help?"
@@ -116,7 +122,6 @@ Agent: I'll create an echo bot for you.
 
 ## Requirements
 
-- Teams Developer CLI installed (`npm install -g @microsoft/teams.cli@preview`)
+- Teams Developer CLI installed (`npm install -g @microsoft/teams.cli`)
 - Node.js 20 or later
 - Microsoft 365 account with sideloading enabled
-

--- a/teams.md/docs/main/get-started/quickstart-register.md
+++ b/teams.md/docs/main/get-started/quickstart-register.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: "Quickstart: Register your app"
+title: 'Quickstart: Register your app'
 summary: Register a Teams app and bot using the Teams Developer CLI, then sideload into Teams.
 ---
 
@@ -11,7 +11,7 @@ Register a Teams app and its bot infrastructure with the [Teams Developer CLI](/
 If you don't have an agent yet, step 3 scaffolds one using the Teams SDK. If you already have a server, skip step 3 and pass your endpoint to step 4.
 
 :::tip Let your AI assistant do this for you
-Install the [`teams-dev` skill](/developer-tools/agent-skills) in Claude Code, GitHub Copilot, Cursor, or VS Code, then say *"create a Teams bot"* — your assistant runs every step on this page for you, including the tunnel setup and sideload link.
+Install the [`teams-dev` skill](/developer-tools/agent-skills) in Claude Code, GitHub Copilot, Cursor, or VS Code, then say _"create a Teams bot"_ — your assistant runs every step on this page for you, including the tunnel setup and sideload link.
 :::
 
 ## Prerequisites
@@ -23,7 +23,7 @@ Install the [`teams-dev` skill](/developer-tools/agent-skills) in Claude Code, G
 ## 1. Install the CLI
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 teams --version
 ```
 

--- a/teams.md/src/pages/templates/getting-started/quickstart.mdx
+++ b/teams.md/src/pages/templates/getting-started/quickstart.mdx
@@ -22,7 +22,7 @@ Get started with Teams SDK quickly using the Teams Developer CLI.
 Install `teams` globally:
 
 ```sh
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 teams --version
 ```
 

--- a/teams.md/src/pages/templates/getting-started/running-in-teams/README.mdx
+++ b/teams.md/src/pages/templates/getting-started/running-in-teams/README.mdx
@@ -11,7 +11,7 @@ Now that you completed [the quickstart](../quickstart) and your agent is running
 
 ## Prerequisites
 
-- The CLI installed: `npm install -g @microsoft/teams.cli@preview`
+- The CLI installed: `npm install -g @microsoft/teams.cli`
 - An M365 account with **custom app upload (sideloading) enabled** on the tenant
 - A public HTTPS tunnel pointing at your local server (e.g. [DevTunnels](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/overview), [ngrok](https://ngrok.com/))
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0-beta.{height}",
-  "publicReleaseRefSpec": [
-    "^refs/heads/main$",
-    "^refs/heads/preview$"
-  ]
+  "version": "3.0.{height}",
+  "publicReleaseRefSpec": ["^refs/heads/release$", "^refs/heads/preview$"]
 }


### PR DESCRIPTION
## Summary
- move CLI versioning/package metadata to stable v3
- update CLI docs, README install snippets, and teams-dev skill guidance for stable installs
- refresh RELEASE.md with stable, preview bridge, and npm tag steps

This is stacked on #2841 so the stable release also keeps self-update on npm `latest`.

## Validation
- `npm -w @microsoft/teams.cli test -- self-update.test.ts update-info.test.ts`
- `npm -w @microsoft/teams.cli run build`
- `npm -w teams-md run build`