### PR TITLE
Add Slash Commands Support in Docs

### DIFF
--- a/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
@@ -20,7 +20,7 @@ In the above example, the `context.activity` parameter is of type `MessageActivi
 ```csharp
 app.OnMessage(async (context, cancellationToken) =>
 {
-    if (context.Activity.IsTargeted == true)
+    if (context.Activity.Recipient?.IsTargeted == true)
     {
         await context.Send($"Received slash command: {context.Activity.Text}", cancellationToken);
         return;

--- a/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
@@ -26,7 +26,7 @@ app.OnMessage(async (context, cancellationToken) =>
         return;
     }
 
-    context.Next();
+    await context.Next();
 });
 ```
 

--- a/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
@@ -15,6 +15,21 @@ The Teams SDK exposes a fluent router so you can subscribe to these activities w
 
 In the above example, the `context.activity` parameter is of type `MessageActivity`, which has a `Text` property. You'll notice that the handler here does not return anything, but instead handles it by `send`ing a message back. For message activities, Teams does not expect your application to return anything (though it's usually a good idea to send some sort of friendly acknowledgment!).
 
+<!-- slash-command-example -->
+
+```csharp
+app.OnMessage(async (context, cancellationToken) =>
+{
+    if (context.Activity.IsTargeted == true)
+    {
+        await context.Send($"Received slash command: {context.Activity.Text}", cancellationToken);
+        return;
+    }
+
+    context.Next();
+});
+```
+
 <!-- middleware-intro -->
 
 The `OnActivity` activity handlers (and attributes) follow a [middleware](https://www.patterns.dev/vanilla/mediator-pattern/) pattern similar to how `dotnet` middlewares work. This means that for each activity handler, a `Next` function is passed in which can be called to pass control to the next handler. This allows you to build a chain of handlers that can process the same activity in different ways.

--- a/teams.md/src/components/include/essentials/on-activity/python.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/python.incl.md
@@ -19,7 +19,7 @@ In the above example, the `ctx.activity` parameter is of type `MessageActivity`,
 ```python
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
-    if getattr(ctx.activity, "is_targeted", False):
+    if ctx.activity.is_targeted:
         await ctx.send(f"Received slash command: {ctx.activity.text}")
         return
 

--- a/teams.md/src/components/include/essentials/on-activity/python.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/python.incl.md
@@ -19,7 +19,7 @@ In the above example, the `ctx.activity` parameter is of type `MessageActivity`,
 ```python
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
-    if ctx.activity.is_targeted:
+    if ctx.activity.recipient and ctx.activity.recipient.is_targeted:
         await ctx.send(f"Received slash command: {ctx.activity.text}")
         return
 

--- a/teams.md/src/components/include/essentials/on-activity/python.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/python.incl.md
@@ -14,6 +14,18 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
 In the above example, the `ctx.activity` parameter is of type `MessageActivity`, which has a `text` property. You'll notice that the handler here does not return anything, but instead handles it by `send`ing a message back. For message activities, Teams does not expect your application to return anything (though it's usually a good idea to send some sort of friendly acknowledgment!).
 
+<!-- slash-command-example -->
+
+```python
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]):
+    if getattr(ctx.activity, "is_targeted", False):
+        await ctx.send(f"Received slash command: {ctx.activity.text}")
+        return
+
+    await ctx.next()
+```
+
 <!-- middleware-intro -->
 
 The `event` activity handlers (and attributes) follow a [middleware](https://www.patterns.dev/vanilla/mediator-pattern/) pattern similar to how `python` middlewares work. This means that for each activity handler, a `next` function is passed in which can be called to pass control to the next handler. This allows you to build a chain of handlers that can process the same activity in different ways.

--- a/teams.md/src/components/include/essentials/on-activity/typescript.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/typescript.incl.md
@@ -20,7 +20,7 @@ In the above example, the `activity` parameter is of type `MessageActivity`, whi
 
 ```typescript
 app.on('message', async ({ activity, send, next }) => {
-  if (activity.isTargeted) {
+  if (activity.recipient?.isTargeted) {
     await send(`Received slash command: ${activity.text}`);
     return;
   }

--- a/teams.md/src/components/include/essentials/on-activity/typescript.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/typescript.incl.md
@@ -16,6 +16,19 @@ In the above example, the `activity` parameter is of type `MessageActivity`, whi
 
 [Other activity types](./activity-ref) have different properties and different required results. For a given handler, the SDK will automatically determine the type of `activity` and also enforce the correct return type.
 
+<!-- slash-command-example -->
+
+```typescript
+app.on('message', async ({ activity, send, next }) => {
+  if (activity.isTargeted) {
+    await send(`Received slash command: ${activity.text}`);
+    return;
+  }
+
+  await next();
+});
+```
+
 <!-- middleware-intro -->
 
 The `on` activity handlers follow a [middleware](https://www.patterns.dev/vanilla/mediator-pattern/) pattern similar to how `express` middlewares work. This means that for each activity handler, a `next` function is passed in which can be called to pass control to the next handler. This allows you to build a chain of handlers that can process the same activity in different ways.

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -40,7 +40,7 @@ Slash commands are coming soon in May 2026.
 
 When a user sends a slash command, it appears as a private message visible only to them. Your agent can reply privately or, when appropriate, share a response with the broader group or channel.
 
-Slash commands arrive as targeted message activities and can be identified with the targeted flag on the incoming activity.
+Slash commands arrive as targeted message activities and can be identified with the targeted flag on the activity's recipient object.
 
 <LanguageInclude section="slash-command-example" />
 

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -38,6 +38,8 @@ Here is an example of a basic message handler:
 Slash commands are coming soon in May 2026.
 :::
 
+Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section, and optionally declare specific commands using `commandLists`.
+
 When a user sends a slash command, it appears as a private message visible only to them. Your agent can reply privately or, when appropriate, share a response with the broader group or channel.
 
 Slash commands arrive as targeted message activities and can be identified with the targeted flag on the activity's recipient object.

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -38,7 +38,7 @@ Here is an example of a basic message handler:
 Slash commands are coming soon in May 2026.
 :::
 
-Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section, and optionally declare specific commands using `commandLists`.
+Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section and declare specific commands using `commandLists` with `triggers: ["slash"]`.
 
 When a user sends a slash command, it appears as a private message visible only to them. Your agent can reply privately or, when appropriate, share a response with the broader group or channel.
 

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -32,6 +32,18 @@ Here is an example of a basic message handler:
 
 <LanguageInclude section="example-explanation" />
 
+## Slash Commands
+
+:::info[Preview]
+Slash commands are coming soon in May 2026.
+:::
+
+When a user sends a slash command, it appears as a private message visible only to them. Your agent can reply privately or, when appropriate, share a response with the broader group or channel.
+
+Slash commands arrive as targeted message activities and can be identified with the targeted flag on the incoming activity.
+
+<LanguageInclude section="slash-command-example" />
+
 ## Middleware pattern
 
 <LanguageInclude section="middleware-intro" />

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -38,11 +38,32 @@ Here is an example of a basic message handler:
 Slash commands are coming soon in May 2026.
 :::
 
-Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section and declare specific commands using `commandLists` with `triggers: ["slash"]`.
+Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section. You can opt in with an explicit command list by declaring specific commands using `commandLists` with `triggers: ["slash"]`, which Teams shows in the slash menu when a user types `/`. Without a command list, users can still invoke your agent via `/agent-name` and provide free-form input.
+
+```json
+{
+  "bots": [
+    {
+      "botId": "{{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsTargetedMessages": true,
+      "commandLists": [
+        {
+          "scopes": ["team", "groupChat"],
+          "triggers": ["slash"],
+          "commands": [
+            { "title": "Review", "description": "Review a document" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
 When a user sends a slash command, it appears as a private message visible only to them. Your agent can reply privately or, when appropriate, share a response with the broader group or channel.
 
-Slash commands arrive as targeted message activities and can be identified with the targeted flag on the activity's recipient object.
+Slash commands arrive as normal message activities with the targeted flag set on the activity's recipient object.
 
 <LanguageInclude section="slash-command-example" />
 


### PR DESCRIPTION
Add preview slash command documentation to the On Activity page, including behavior notes and language-specific examples for TypeScript, C#, and Python.