### PR TITLE
Fix app create fallback and RSC reinstall hints

### DIFF
--- a/packages/cli/src/apps/basic-info.ts
+++ b/packages/cli/src/apps/basic-info.ts
@@ -3,6 +3,7 @@ import pc from 'picocolors';
 import { createSpinner } from 'nanospinner';
 import type { AppDetails } from './types.js';
 import { updateAppDetails } from './api.js';
+import { logVersionBumpReinstallHint } from './reinstall-hint.js';
 import {
   getAppMetadataFieldRule,
   isAppMetadataField,
@@ -110,9 +111,7 @@ async function editField(
       [fieldKey]: newValue.trim(),
     });
     spinner.success({ text: `${field.label} updated successfully` });
-    if (updated.versionBumped) {
-      logger.info(pc.dim(`Version auto-bumped: ${updated.previousVersion} → ${updated.version} — reinstall may be needed`));
-    }
+    logVersionBumpReinstallHint(updated);
     return updated;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/cli/src/apps/index.ts
+++ b/packages/cli/src/apps/index.ts
@@ -10,3 +10,4 @@ export * from './bot-location.js';
 export * from './bot-handler.js';
 export * from './links.js';
 export * from './validation.js';
+export * from './reinstall-hint.js';

--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -14,6 +14,13 @@ function validateField(field: AppMetadataField, value: string): string | true {
 }
 
 /**
+ * Validates an optional field. Empty values are accepted so callers can apply a fallback.
+ */
+function validateOptionalField(field: AppMetadataField, value: string): string | true {
+  return value.trim() ? validateField(field, value) : true;
+}
+
+/**
  * Placeholder bot ID for manifest generation when no real bot ID is available.
  */
 export const PLACEHOLDER_BOT_ID = '00000000-0000-0000-0000-000000000000';
@@ -58,9 +65,9 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
     });
     const fullDesc = await input({
       message: 'Full description (leave empty to use short):',
-      validate: (value) => validateField('longDescription', value),
+      validate: (value) => validateOptionalField('longDescription', value),
     });
-    result.description = { short: shortDesc, full: fullDesc || undefined };
+    result.description = { short: shortDesc, full: fullDesc.trim() || undefined };
   }
 
   if (customizeFields.includes('icons')) {

--- a/packages/cli/src/apps/reinstall-hint.ts
+++ b/packages/cli/src/apps/reinstall-hint.ts
@@ -1,0 +1,20 @@
+import pc from 'picocolors';
+import type { UpdateAppDetailsResult } from './api.js';
+import { logger } from '../utils/logger.js';
+
+export function formatVersionBumpReinstallHint(
+  previousVersion: string | undefined,
+  version: string | undefined
+): string {
+  const versionChange = previousVersion && version ? `${previousVersion} → ${version}` : version;
+  return versionChange
+    ? `Version auto-bumped: ${versionChange} — reinstall may be needed`
+    : 'Version auto-bumped — reinstall may be needed';
+}
+
+export function logVersionBumpReinstallHint(
+  result: Pick<UpdateAppDetailsResult, 'versionBumped' | 'previousVersion' | 'version'> | undefined
+): void {
+  if (!result?.versionBumped) return;
+  logger.info(pc.dim(formatVersionBumpReinstallHint(result.previousVersion, result.version)));
+}

--- a/packages/cli/src/commands/app/rsc/actions.ts
+++ b/packages/cli/src/commands/app/rsc/actions.ts
@@ -1,4 +1,8 @@
-import { fetchAppDetailsV2, updateAppDetails } from '../../../apps/api.js';
+import {
+  fetchAppDetailsV2,
+  updateAppDetails,
+  type UpdateAppDetailsResult,
+} from '../../../apps/api.js';
 import type { RscPermissionEntry, AppAuthorization } from '../../../apps/types.js';
 
 /** Composite key for deduplication: "name|type" */
@@ -99,7 +103,11 @@ export async function addRscPermissions(
   token: string,
   teamsAppId: string,
   permissions: RscPermissionEntry[]
-): Promise<{ added: RscPermissionEntry[]; skipped: RscPermissionEntry[] }> {
+): Promise<{
+  added: RscPermissionEntry[];
+  skipped: RscPermissionEntry[];
+  updateResult?: UpdateAppDetailsResult;
+}> {
   const current = await listRscPermissions(token, teamsAppId);
   const existingKeys = new Set(current.map(permKey));
 
@@ -114,13 +122,14 @@ export async function addRscPermissions(
     }
   }
 
+  let updateResult: UpdateAppDetailsResult | undefined;
   if (added.length > 0) {
     const merged = [...current, ...added];
     const update = await buildAuthorizationUpdate(token, teamsAppId, merged);
-    await updateAppDetails(token, teamsAppId, update);
+    updateResult = await updateAppDetails(token, teamsAppId, update);
   }
 
-  return { added, skipped };
+  return { added, skipped, updateResult };
 }
 
 /**
@@ -131,7 +140,7 @@ export async function removeRscPermissions(
   token: string,
   teamsAppId: string,
   permissionNames: string[]
-): Promise<{ removed: string[]; notFound: string[] }> {
+): Promise<{ removed: string[]; notFound: string[]; updateResult?: UpdateAppDetailsResult }> {
   const current = await listRscPermissions(token, teamsAppId);
   const currentNames = new Set(current.map((p) => p.name));
 
@@ -146,14 +155,15 @@ export async function removeRscPermissions(
     }
   }
 
+  let updateResult: UpdateAppDetailsResult | undefined;
   if (removed.length > 0) {
     const removedSet = new Set(removed);
     const filtered = current.filter((p) => !removedSet.has(p.name));
     const update = await buildAuthorizationUpdate(token, teamsAppId, filtered);
-    await updateAppDetails(token, teamsAppId, update);
+    updateResult = await updateAppDetails(token, teamsAppId, update);
   }
 
-  return { removed, notFound };
+  return { removed, notFound, updateResult };
 }
 
 /**
@@ -164,7 +174,7 @@ export async function setRscPermissions(
   token: string,
   teamsAppId: string,
   permissions: RscPermissionEntry[]
-): Promise<void> {
+): Promise<UpdateAppDetailsResult> {
   const update = await buildAuthorizationUpdate(token, teamsAppId, permissions);
-  await updateAppDetails(token, teamsAppId, update);
+  return updateAppDetails(token, teamsAppId, update);
 }

--- a/packages/cli/src/commands/app/rsc/index.ts
+++ b/packages/cli/src/commands/app/rsc/index.ts
@@ -12,6 +12,7 @@ import {
   getPermissionsForScope,
   type RscScope,
 } from '../../../apps/rsc-catalog.js';
+import { logVersionBumpReinstallHint } from '../../../apps/reinstall-hint.js';
 import type { RscPermissionEntry, AppSummary } from '../../../apps/types.js';
 import {
   listRscPermissions,
@@ -175,12 +176,13 @@ async function editScopePermissions(
   const finalPerms = [...otherScopePerms, ...selected];
 
   const updateSpinner = createSilentSpinner('Updating RSC permissions...').start();
-  await setRscPermissions(token, teamsAppId, finalPerms);
+  const updateResult = await setRscPermissions(token, teamsAppId, finalPerms);
 
   const parts: string[] = [];
   if (toAdd.length > 0) parts.push(`added ${toAdd.length}`);
   if (toRemoveKeys.size > 0) parts.push(`removed ${toRemoveKeys.size}`);
   updateSpinner.success({ text: `RSC permissions updated (${parts.join(', ')}).` });
+  logVersionBumpReinstallHint(updateResult);
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -215,11 +217,13 @@ interface RscRemoveOptions {
 interface RscAddOutput {
   added: RscPermissionEntry[];
   skipped: RscPermissionEntry[];
+  needsReinstall?: boolean;
 }
 
 interface RscRemoveOutput {
   removed: string[];
   notFound: string[];
+  needsReinstall?: boolean;
 }
 
 const rscListCommand = new Command('list')
@@ -265,11 +269,15 @@ const rscAddCommand = new Command('add')
       const entry: RscPermissionEntry = { name: permission, type: options.type };
 
       const spinner = createSilentSpinner('Adding RSC permission...', options.json).start();
-      const { added, skipped } = await addRscPermissions(token, teamsAppId, [entry]);
+      const { added, skipped, updateResult } = await addRscPermissions(token, teamsAppId, [entry]);
       spinner.stop();
 
       if (options.json) {
-        const result: RscAddOutput = { added, skipped };
+        const result: RscAddOutput = {
+          added,
+          skipped,
+          ...(updateResult?.versionBumped ? { needsReinstall: true } : {}),
+        };
         outputJson(result);
         return;
       }
@@ -278,6 +286,7 @@ const rscAddCommand = new Command('add')
         logger.info(pc.yellow(`Permission "${permission}" already exists.`));
       } else {
         logger.info(pc.green(`Added ${permission} (${options.type}).`));
+        logVersionBumpReinstallHint(updateResult);
       }
     })
   );
@@ -292,11 +301,15 @@ const rscRemoveCommand = new Command('remove')
       const token = await requireToken();
 
       const spinner = createSilentSpinner('Removing RSC permission...', options.json).start();
-      const { removed, notFound } = await removeRscPermissions(token, teamsAppId, [permission]);
+      const { removed, notFound, updateResult } = await removeRscPermissions(token, teamsAppId, [permission]);
       spinner.stop();
 
       if (options.json) {
-        const result: RscRemoveOutput = { removed, notFound };
+        const result: RscRemoveOutput = {
+          removed,
+          notFound,
+          ...(updateResult?.versionBumped ? { needsReinstall: true } : {}),
+        };
         outputJson(result);
         return;
       }
@@ -309,6 +322,7 @@ const rscRemoveCommand = new Command('remove')
       }
 
       logger.info(pc.green(`Removed ${permission}.`));
+      logVersionBumpReinstallHint(updateResult);
     })
   );
 
@@ -321,6 +335,7 @@ interface RscSetOutput {
   added: RscPermissionEntry[];
   removed: RscPermissionEntry[];
   unchanged: RscPermissionEntry[];
+  needsReinstall?: boolean;
 }
 
 const rscSetCommand = new Command('set')
@@ -393,7 +408,7 @@ const rscSetCommand = new Command('set')
         return;
       }
 
-      await setRscPermissions(token, teamsAppId, diff.final);
+      const updateResult = await setRscPermissions(token, teamsAppId, diff.final);
       spinner.stop();
 
       if (options.json) {
@@ -401,6 +416,7 @@ const rscSetCommand = new Command('set')
           added: diff.added,
           removed: diff.removed,
           unchanged: diff.unchanged,
+          ...(updateResult.versionBumped ? { needsReinstall: true } : {}),
         };
         outputJson(result);
         return;
@@ -411,6 +427,7 @@ const rscSetCommand = new Command('set')
       if (diff.removed.length > 0) parts.push(`removed ${diff.removed.length}`);
       if (diff.unchanged.length > 0) parts.push(`unchanged ${diff.unchanged.length}`);
       logger.info(pc.green(`RSC permissions updated (${parts.join(', ')}).`));
+      logVersionBumpReinstallHint(updateResult);
     })
   );
 

--- a/packages/cli/src/commands/app/update.ts
+++ b/packages/cli/src/commands/app/update.ts
@@ -18,6 +18,8 @@ import {
   validateAppMetadata,
   validateEndpoint,
   uploadIcon,
+  formatVersionBumpReinstallHint,
+  logVersionBumpReinstallHint,
 } from '../../apps/index.js';
 import { ensureAz } from '../../utils/az.js';
 import { CliError, wrapAction } from '../../utils/errors.js';
@@ -213,9 +215,7 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
       const scopeSpinner = createSilentSpinner('Updating scopes...').start();
       const result = await updateAppDetails(token, app.teamsAppId, scopeUpdates);
       scopeSpinner.success({ text: `Scopes updated: ${(scopeUpdates.bots?.[0]?.scopes ?? []).join(', ')}` });
-      if (result.versionBumped) {
-        logger.info(pc.dim(`Version auto-bumped: ${result.previousVersion} → ${result.version} — reinstall may be needed`));
-      }
+      logVersionBumpReinstallHint(result);
 
       // Refresh appDetails
       appDetails = await fetchAppDetailsV2(token, app.teamsAppId);
@@ -288,9 +288,7 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
             const domainSpinner = createSilentSpinner('Updating valid domains...').start();
             const domainResult = await updateAppDetails(token, app.teamsAppId, { validDomains: [...domains, domain] });
             domainSpinner.success({ text: `Added ${domain} to valid domains` });
-            if (domainResult.versionBumped) {
-              logger.info(pc.dim(`Version auto-bumped: ${domainResult.previousVersion} → ${domainResult.version} — reinstall may be needed`));
-            }
+            logVersionBumpReinstallHint(domainResult);
           }
         }
         continue;
@@ -324,9 +322,7 @@ export async function showUpdateMenu(app: AppSummary, token: string): Promise<vo
             const domainSpinner = createSilentSpinner('Updating valid domains...').start();
             const domainResult = await updateAppDetails(token, app.teamsAppId, { validDomains: [...domains, domain] });
             domainSpinner.success({ text: `Added ${domain} to valid domains` });
-            if (domainResult.versionBumped) {
-              logger.info(pc.dim(`Version auto-bumped: ${domainResult.previousVersion} → ${domainResult.version} — reinstall may be needed`));
-            }
+            logVersionBumpReinstallHint(domainResult);
           }
         }
         continue;
@@ -639,7 +635,7 @@ export const appUpdateCommand = new Command('update')
             versionBumped = true;
             allUpdates.version = bumped;
             if (!silent) {
-              logger.info(pc.dim(`Version auto-bumped: ${detailsAfter.version} → ${bumped} — reinstall may be needed`));
+              logger.info(pc.dim(formatVersionBumpReinstallHint(detailsAfter.version, bumped)));
             }
           }
         }

--- a/packages/cli/tests/manifest-builder-icons.test.ts
+++ b/packages/cli/tests/manifest-builder-icons.test.ts
@@ -23,6 +23,30 @@ describe('collectManifestCustomization icons', () => {
     vi.clearAllMocks();
   });
 
+  it('allows an empty full description and falls back to the short description', async () => {
+    const { checkbox, input } = await import('@inquirer/prompts');
+    const mockedCheckbox = vi.mocked(checkbox);
+    const mockedInput = vi.mocked(input);
+
+    mockedCheckbox.mockResolvedValueOnce(['description'] as never);
+    mockedInput
+      .mockResolvedValueOnce('Handles projects for our team' as never)
+      .mockResolvedValueOnce('' as never);
+
+    const { collectManifestCustomization } = await import('../src/apps/manifest-builder.js');
+
+    const result = await collectManifestCustomization();
+
+    const fullDescriptionPrompt = mockedInput.mock.calls[1][0] as {
+      validate: (value: string) => string | true;
+    };
+    expect(fullDescriptionPrompt.validate('')).toBe(true);
+    expect(result.description).toEqual({
+      short: 'Handles projects for our team',
+      full: undefined,
+    });
+  });
+
   it('offers Icons as a checkbox choice and returns icon paths when selected', async () => {
     const { checkbox, input } = await import('@inquirer/prompts');
     const mockedCheckbox = vi.mocked(checkbox);

--- a/packages/cli/tests/rsc-set.test.ts
+++ b/packages/cli/tests/rsc-set.test.ts
@@ -125,6 +125,7 @@ const mockDetails: AppDetails = {
 
 let capturedUpdate: Partial<AppDetails> | null = null;
 let currentPerms: RscPermissionEntry[] = [];
+let versionBumped = false;
 
 vi.mock('../src/apps/api.js', () => ({
   fetchAppDetailsV2: vi.fn(async () => {
@@ -134,7 +135,13 @@ vi.mock('../src/apps/api.js', () => ({
   }),
   updateAppDetails: vi.fn(async (_token: string, _id: string, update: Partial<AppDetails>) => {
     capturedUpdate = update;
-    return { ...mockDetails, ...update };
+    return {
+      ...mockDetails,
+      ...update,
+      version: versionBumped ? '1.0.1' : mockDetails.version,
+      versionBumped,
+      previousVersion: versionBumped ? mockDetails.version : undefined,
+    };
   }),
 }));
 
@@ -183,6 +190,7 @@ describe('rsc set command', () => {
     capturedUpdate = null;
     currentPerms = [];
     jsonOutput = null;
+    versionBumped = false;
     mockExit.mockClear();
   });
 
@@ -204,6 +212,25 @@ describe('rsc set command', () => {
       added: [{ name: 'TeamSettings.ReadWrite.Group', type: 'Application' }],
       removed: [{ name: 'ChannelMessage.Read.Group', type: 'Application' }],
       unchanged: [],
+    });
+  });
+
+  it('includes needsReinstall in JSON when the app version is bumped', async () => {
+    versionBumped = true;
+    currentPerms = [];
+
+    const { rscCommand } = await import('../src/commands/app/rsc/index.js');
+
+    await rscCommand.parseAsync(
+      ['set', 'test-teams-app-id', '--permissions', 'TeamSettings.ReadWrite.Group', '--json'],
+      { from: 'user' }
+    );
+
+    expect(jsonOutput).toEqual({
+      added: [{ name: 'TeamSettings.ReadWrite.Group', type: 'Application' }],
+      removed: [],
+      unchanged: [],
+      needsReinstall: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- Let the full description prompt accept empty input during app create, so it can fall back to the short description
- Show the reinstall hint after RSC permission updates when the app version auto-bumps
- Include `needsReinstall` in RSC JSON output when relevant

## Test plan
- npm -w @microsoft/teams.cli test -- manifest-builder-icons.test.ts rsc-set.test.ts rsc-web-app-info.test.ts
- npm -w @microsoft/teams.cli run check-types