### PR TITLE
Add AJV dependency and CLI package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22268,6 +22268,7 @@
         "@azure/msal-node-extensions": "^5.0.4",
         "@inquirer/prompts": "^7.2.1",
         "adm-zip": "^0.5.16",
+        "ajv": "^8.20.0",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
         "change-case": "^5.4.4",
@@ -22314,6 +22315,22 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/cli/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "packages/cli/node_modules/ajv-formats": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams.cli",
   "version": "3.0.0",
-  "description": "Teams Developer CLI for scaffolding Teams applications",
+  "description": "Teams Developer CLI for managing Microsoft Teams apps",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -28,6 +28,15 @@
   ],
   "author": "Microsoft",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/teams-sdk.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/teams-sdk/issues"
+  },
+  "homepage": "https://microsoft.github.io/teams-sdk/cli/",
   "engines": {
     "node": ">=20"
   },
@@ -36,6 +45,7 @@
     "@azure/msal-node-extensions": "^5.0.4",
     "@inquirer/prompts": "^7.2.1",
     "adm-zip": "^0.5.16",
+    "ajv": "^8.20.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "change-case": "^5.4.4",


### PR DESCRIPTION
Adds `ajv` as a direct dependency of the Teams Developer CLI and fills in npm package metadata.

## Why
The CLI uses `ajv-draft-04` and `ajv-formats` at runtime for manifest validation. Those packages declare `ajv` as a peer dependency. npm can hide that by hoisting/auto-installing peers, but pnpm global installs keep things stricter and fail with `Cannot find module 'ajv/dist/core'`.

Also, while we're here, the npm package should point folks to the right repo, issues page, and CLI docs. The package description now matches the CLI's broader app-management scope, not just scaffolding.

## Interesting bits
- Adds `ajv` to `packages/cli/package.json` dependencies.
- Updates the lockfile so installs have the peer available for runtime manifest validation.
- Adds `repository`, `bugs`, and `homepage` metadata for the npm page.
- Updates the package description to “Teams Developer CLI for managing Microsoft Teams apps”.

## Testing
- `npm audit -w @microsoft/teams.cli`
- `npm -w @microsoft/teams.cli test -- tests/manifest-schema-validation.test.ts tests/manifest-update-command.test.ts`
- `npm -w @microsoft/teams.cli run check-types`
