### PR TITLE
Update CLI docs sidebar and remove beta label

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ function teamsColor(text: string): string {
 program
   .name('teams')
   .description('Teams Developer CLI for managing Microsoft Teams apps')
-  .addHelpText('beforeAll', `${pc.bold(teamsColor('Teams Developer CLI'))} ${pc.bold(pc.yellow('[Beta]'))}\n`)
+  .addHelpText('beforeAll', `${pc.bold(teamsColor('Teams Developer CLI'))}\n`)
   .version(version)
   .option('-v, --verbose', '[OPTIONAL] Enable verbose logging')
   .option('-y, --yes', '[OPTIONAL] Auto-confirm prompts (for CI/agent use)')

--- a/teams.md/sidebars-cli.ts
+++ b/teams.md/sidebars-cli.ts
@@ -39,6 +39,7 @@ export default {
             'commands/app/manifest',
             'commands/app/manifest-download',
             'commands/app/manifest-upload',
+            'commands/app/manifest-update',
             'commands/app/package',
             'commands/app/package-download',
             'commands/app/bot',


### PR DESCRIPTION
Adds the `teams app manifest update` page to the CLI docs sidebar and removes the beta label from CLI help output.

## Why
The manifest update command doc exists, but the manually-maintained CLI sidebar did not link to it. Sneaky little missing nav item. Also, the CLI help header should no longer say `[Beta]` as we prep the stable release.

## Interesting bits
- Checked generated command docs against `sidebars-cli.ts`; `manifest-update` was the only missing command page.
- Removes `[Beta]` from the top-level `teams --help` banner.

## Testing
- Sidebar/docs sync scriptlet: no missing command docs, no extra sidebar IDs
- `npm -w teams-md run build`
- `npm -w @microsoft/teams.cli test -- tests/json-help.test.ts tests/help.test.ts`
- `npm -w @microsoft/teams.cli run check-types`
