### PR TITLE
Prepare stable Teams CLI release

### DIFF
--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -1,0 +1,109 @@
+name: Teams Developer CLI issue
+description: Report a bug or packaging/install issue with @microsoft/teams.cli
+title: '[CLI]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a Teams Developer CLI issue. Please include enough detail for us to reproduce the problem.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the issue and what you were trying to do.
+      placeholder: Tell us what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Share the exact commands or actions that reproduce the issue.
+      placeholder: |
+        1. Run `npm install -g @microsoft/teams.cli`
+        2. Run `teams ...`
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error output, stack traces, or screenshots if useful.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: cli-version
+    attributes:
+      label: CLI version
+      description: Run `teams --version`.
+      placeholder: e.g., 3.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Run `node --version`.
+      placeholder: e.g., v22.11.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      description: How did you install or run the CLI?
+      options:
+        - npm global install
+        - pnpm global install
+        - yarn global install
+        - npx
+        - local repo checkout
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: package-manager
+    attributes:
+      label: Package manager version
+      description: Run `npm --version`, `pnpm --version`, or `yarn --version`.
+      placeholder: e.g., npm 10.9.2
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, related links, logs, or screenshots here.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can find a set of open-source agent accelerator templates in the [Teams Agen
 The Teams Developer CLI makes it easy to bootstrap your first agent. First, install the CLI via NPM:
 
 ```sh
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 Next, use the CLI to create your agent:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,16 +1,17 @@
 # Release Process
 
-This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic version management.
+This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic version management on prerelease branches. Stable release branches use explicit, manually-bumped versions.
 
 ## How Versioning Works
 
-Versions are computed automatically from git history based on `version.json`.
+Versions are computed from `version.json` and git history.
 
 - **Main branch**: active development.
-- **Preview branch**: preview releases.
+- **Preview branch**: public preview releases.
 - **Release branch**: stable releases. For v3, use `release/v3`.
-- Versions without a prerelease suffix are stable releases, for example `3.0`.
-- Versions with a prerelease suffix are prereleases, for example `3.1-beta.{height}`.
+- **Release refs** are configured in `version.json` via `publicReleaseRefSpec`; keep this in sync with any release branch name changes.
+- **Preview versions** use a prerelease suffix and automatic height, for example `3.1-preview.{height}`. This produces versions like `3.1.0-preview.12`.
+- **Stable versions** are hard-coded on the release branch, for example `3.0.0` or `3.0.1`.
 
 The publish pipeline determines the npm tag from the computed version:
 
@@ -19,12 +20,40 @@ The publish pipeline determines the npm tag from the computed version:
 - any other prerelease → `next`
 - stable versions → `latest`
 
+Do not use a stable-looking version such as `3.1.{height}` for preview releases. Without a prerelease suffix, the publish pipeline treats the package as stable and publishes it with the `latest` npm tag.
+
+## Creating a Preview Release
+
+1. **Prepare the `preview` branch:**
+
+   - Create or update the `preview` branch from the commit you want to ship.
+   - Set `version.json` to the preview version line, for example `"3.1-preview.{height}"`.
+   - Update docs and install instructions to use the preview package where appropriate:
+
+     ```bash
+     npm install -g @microsoft/teams.cli@preview
+     ```
+
+2. **Create a PR to `preview`**, get approval, and merge.
+
+3. **Trigger the publish pipeline** for `preview` with **Public** publish type.
+
+   The pipeline stamps versions, packs packages, signs them, and publishes preview packages to npm with the `preview` tag.
+
+4. **Verify the preview release:**
+
+   ```bash
+   npm view @microsoft/teams.cli dist-tags
+   npm view @microsoft/teams.cli@preview version
+   ```
+
 ## Creating a Stable Release
 
-1. **Prepare the release branch:**
+1. **Prepare the stable release branch:**
 
-   - Create or update the stable release branch from the commit you want to ship. For v3, use `release/v3`.
-   - Set `version.json` to the stable version line, for example `"3.0"`.
+   - Create or update `release/v3` from the commit you want to ship.
+   - Set `version.json` to an explicit stable version, for example `"3.0.0"`.
+   - For patches, bump the version manually, for example from `"3.0.0"` to `"3.0.1"`.
    - Update package metadata if it still has a prerelease placeholder version.
    - Update docs and install instructions to use the stable package:
 
@@ -34,13 +63,13 @@ The publish pipeline determines the npm tag from the computed version:
 
    - Make sure CLI self-update points at npm `latest`.
 
-2. **Create a PR to the stable release branch** (`release/v3` for v3), get approval, and merge.
+2. **Create a PR to `release/v3`**, get approval, and merge.
 
-3. **Trigger the publish pipeline** for the stable release branch (`release/v3` for v3) with **Public** publish type.
+3. **Trigger the publish pipeline** for `release/v3` with **Public** publish type.
 
    The pipeline stamps versions, packs packages, signs them, and publishes stable packages to npm with the `latest` tag.
 
-4. **Verify the release:**
+4. **Verify the stable release:**
 
    ```bash
    npm view @microsoft/teams.cli dist-tags
@@ -49,7 +78,7 @@ The publish pipeline determines the npm tag from the computed version:
 
 5. **Bump `main` for the next development cycle** if needed:
    - Edit `version.json` on `main`.
-   - For example, move from `"3.0"` to `"3.1-beta.{height}"`.
+   - For example, move to `"3.1-preview.{height}"` or `"3.1-beta.{height}"`.
    - Commit and push via PR.
 
 ## Publishing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,8 +8,8 @@ Versions are computed automatically from git history based on `version.json`.
 
 - **Main branch**: active development.
 - **Preview branch**: preview releases.
-- **Release branch**: stable releases.
-- Versions without a prerelease suffix are stable releases, for example `3.0.{height}`.
+- **Release branch**: stable releases. For v3, use `release/v3`.
+- Versions without a prerelease suffix are stable releases, for example `3.0`.
 - Versions with a prerelease suffix are prereleases, for example `3.1-beta.{height}`.
 
 The publish pipeline determines the npm tag from the computed version:
@@ -23,8 +23,8 @@ The publish pipeline determines the npm tag from the computed version:
 
 1. **Prepare the release branch:**
 
-   - Create or update the `release` branch from the commit you want to ship.
-   - Set `version.json` to the stable version line, for example `"3.0.{height}"`.
+   - Create or update the stable release branch from the commit you want to ship. For v3, use `release/v3`.
+   - Set `version.json` to the stable version line, for example `"3.0"`.
    - Update package metadata if it still has a prerelease placeholder version.
    - Update docs and install instructions to use the stable package:
 
@@ -34,9 +34,9 @@ The publish pipeline determines the npm tag from the computed version:
 
    - Make sure CLI self-update points at npm `latest`.
 
-2. **Create a PR to `release`**, get approval, and merge.
+2. **Create a PR to the stable release branch** (`release/v3` for v3), get approval, and merge.
 
-3. **Trigger the publish pipeline** for `release` with **Public** publish type.
+3. **Trigger the publish pipeline** for the stable release branch (`release/v3` for v3) with **Public** publish type.
 
    The pipeline stamps versions, packs packages, signs them, and publishes stable packages to npm with the `latest` tag.
 
@@ -49,7 +49,7 @@ The publish pipeline determines the npm tag from the computed version:
 
 5. **Bump `main` for the next development cycle** if needed:
    - Edit `version.json` on `main`.
-   - For example, move from `"3.0.{height}"` to `"3.1-beta.{height}"`.
+   - For example, move from `"3.0"` to `"3.1-beta.{height}"`.
    - Commit and push via PR.
 
 ## Publishing

--- a/package-lock.json
+++ b/package-lock.json
@@ -22261,13 +22261,14 @@
     },
     "packages/cli": {
       "name": "@microsoft/teams.cli",
-      "version": "3.0.0-beta.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.2.2",
         "@azure/msal-node-extensions": "^5.0.4",
         "@inquirer/prompts": "^7.2.1",
         "adm-zip": "^0.5.16",
+        "ajv": "^8.20.0",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
         "change-case": "^5.4.4",
@@ -22314,6 +22315,22 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/cli/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "packages/cli/node_modules/ajv-formats": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
-# @microsoft/teams.cli
+# Teams Developer CLI
 
-Teams Developer CLI for managing Microsoft Teams apps.
+[![npm version](https://img.shields.io/npm/v/@microsoft/teams.cli.svg)](https://www.npmjs.com/package/@microsoft/teams.cli)
+
+Teams Developer CLI helps you create, configure, and manage Microsoft Teams apps from the command line. Use it to scaffold projects, register Teams apps and bots, manage manifests and packages, configure authentication, and automate common app lifecycle tasks.
 
 ## Install
 
@@ -14,51 +16,36 @@ npm install -g @microsoft/teams.cli
 teams
 ```
 
-This launches an interactive CLI. You can also run specific commands directly:
+This launches the interactive CLI. You can also run commands directly for scripting and automation.
 
-```bash
-teams login                          # Sign in with your Microsoft account
-teams logout                         # Sign out
-teams status                         # Check authentication status
-teams app                            # Manage a Teams app (interactive menu)
-teams app list                       # List your Teams apps
-teams app create                     # Create a new Teams app with bot
-teams app get [appId]                # Get a Teams app
-teams app update [appId]             # Update app properties
-teams app doctor [appId]             # Run diagnostic checks
-teams app manifest download [appId]  # Download manifest
-teams app manifest upload [appId]    # Upload manifest
-teams app package download [appId]   # Download app package
-teams app bot get [appId]            # Get bot location (Teams-managed vs Azure)
-teams app bot migrate [appId]        # Migrate bot to Azure
-teams app auth secret create [appId] # Generate a client secret
-teams app rsc list [appId]           # List RSC permissions
-teams app rsc add [appId]            # Add RSC permission
-teams app rsc remove [appId]         # Remove RSC permission
-teams app rsc set [appId]            # Declaratively set RSC permissions
-teams project new                    # Create a new Teams app project
-teams config                         # Manage CLI configuration
-teams self-update                    # Update to the latest version
-```
+## Documentation
 
-## Global Options
+For command reference, guides, and examples, see:
 
-| Flag                    | Description                                                        |
-| ----------------------- | ------------------------------------------------------------------ |
-| `-v, --verbose`         | Enable verbose logging                                             |
-| `--json`                | Output results as JSON (structured output, recommended for agents) |
-| `--yes` / `-y`          | Skip confirmation prompts (CI/agent use)                           |
-| `--disable-auto-update` | Disable automatic update checks                                    |
+https://aka.ms/teamscli
+
+## Automation
+
+Use these options for CI and agent workflows:
+
+| Flag                    | Description                            |
+| ----------------------- | -------------------------------------- |
+| `--json`                | Output structured JSON where supported |
+| `--yes` / `-y`          | Skip confirmation prompts              |
+| `--disable-auto-update` | Disable automatic update checks        |
+| `-v, --verbose`         | Enable verbose logging                 |
+
+Set `TEAMS_NO_INTERACTIVE=1` to disable interactive prompts entirely.
 
 ## AI Agent Skills
 
-Install agent skills to help AI assistants manage Teams bot infrastructure:
+Use Teams developer skills to help AI assistants manage Teams bot infrastructure:
 
-```bash
-npx skills add microsoft/teams-sdk --skill teams-dev
-```
+https://aka.ms/Teams-Skills
 
-See [skills/README.md](skills/README.md) for details.
+## Issues
+
+Report CLI issues at https://aka.ms/teams-cli-issues.
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,7 @@ Teams Developer CLI for managing Microsoft Teams apps.
 ## Install
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 ## Usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams.cli",
-  "version": "3.0.0-beta.0",
-  "description": "Teams Developer CLI for scaffolding Teams applications",
+  "version": "3.0.0",
+  "description": "Teams Developer CLI for managing Microsoft Teams apps",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -28,6 +28,15 @@
   ],
   "author": "Microsoft",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/teams-sdk.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/teams-sdk/issues"
+  },
+  "homepage": "https://microsoft.github.io/teams-sdk/cli/",
   "engines": {
     "node": ">=20"
   },
@@ -36,6 +45,7 @@
     "@azure/msal-node-extensions": "^5.0.4",
     "@inquirer/prompts": "^7.2.1",
     "adm-zip": "^0.5.16",
+    "ajv": "^8.20.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "change-case": "^5.4.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/microsoft/teams-sdk/issues"
+    "url": "https://aka.ms/teams-cli-issues"
   },
   "homepage": "https://microsoft.github.io/teams-sdk/cli/",
   "engines": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ function teamsColor(text: string): string {
 program
   .name('teams')
   .description('Teams Developer CLI for managing Microsoft Teams apps')
-  .addHelpText('beforeAll', `${pc.bold(teamsColor('Teams Developer CLI'))} ${pc.bold(pc.yellow('[Beta]'))}\n`)
+  .addHelpText('beforeAll', `${pc.bold(teamsColor('Teams Developer CLI'))}\n`)
   .version(version)
   .option('-v, --verbose', '[OPTIONAL] Enable verbose logging')
   .option('-y, --yes', '[OPTIONAL] Auto-confirm prompts (for CI/agent use)')

--- a/plugins/teams-sdk/skills/teams-dev/SKILL.md
+++ b/plugins/teams-sdk/skills/teams-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: teams-dev
 description: Use this skill whenever the user mentions Microsoft Teams in a development context — whether they're building, integrating, configuring, debugging, or just asking questions. Covers bots, message extensions, embedded web apps, Adaptive Cards, dialogs, SSO, infrastructure, the Teams Developer CLI/SDK, and general Teams platform queries. If the word "Teams" appears, err on the side of invoking this skill.
-teams_cli_version: 3.0.0-preview.*
+teams_cli_version: 3.0.*
 ---
 
 # Teams Bot Development & Infrastructure

--- a/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-infra.md
+++ b/plugins/teams-sdk/skills/teams-dev/references/guide-create-bot-infra.md
@@ -16,14 +16,14 @@ Verify the Teams Developer CLI is installed:
 teams --version
 ```
 
-**Expected output:** Shows version number (e.g., `3.0.0-preview.*` or later)
+**Expected output:** Shows version number (e.g., `3.0.0` or later)
 
 **If not installed:**
 
 Install the Teams Developer CLI using npm:
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 **After installation:**

--- a/teams.md/docs/cli/getting-started/installation.md
+++ b/teams.md/docs/cli/getting-started/installation.md
@@ -11,7 +11,7 @@
 Install `teams` globally from npm:
 
 ```bash
-npm install -g @microsoft/teams.cli@preview
+npm install -g @microsoft/teams.cli
 ```
 
 ## Verify

--- a/teams.md/docs/cli/index.md
+++ b/teams.md/docs/cli/index.md
@@ -5,11 +5,6 @@ slug: /
 
 # Teams Developer CLI
 
-:::warning[Preview]
-The Teams Developer CLI v3 is currently in **preview**. Commands, options, and behavior may change between releases.
-:::
-
-
 Teams Developer CLI for managing Microsoft Teams apps. Create, manage, and configure Teams apps from the command line.
 
 ## Features

--- a/teams.md/docs/main/developer-tools/agent-skills.md
+++ b/teams.md/docs/main/developer-tools/agent-skills.md
@@ -122,6 +122,6 @@ Agent: I'll create an echo bot for you.
 
 ## Requirements
 
-- Teams Developer CLI installed (`npm install -g @microsoft/teams.cli@preview`)
+- Teams Developer CLI installed (`npm install -g @microsoft/teams.cli`)
 - Node.js 20 or later
 - Microsoft 365 account with sideloading enabled

--- a/teams.md/sidebars-cli.ts
+++ b/teams.md/sidebars-cli.ts
@@ -39,6 +39,7 @@ export default {
             'commands/app/manifest',
             'commands/app/manifest-download',
             'commands/app/manifest-upload',
+            'commands/app/manifest-update',
             'commands/app/package',
             'commands/app/package-download',
             'commands/app/bot',

--- a/version.json
+++ b/version.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0",
+  "version": "3.0.0",
   "publicReleaseRefSpec": [
+    "^refs/heads/release$",
     "^refs/heads/release/v3$",
     "^refs/heads/preview$"
   ]

--- a/version.json
+++ b/version.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0-preview.{height}",
-  "publicReleaseRefSpec": ["^refs/heads/release$", "^refs/heads/preview$"]
+  "version": "3.0",
+  "publicReleaseRefSpec": [
+    "^refs/heads/release/v3$",
+    "^refs/heads/preview$"
+  ]
 }


### PR DESCRIPTION
Prepares the Teams Developer CLI stable release from the current preview branch.

## Why
This moves the CLI from the preview train to the stable release train so the publish pipeline can ship it to npm with the `latest` tag. 

## Interesting bits
- Switches `version.json` from `3.0-preview.{height}` to the stable `3.0` line.
- Updates install docs and skill guidance from `@preview` to the stable package.
- Removes the CLI preview warning from the docs.
- Keeps self-update pointed at npm `latest`.
- Updates release docs to use the v3 stable branch, `release/v3`. The plain `release` branch name is blocked by the existing `release/v1` ref.

## Testing
- `nbgv get-version -v NpmPackageVersion --public-release=true` → `3.0.1`
- `npm audit -w @microsoft/teams.cli`
- `npm -w @microsoft/teams.cli test -- tests/self-update.test.ts tests/manifest-schema-validation.test.ts tests/manifest-update-command.test.ts`
- `npm -w @microsoft/teams.cli run check-types`
- `npm -w teams-md run build`
