### PR TITLE
docs: suggestedActions/submit + python AI best practices

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/ai/best-practices/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/best-practices/csharp.incl.md
@@ -56,3 +56,55 @@ var message = new MessageActivity
     }).AddAIGenerated();
 await context.Send(message);
 ```
+
+<!-- suggested-actions-submit-send-method -->
+
+Use the `ActionType.Submit` suggested action type when you want the click to deliver a structured payload to your bot without posting a visible message on the user's behalf.
+
+:::warning Experimental API
+`ActionType.Submit` and `OnSuggestedActionSubmit` are marked `[Experimental("ExperimentalTeamsSuggestedAction")]`. The platform feature will be generally available by end of summer 2026.
+:::
+
+<!-- suggested-actions-submit-send-code -->
+
+```csharp
+#pragma warning disable ExperimentalTeamsSuggestedAction
+
+using CardAction = Microsoft.Teams.Api.Cards.Action;
+using CardActionType = Microsoft.Teams.Api.Cards.ActionType;
+
+var reply = new MessageActivity("Approve or reject the request:")
+{
+    SuggestedActions = new SuggestedActions
+    {
+        Actions =
+        {
+            new CardAction(CardActionType.Submit) { Title = "Approve", Value = new { vote = "approve" } },
+            new CardAction(CardActionType.Submit) { Title = "Reject",  Value = new { vote = "reject" } }
+        }
+    }
+};
+await context.Send(reply);
+```
+
+<!-- suggested-actions-submit-handle-method -->
+
+The click arrives as a typed `suggestedActions/submit` invoke. Register a handler with `OnSuggestedActionSubmit` and read the payload from `context.Activity.Value`.
+
+<!-- suggested-actions-submit-handle-code -->
+
+```csharp
+#pragma warning disable ExperimentalTeamsSuggestedAction
+
+using System.Text.Json;
+using Microsoft.Teams.Apps.Activities.Invokes;
+
+teams.OnSuggestedActionSubmit(async (context, cancellationToken) =>
+{
+    var payload = context.Activity.Value is JsonElement value
+        ? value.GetRawText()
+        : "<none>";
+
+    await context.Send($"Got vote: {payload}", cancellationToken);
+});
+```

--- a/teams.md/src/components/include/in-depth-guides/ai/best-practices/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/best-practices/python.incl.md
@@ -1,0 +1,102 @@
+<!-- ai-generated-method -->
+
+This can be done by calling the `.add_ai_generated()` method on outgoing messages.
+
+<!-- ai-generated-code -->
+
+```python
+message = MessageActivityInput(text="Hello!").add_ai_generated()
+```
+
+<!-- citations-method -->
+
+This is easy to do by using the `add_citation` method on the message.
+
+<!-- citations-code -->
+
+```python
+from microsoft_teams.api import MessageActivityInput
+from microsoft_teams.api.models.entity import CitationAppearance
+
+message = MessageActivityInput(text=result.content).add_ai_generated()
+
+for i, doc in enumerate(cited_docs):
+    position = i + 1
+    message.text += f"[{position}]"
+    message.add_citation(
+        position,
+        CitationAppearance(name=doc.title, abstract=doc.content),
+    )
+```
+
+<!-- suggested-actions-method -->
+
+You can do that by using the `with_suggested_actions` method on the message.
+
+<!-- suggested-actions-code -->
+
+```python
+from microsoft_teams.api import MessageActivityInput
+from microsoft_teams.api.models.card.card_action import CardAction
+from microsoft_teams.api.models.card.card_action_type import CardActionType
+from microsoft_teams.api.models.suggested_actions import SuggestedActions
+
+message = MessageActivityInput(text=result.content).with_suggested_actions(
+    SuggestedActions(
+        to=[ctx.activity.from_.id],
+        actions=[
+            CardAction(
+                type=CardActionType.IM_BACK,
+                title="Thank you!",
+                value="Thank you very much!",
+            ),
+        ],
+    )
+).add_ai_generated()
+await ctx.send(message)
+```
+
+<!-- suggested-actions-submit-send-method -->
+
+Use the `CardActionType.SUBMIT` suggested action type when you want the click to deliver a structured payload to your bot without posting a visible message on the user's behalf.
+
+:::warning Experimental API
+`CardActionType.SUBMIT`, `SuggestedActionSubmitInvokeActivity`, and `on_suggested_action_submit` are marked `@experimental("ExperimentalTeamsSuggestedAction")`. The platform feature will be generally available by end of summer 2026.
+:::
+
+<!-- suggested-actions-submit-send-code -->
+
+```python
+from microsoft_teams.api import MessageActivityInput
+from microsoft_teams.api.models.card.card_action import CardAction
+from microsoft_teams.api.models.card.card_action_type import CardActionType
+from microsoft_teams.api.models.suggested_actions import SuggestedActions
+
+reply = MessageActivityInput(text="Approve or reject the request:").with_suggested_actions(
+    SuggestedActions(
+        to=[],
+        actions=[
+            CardAction(type=CardActionType.SUBMIT, title="Approve", value={"vote": "approve"}),
+            CardAction(type=CardActionType.SUBMIT, title="Reject", value={"vote": "reject"}),
+        ],
+    )
+)
+await ctx.send(reply)
+```
+
+<!-- suggested-actions-submit-handle-method -->
+
+The click arrives as a typed `suggestedActions/submit` invoke. Register a handler with the `@app.on_suggested_action_submit` decorator and read the payload from `ctx.activity.value`.
+
+<!-- suggested-actions-submit-handle-code -->
+
+```python
+import json
+from microsoft_teams.api.activities.invoke.suggested_action_submit import SuggestedActionSubmitInvokeActivity
+from microsoft_teams.apps import ActivityContext
+
+@app.on_suggested_action_submit
+async def handle_suggested_action_submit(ctx: ActivityContext[SuggestedActionSubmitInvokeActivity]) -> None:
+    payload = json.dumps(ctx.activity.value)
+    await ctx.send(f"Got vote: {payload}")
+```

--- a/teams.md/src/components/include/in-depth-guides/ai/best-practices/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/best-practices/typescript.incl.md
@@ -48,3 +48,41 @@ message.withSuggestedActions({
   ],
 });
 ```
+
+<!-- suggested-actions-submit-send-method -->
+
+Use the `Action.Submit` suggested action type when you want the click to deliver a structured payload to your bot without posting a visible message on the user's behalf.
+
+:::warning Experimental API
+The `Action.Submit` card action type and the `suggested-action.submit` route are marked `@experimental`. The platform feature will be generally available by end of summer 2026.
+:::
+
+<!-- suggested-actions-submit-send-code -->
+
+```typescript
+import { MessageActivity, SuggestedActions } from '@microsoft/teams.api';
+
+const reply = new MessageActivity('Approve or reject the request:');
+reply.suggestedActions = {
+  to: [],
+  actions: [
+    { type: 'Action.Submit', title: 'Approve', value: { vote: 'approve' } },
+    { type: 'Action.Submit', title: 'Reject', value: { vote: 'reject' } },
+  ],
+} satisfies SuggestedActions;
+
+await send(reply);
+```
+
+<!-- suggested-actions-submit-handle-method -->
+
+The click arrives as a typed `suggestedActions/submit` invoke. Register a handler with the `suggested-action.submit` route and read the payload from `activity.value`.
+
+<!-- suggested-actions-submit-handle-code -->
+
+```typescript
+app.on('suggested-action.submit', async ({ send, activity }) => {
+  const payload = activity.value != null ? JSON.stringify(activity.value) : '<none>';
+  await send(`Got vote: ${payload}`);
+});
+```

--- a/teams.md/src/pages/templates/in-depth-guides/ai/best-practices.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai/best-practices.mdx
@@ -3,7 +3,7 @@ sidebar_position: 5
 sidebar_label: Best Practices
 title: Best Practices
 summary: Best practices for AI integration in Teams applications, including AI-generated message indicators, feedback collection for prompt improvement, and citation handling to ensure transparency and accuracy in AI responses.
-languages: ['typescript', 'csharp']
+languages: ['typescript', 'csharp', 'python']
 ---
 
 # Best Practices
@@ -38,6 +38,20 @@ Citations are added with a `position` property. This property value needs to als
 
 ## Suggested actions
 
-Suggested actions help users with ideas of what to ask next, based on the previous response or conversation. Teams recommends including suggested actions in your messages. <LanguageInclude section="suggested-actions-method" /> See [Suggested actions](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/conversations/prompt-suggestions) for more information on suggested actions.
+Suggested actions help users with ideas of what to ask next, based on the previous response or conversation. Teams recommends including suggested actions in your messages. <LanguageInclude section="suggested-actions-method" />
 
 <LanguageInclude section="suggested-actions-code" />
+
+### Sending an Action.Submit suggested action
+
+<LanguageInclude section="suggested-actions-submit-send-method" />
+
+<LanguageInclude section="suggested-actions-submit-send-code" />
+
+### Handling an Action.Submit suggested action
+
+<LanguageInclude section="suggested-actions-submit-handle-method" />
+
+<LanguageInclude section="suggested-actions-submit-handle-code" />
+
+See [Suggested actions](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/conversations/prompt-suggestions) for more information on suggested actions.


### PR DESCRIPTION
Adds docs for the new suggestedActions/submit (Action.Submit) feature across C#, TypeScript, and Python. Also fills in the missing AI best practices sections for Python (AI-generated indicator, citations, suggested actions).

How it looks like in the csharp docs:

<img width="939" height="661" alt="image" src="https://github.com/user-attachments/assets/f2efba95-8dd3-44c5-8122-74e8a49fbe03" />

<img width="948" height="479" alt="image" src="https://github.com/user-attachments/assets/71d12d9c-bc24-46ae-80e7-16175bf7942f" />

Content is pretty much the same for the other languages.