### PR TITLE
Update CLI README and release guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -1,0 +1,109 @@
+name: Teams Developer CLI issue
+description: Report a bug or packaging/install issue with @microsoft/teams.cli
+title: '[CLI]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a Teams Developer CLI issue. Please include enough detail for us to reproduce the problem.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the issue and what you were trying to do.
+      placeholder: Tell us what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Share the exact commands or actions that reproduce the issue.
+      placeholder: |
+        1. Run `npm install -g @microsoft/teams.cli`
+        2. Run `teams ...`
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error output, stack traces, or screenshots if useful.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: cli-version
+    attributes:
+      label: CLI version
+      description: Run `teams --version`.
+      placeholder: e.g., 3.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Run `node --version`.
+      placeholder: e.g., v22.11.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      description: How did you install or run the CLI?
+      options:
+        - npm global install
+        - pnpm global install
+        - yarn global install
+        - npx
+        - local repo checkout
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: package-manager
+    attributes:
+      label: Package manager version
+      description: Run `npm --version`, `pnpm --version`, or `yarn --version`.
+      placeholder: e.g., npm 10.9.2
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, related links, logs, or screenshots here.
+    validations:
+      required: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,16 +1,17 @@
 # Release Process
 
-This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic version management.
+This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic version management on prerelease branches. Stable release branches use explicit, manually-bumped versions.
 
 ## How Versioning Works
 
-Versions are computed automatically from git history based on `version.json`.
+Versions are computed from `version.json` and git history.
 
 - **Main branch**: active development.
-- **Preview branch**: preview releases.
-- **Release branch**: stable releases.
-- Versions without a prerelease suffix are stable releases, for example `3.0.{height}`.
-- Versions with a prerelease suffix are prereleases, for example `3.1-beta.{height}`.
+- **Preview branch**: public preview releases.
+- **Release branch**: stable releases. For v3, use `release/v3`.
+- **Release refs** are configured in `version.json` via `publicReleaseRefSpec`; keep this in sync with any release branch name changes.
+- **Preview versions** use a prerelease suffix and automatic height, for example `3.1-preview.{height}`. This produces versions like `3.1.0-preview.12`.
+- **Stable versions** are hard-coded on the release branch, for example `3.0.0` or `3.0.1`.
 
 The publish pipeline determines the npm tag from the computed version:
 
@@ -19,12 +20,40 @@ The publish pipeline determines the npm tag from the computed version:
 - any other prerelease → `next`
 - stable versions → `latest`
 
+Do not use a stable-looking version such as `3.1.{height}` for preview releases. Without a prerelease suffix, the publish pipeline treats the package as stable and publishes it with the `latest` npm tag.
+
+## Creating a Preview Release
+
+1. **Prepare the `preview` branch:**
+
+   - Create or update the `preview` branch from the commit you want to ship.
+   - Set `version.json` to the preview version line, for example `"3.1-preview.{height}"`.
+   - Update docs and install instructions to use the preview package where appropriate:
+
+     ```bash
+     npm install -g @microsoft/teams.cli@preview
+     ```
+
+2. **Create a PR to `preview`**, get approval, and merge.
+
+3. **Trigger the publish pipeline** for `preview` with **Public** publish type.
+
+   The pipeline stamps versions, packs packages, signs them, and publishes preview packages to npm with the `preview` tag.
+
+4. **Verify the preview release:**
+
+   ```bash
+   npm view @microsoft/teams.cli dist-tags
+   npm view @microsoft/teams.cli@preview version
+   ```
+
 ## Creating a Stable Release
 
-1. **Prepare the release branch:**
+1. **Prepare the stable release branch:**
 
-   - Create or update the `release` branch from the commit you want to ship.
-   - Set `version.json` to the stable version line, for example `"3.0.{height}"`.
+   - Create or update `release/v3` from the commit you want to ship.
+   - Set `version.json` to an explicit stable version, for example `"3.0.0"`.
+   - For patches, bump the version manually, for example from `"3.0.0"` to `"3.0.1"`.
    - Update package metadata if it still has a prerelease placeholder version.
    - Update docs and install instructions to use the stable package:
 
@@ -34,13 +63,13 @@ The publish pipeline determines the npm tag from the computed version:
 
    - Make sure CLI self-update points at npm `latest`.
 
-2. **Create a PR to `release`**, get approval, and merge.
+2. **Create a PR to `release/v3`**, get approval, and merge.
 
-3. **Trigger the publish pipeline** for `release` with **Public** publish type.
+3. **Trigger the publish pipeline** for `release/v3` with **Public** publish type.
 
    The pipeline stamps versions, packs packages, signs them, and publishes stable packages to npm with the `latest` tag.
 
-4. **Verify the release:**
+4. **Verify the stable release:**
 
    ```bash
    npm view @microsoft/teams.cli dist-tags
@@ -49,7 +78,7 @@ The publish pipeline determines the npm tag from the computed version:
 
 5. **Bump `main` for the next development cycle** if needed:
    - Edit `version.json` on `main`.
-   - For example, move from `"3.0.{height}"` to `"3.1-beta.{height}"`.
+   - For example, move to `"3.1-preview.{height}"` or `"3.1-beta.{height}"`.
    - Commit and push via PR.
 
 ## Publishing

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,8 @@
-# @microsoft/teams.cli
+# Teams Developer CLI
 
-Teams Developer CLI for managing Microsoft Teams apps.
+[![npm version](https://img.shields.io/npm/v/@microsoft/teams.cli.svg)](https://www.npmjs.com/package/@microsoft/teams.cli)
+
+Teams Developer CLI helps you create, configure, and manage Microsoft Teams apps from the command line. Use it to scaffold projects, register Teams apps and bots, manage manifests and packages, configure authentication, and automate common app lifecycle tasks.
 
 ## Install
 
@@ -14,51 +16,36 @@ npm install -g @microsoft/teams.cli
 teams
 ```
 
-This launches an interactive CLI. You can also run specific commands directly:
+This launches the interactive CLI. You can also run commands directly for scripting and automation.
 
-```bash
-teams login                          # Sign in with your Microsoft account
-teams logout                         # Sign out
-teams status                         # Check authentication status
-teams app                            # Manage a Teams app (interactive menu)
-teams app list                       # List your Teams apps
-teams app create                     # Create a new Teams app with bot
-teams app get [appId]                # Get a Teams app
-teams app update [appId]             # Update app properties
-teams app doctor [appId]             # Run diagnostic checks
-teams app manifest download [appId]  # Download manifest
-teams app manifest upload [appId]    # Upload manifest
-teams app package download [appId]   # Download app package
-teams app bot get [appId]            # Get bot location (Teams-managed vs Azure)
-teams app bot migrate [appId]        # Migrate bot to Azure
-teams app auth secret create [appId] # Generate a client secret
-teams app rsc list [appId]           # List RSC permissions
-teams app rsc add [appId]            # Add RSC permission
-teams app rsc remove [appId]         # Remove RSC permission
-teams app rsc set [appId]            # Declaratively set RSC permissions
-teams project new                    # Create a new Teams app project
-teams config                         # Manage CLI configuration
-teams self-update                    # Update to the latest version
-```
+## Documentation
 
-## Global Options
+For command reference, guides, and examples, see:
 
-| Flag                    | Description                                                        |
-| ----------------------- | ------------------------------------------------------------------ |
-| `-v, --verbose`         | Enable verbose logging                                             |
-| `--json`                | Output results as JSON (structured output, recommended for agents) |
-| `--yes` / `-y`          | Skip confirmation prompts (CI/agent use)                           |
-| `--disable-auto-update` | Disable automatic update checks                                    |
+https://aka.ms/teamscli
+
+## Automation
+
+Use these options for CI and agent workflows:
+
+| Flag                    | Description                            |
+| ----------------------- | -------------------------------------- |
+| `--json`                | Output structured JSON where supported |
+| `--yes` / `-y`          | Skip confirmation prompts              |
+| `--disable-auto-update` | Disable automatic update checks        |
+| `-v, --verbose`         | Enable verbose logging                 |
+
+Set `TEAMS_NO_INTERACTIVE=1` to disable interactive prompts entirely.
 
 ## AI Agent Skills
 
-Install agent skills to help AI assistants manage Teams bot infrastructure:
+Use Teams developer skills to help AI assistants manage Teams bot infrastructure:
 
-```bash
-npx skills add microsoft/teams-sdk --skill teams-dev
-```
+https://aka.ms/Teams-Skills
 
-See [skills/README.md](skills/README.md) for details.
+## Issues
+
+Report CLI issues at https://aka.ms/teams-cli-issues.
 
 ## License
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/microsoft/teams-sdk/issues"
+    "url": "https://aka.ms/teams-cli-issues"
   },
   "homepage": "https://microsoft.github.io/teams-sdk/cli/",
   "engines": {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "3.0.{height}",
-  "publicReleaseRefSpec": ["^refs/heads/release$", "^refs/heads/preview$"]
+  "publicReleaseRefSpec": [
+    "^refs/heads/release$",
+    "^refs/heads/release/v3$",
+    "^refs/heads/preview$"
+  ]
 }


### PR DESCRIPTION
Cleans up the CLI package README, adds a CLI issue template, and updates release guidance.

## Why
The npm README was a little too command-dumpy and had a stale skills link. Also we decided release docs should be explicit about preview vs stable versioning: preview uses height-based prerelease versions, stable release branches use manually bumped versions.

## Interesting bits
- Simplifies the CLI README with a short About, install, usage, docs, automation, skills, and issues sections.
- Points CLI docs to `http://aka.ms/teamscli` and skills to `https://aka.ms/Teams-Skills`.
- Adds a dedicated Teams Developer CLI issue template.
- Updates `RELEASE.md` to document `3.1-preview.{height}` for preview and manual versions on `release/v3`.

## Testing
- `npx prettier --check RELEASE.md packages/cli/README.md .github/ISSUE_TEMPLATE/cli.yml`
- YAML parse check for `.github/ISSUE_TEMPLATE/cli.yml`
