### PR TITLE
Bump preview to 3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22261,7 +22261,7 @@
     },
     "packages/cli": {
       "name": "@microsoft/teams.cli",
-      "version": "3.0.0-beta.0",
+      "version": "3.1.0-preview.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.2.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teams.cli",
-  "version": "3.0.0-beta.0",
+  "version": "3.1.0-preview.0",
   "description": "Teams Developer CLI for managing Microsoft Teams apps",
   "type": "module",
   "main": "dist/index.js",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0-preview.{height}",
-  "publicReleaseRefSpec": ["^refs/heads/release$", "^refs/heads/preview$"]
+  "version": "3.1-preview.{height}",
+  "publicReleaseRefSpec": [
+    "^refs/heads/release$",
+    "^refs/heads/release/v3$",
+    "^refs/heads/preview$"
+  ]
 }


### PR DESCRIPTION
Moves the preview branch to the 3.1 preview train.

## Why
3.0 has shipped stable, so preview can move forward to the next 3.1 prerelease line.

## Interesting bits
- Sets `version.json` to `3.1-preview.{height}` so the publish pipeline keeps using the npm `preview` tag.
- Updates the CLI package placeholder version to `3.1.0-preview.0`.
- Carries `release/v3` in `publicReleaseRefSpec` so future stable release refs stay recognized.

## Testing
- `nbgv get-version -v NpmPackageVersion` → `3.1.0-preview.0.ge3817dadd0`
- `nbgv get-version -v NpmPackageVersion --public-release=true` → `3.1.0-preview.0`
- `npm audit -w @microsoft/teams.cli`
- `npm -w @microsoft/teams.cli run check-types`
- `npx prettier --check version.json packages/cli/package.json package-lock.json`
