### PR TITLE
docs(blog): add DevTools to Agents Playground migration post

### DIFF
--- a/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
+++ b/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
@@ -22,7 +22,7 @@ DevTools, a local set of development tools for testing Teams apps without sidelo
 
 ## What is Microsoft 365 Agents Playground
 
-Playground is a standalone CLI tool, installed alongside your bot rather than bundled into your project. It opens a chat UI at `http://localhost:56150`, lets you send messages to your bot, mock arbitrary activity types (membership changes, invokes, message reactions), and inspect every HTTP exchange in a log panel.
+Playground is a standalone web app you launch from the command line, installed alongside your bot rather than bundled into your project. It opens a chat UI at `http://localhost:56150`, lets you send messages to your bot, mock arbitrary activity types (membership changes, invokes, message reactions), and inspect every HTTP exchange in a log panel.
 
 ## Install
 
@@ -86,8 +86,10 @@ If you never used the DevTools package, no code change is needed. Just install P
 Start your bot locally on port `3978`, then in another shell:
 
 ```bash
-agentsplayground -e http://localhost:3978/api/messages -c emulator
+agentsplayground -e http://localhost:3978/api/messages -c msteams
 ```
+
+The `-c msteams` flag runs Playground in the Teams channel, so your agent receives the same `channelId` and lifecycle events (like installation updates) it would in production.
 
 The UI opens at `http://localhost:56150`. Type a message, your bot replies inline, and the log panel shows the full HTTP round trip.
 
@@ -95,17 +97,19 @@ The UI opens at `http://localhost:56150`. Type a message, your bot replies inlin
 
 DevTools bypassed authentication implicitly because it ran in-process. Playground sends real HTTP requests, so your bot needs to accept them.
 
-The easiest path is to leave your AAD credentials unset. Comment out `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` in `.env` (TypeScript and Python), or omit the equivalents from `appsettings.json` (.NET). The SDK detects there are no credentials and accepts unauthenticated requests, with a startup warning so the mode is explicit:
+The easiest path is to leave your credentials unset. The SDK detects there are no credentials and accepts unauthenticated requests, with a startup warning so the mode is explicit:
 
 ```
 [WARN] No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). Bot will accept unauthenticated requests on /api/messages.
 ```
 
-If you want to keep credentials configured (for example, to match a production environment), set the `skipAuth` option instead. In TypeScript that is `new App({ skipAuth: true })`; in Python, `App(skip_auth=True)`; in .NET, `builder.AddTeams(skipAuth: true)`. This option assumes your credentials are real and valid.
-
 ## Want to test in Teams directly?
 
-Playground is the fastest way to iterate locally, but you can also run your agent inside Teams itself. The Teams Developer CLI registers your agent (identity, credentials, and manifest) in a single command, so you can test in the real client instead of an emulator:
+Playground is the fastest way to iterate locally, but you can also run your agent inside Teams itself. There are a few ways to get there.
+
+Let your coding agent handle it with the [`teams-dev` agent skill](/developer-tools/agent-skills), which works with Copilot, Claude Code, and Cursor. Ask it to "get my agent running in Teams" and it drives the registration for you.
+
+Or use the Teams Developer CLI directly. It registers your agent (identity, credentials, and manifest) in a single command, so you can test in the real Teams client instead of locally:
 
 ```bash
 npm install -g @microsoft/teams.cli@preview
@@ -113,11 +117,13 @@ teams login
 teams app create --name "My Agent" --endpoint https://<your-tunnel>/api/messages --env .env
 ```
 
+The Teams Developer CLI is not required for this. You can register the app and create the bot resource directly with the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) (`az`) or the Azure portal; the Teams CLI simply rolls those steps into one command.
+
 See the [CLI docs](/cli/) to get your agent running in Teams.
 
 ## What stays the same
 
-Your bot code, message handlers, manifests, and deployment story all work unchanged. Only the local debugging glue moves: a plugin or project reference goes away, and a standalone CLI tool takes its place.
+Your bot code, message handlers, manifests, and deployment story all work unchanged. Only the local debugging glue moves: a plugin or project reference goes away, and a standalone tool takes its place.
 
 ## Questions and feedback
 

--- a/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
+++ b/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
@@ -13,6 +13,8 @@ description: DevTools is being deprecated in favor of Microsoft 365 Agents Playg
 
 DevTools, a local set of development tools for testing Teams apps without sideloading, is being retired across all three Teams SDK languages in favor of Microsoft 365 Agents Playground. The DevTools integrations in code have been marked as obsolete in TypeScript and .NET, and for Python the package has already been removed from PyPI. If you use DevTools today, here is what to install, what to remove from your bot, and how the local dev loop changes.
 
+To make the development experience more streamlined, we've decided to adopt Agents Playground as our primary local development tool. This affords developers the robust feature set of Agents Playground while still streamlining being able to test your agent where it truly matters, in Teams.
+
 <!-- truncate -->
 
 ## What changes

--- a/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
+++ b/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
@@ -11,7 +11,7 @@ tags: [teams-sdk, devtools, agents-playground, local-development]
 description: DevTools is being deprecated in favor of Microsoft 365 Agents Playground. Here is what to install, what to remove from your bot, and how your local dev loop changes.
 ---
 
-DevTools is being retired across all three Teams SDK languages in favor of Microsoft 365 Agents Playground. It is now obsolete in TypeScript and .NET, and the package has already been removed in Python. If you use DevTools today, here is what to install, what to remove from your bot, and how the local dev loop changes.
+DevTools, a local set of development tools for testing Teams apps without sideloading, is being retired across all three Teams SDK languages in favor of Microsoft 365 Agents Playground. The DevTools integrations in code have been marked as obsolete in TypeScript and .NET, and for Python the package has already been removed from PyPI. If you use DevTools today, here is what to install, what to remove from your bot, and how the local dev loop changes.
 
 <!-- truncate -->
 
@@ -98,11 +98,22 @@ DevTools bypassed authentication implicitly because it ran in-process. Playgroun
 The easiest path is to leave your AAD credentials unset. Comment out `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` in `.env` (TypeScript and Python), or omit the equivalents from `appsettings.json` (.NET). The SDK detects there are no credentials and accepts unauthenticated requests, with a startup warning so the mode is explicit:
 
 ```
-[WARN] No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID).
-       Bot will accept unauthenticated requests on /api/messages.
+[WARN] No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). Bot will accept unauthenticated requests on /api/messages.
 ```
 
 If you want to keep credentials configured (for example, to match a production environment), set the `skipAuth` option instead. In TypeScript that is `new App({ skipAuth: true })`; in Python, `App(skip_auth=True)`; in .NET, `builder.AddTeams(skipAuth: true)`. This option assumes your credentials are real and valid.
+
+## Want to test in Teams directly?
+
+Playground is the fastest way to iterate locally, but you can also run your agent inside Teams itself. The Teams Developer CLI registers your agent (identity, credentials, and manifest) in a single command, so you can test in the real client instead of an emulator:
+
+```bash
+npm install -g @microsoft/teams.cli@preview
+teams login
+teams app create --name "My Agent" --endpoint https://<your-tunnel>/api/messages --env .env
+```
+
+See the [CLI docs](/cli/) to get your agent running in Teams.
 
 ## What stays the same
 

--- a/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
+++ b/teams.md/blog/2026-06-04-devtools-to-agents-playground/index.md
@@ -1,0 +1,117 @@
+---
+slug: devtools-to-agents-playground
+title: "Switching from DevTools to Microsoft 365 Agents Playground"
+date: 2026-06-04
+authors:
+  - name: Corina Gum
+    title: Microsoft
+    url: https://github.com/corinagum
+    image_url: https://github.com/corinagum.png
+tags: [teams-sdk, devtools, agents-playground, local-development]
+description: DevTools is being deprecated in favor of Microsoft 365 Agents Playground. Here is what to install, what to remove from your bot, and how your local dev loop changes.
+---
+
+DevTools is being retired across all three Teams SDK languages in favor of Microsoft 365 Agents Playground. It is now obsolete in TypeScript and .NET, and the package has already been removed in Python. If you use DevTools today, here is what to install, what to remove from your bot, and how the local dev loop changes.
+
+<!-- truncate -->
+
+## What changes
+
+- **TypeScript and .NET:** `DevtoolsPlugin` and `AddTeamsDevTools()` are now marked obsolete. They keep working through the grace period and emit a deprecation warning at build time. Removal will happen in a later release, so you can migrate at your own pace.
+- **Python:** The `microsoft-teams-devtools` package was deprecated and has already been removed. If you depend on it, move to Playground now.
+
+## What is Microsoft 365 Agents Playground
+
+Playground is a standalone CLI tool, installed alongside your bot rather than bundled into your project. It opens a chat UI at `http://localhost:56150`, lets you send messages to your bot, mock arbitrary activity types (membership changes, invokes, message reactions), and inspect every HTTP exchange in a log panel.
+
+## Install
+
+### Option 1: npm (recommended)
+
+```bash
+npm install -g @microsoft/m365agentsplayground
+```
+
+### Option 2: Standalone binary (Windows)
+
+```bash
+winget install agentsplayground
+```
+
+For other platforms and full install options, see the [Microsoft Learn guide](https://learn.microsoft.com/en-us/microsoft-365/agents-sdk/test-with-toolkit-project).
+
+## Migration steps
+
+### TypeScript
+
+Remove the plugin from your `App` constructor:
+
+```diff
+- import { DevtoolsPlugin } from '@microsoft/teams.dev';
+  import { App } from '@microsoft/teams.apps';
+
+- const app = new App({ plugins: [new DevtoolsPlugin()] });
++ const app = new App();
+```
+
+Then remove `@microsoft/teams.dev` from your `package.json`.
+
+### .NET
+
+Remove the call and the project reference:
+
+```diff
+- builder.AddTeams().AddTeamsDevTools();
++ builder.AddTeams();
+```
+
+Drop the `Microsoft.Teams.Plugins.AspNetCore.DevTools` `ProjectReference` from your `.csproj`.
+
+### Python
+
+Remove the plugin from your `App` and drop `microsoft-teams-devtools` from your dependencies:
+
+```diff
+- from microsoft_teams.devtools import DevToolsPlugin
+  from microsoft_teams.apps import App
+
+- app = App(plugins=[DevToolsPlugin()])
++ app = App()
+```
+
+If you never used the DevTools package, no code change is needed. Just install Playground.
+
+## Run Playground against your bot
+
+Start your bot locally on port `3978`, then in another shell:
+
+```bash
+agentsplayground -e http://localhost:3978/api/messages -c emulator
+```
+
+The UI opens at `http://localhost:56150`. Type a message, your bot replies inline, and the log panel shows the full HTTP round trip.
+
+## Running without credentials
+
+DevTools bypassed authentication implicitly because it ran in-process. Playground sends real HTTP requests, so your bot needs to accept them.
+
+The easiest path is to leave your AAD credentials unset. Comment out `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` in `.env` (TypeScript and Python), or omit the equivalents from `appsettings.json` (.NET). The SDK detects there are no credentials and accepts unauthenticated requests, with a startup warning so the mode is explicit:
+
+```
+[WARN] No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID).
+       Bot will accept unauthenticated requests on /api/messages.
+```
+
+If you want to keep credentials configured (for example, to match a production environment), set the `skipAuth` option instead. In TypeScript that is `new App({ skipAuth: true })`; in Python, `App(skip_auth=True)`; in .NET, `builder.AddTeams(skipAuth: true)`. This option assumes your credentials are real and valid.
+
+## What stays the same
+
+Your bot code, message handlers, manifests, and deployment story all work unchanged. Only the local debugging glue moves: a plugin or project reference goes away, and a standalone CLI tool takes its place.
+
+## Questions and feedback
+
+File issues against the relevant SDK repo:
+
+- [microsoft/teams.ts](https://github.com/microsoft/teams.ts)
+- [microsoft/teams.py](https://github.com/microsoft/teams.py)
+- [microsoft/teams.net](https://github.com/microsoft/teams.net)

--- a/teams.md/docs/main/developer-tools/agents-playground/README.md
+++ b/teams.md/docs/main/developer-tools/agents-playground/README.md
@@ -31,9 +31,7 @@ If your agent previously used `DevtoolsPlugin` from `@microsoft/teams.dev`, remo
 
 You can also remove `@microsoft/teams.dev` from your `package.json` after deleting `DevtoolsPlugin`. The Playground is installed separately as a CLI tool, not as a project dependency.
 
-The Playground talks to your agent in `emulator` channel mode, which sends no JWT. Your agent therefore needs to accept unauthenticated requests on `/api/messages`. There are two ways to do this.
-
-### Recommended: run anonymously
+The Playground sends requests without a Bot Framework JWT, so your agent needs to accept unauthenticated requests on `/api/messages`.
 
 For local development, leave `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` unset (for example, comment them out of your `.env`). With no credentials configured, the bot does not enforce JWT validation. The SDK logs a warning at startup confirming the bot is in anonymous mode:
 
@@ -43,27 +41,16 @@ For local development, leave `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` unset (
 
 This is the cleanest migration path: nothing to add to your code, and the startup warning makes the mode explicit.
 
-### Alternative: `skipAuth: true`
-
-If you need to keep credentials configured for local dev (for example, to match a production config), set `skipAuth: true` on your `App` instead:
-
-```typescript
-const app = new App({
-  // ...
-  skipAuth: true,  // local development only; do not enable in production
-});
-```
-
 ### Why this is needed
 
-`DevtoolsPlugin` previously bypassed JWT validation implicitly because it ran in-process and never went through `/api/messages` over HTTP. The Playground sends real HTTP requests, so the bot's JWT validator fires unless one of the two options above is in effect.
+`DevtoolsPlugin` previously bypassed JWT validation implicitly because it ran in-process and never went through `/api/messages` over HTTP. The Playground sends real HTTP requests, so the bot's JWT validator runs unless the bot is left anonymous.
 
 ## Launch
 
 Start your agent locally (default port `3978`), then run:
 
 ```bash
-agentsplayground -e http://localhost:3978/api/messages -c emulator
+agentsplayground -e http://localhost:3978/api/messages -c msteams
 ```
 
 The playground opens at [http://localhost:56150](http://localhost:56150).


### PR DESCRIPTION
## Summary

Adds a blog post walking developers through migrating from DevTools to Microsoft 365 Agents Playground.

Covers:
- What changes per language (TypeScript and .NET marked obsolete; the Python `microsoft-teams-devtools` package already removed)
- Installing Playground (npm and winget)
- Per-language removal steps with before/after diffs
- Running Playground against a local bot
- Running without credentials (anonymous mode) vs. `skipAuth`, including the note that `skipAuth` assumes valid credentials

## Notes

- The anonymous-mode and `skipAuth` behaviors described were verified end-to-end against Playground with the TypeScript and Python echo examples.
- Post dated `2026-06-04`; folder name matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)