### PR TITLE
Add service-attributed app creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # Local env files
 .env
+.teams_env
 .env.local
 .env.development.local
 .env.test.local

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -47,6 +47,8 @@ Use `createSilentSpinner()` from `src/utils/spinner.ts` (not `createSpinner` fro
 
 Strong, precise types are extremely important. Every interface, output shape, and function signature must be explicitly typed — never fall back to `Record<string, unknown>`, `any`, or untyped parameters when a concrete type is possible. Define dedicated interfaces for command options, JSON output shapes, and API responses. Avoid `as unknown as X` double-casts and `any` types unless absolutely necessary. Prefer fixing the underlying type (adding a field to an interface, using a proper generic, etc.) over casting.
 
+When an options object has a field that callers should consciously decide, prefer a required key with an explicit `| undefined` value over an optional key. Use optional keys only when the field is genuinely not part of the contract for all callers.
+
 ## CLI Options
 
 Prefix truly optional flags with `[OPTIONAL]` in their description:
@@ -128,7 +130,7 @@ Before creating a PR:
 
 Create AAD apps via TDP's `/aadapp/v2` endpoint (`createAadAppViaTdp` in `src/apps/tdp.ts`), NOT via Graph API directly. TDP's backend creates the service principal server-side, which is required for single-tenant bot registration.
 
-- `signInAudience`: Always `AzureADMultipleOrgs` (multi-tenant AAD app)
+- `signInAudience`: Defaults to `AzureADMultipleOrgs`; `teams app create --single-tenant` uses `AzureADMyOrg` for tenants that require single-tenant app registrations.
 - `isSingleTenant`: Always `true` on bot registration (SFI requirement)
 - TDP returns a different `id` than Graph's object ID — use `getAadAppByClientId` to look up the Graph object ID before calling `addPassword`
 - Graph replication lag may require retries after TDP creates the app

--- a/packages/cli/src/apps/tdp.ts
+++ b/packages/cli/src/apps/tdp.ts
@@ -3,10 +3,21 @@ import { apiFetch } from '../utils/http.js';
 
 const TDP_BASE_URL = 'https://dev.teams.microsoft.com/api';
 
+export type SignInAudience = 'AzureADMyOrg' | 'AzureADMultipleOrgs';
+
+export interface CreateAadAppViaTdpOptions {
+  serviceManagementReference: string | undefined;
+  signInAudience: SignInAudience;
+}
+
 /**
  * Create an AAD app via TDP, which also creates the service principal server-side.
  */
-export async function createAadAppViaTdp(token: string, displayName: string): Promise<AadApp> {
+export async function createAadAppViaTdp(
+  token: string,
+  displayName: string,
+  options: CreateAadAppViaTdpOptions
+): Promise<AadApp> {
   const response = await apiFetch(`${TDP_BASE_URL}/aadapp/v2`, {
     method: 'POST',
     headers: {
@@ -15,7 +26,10 @@ export async function createAadAppViaTdp(token: string, displayName: string): Pr
     },
     body: JSON.stringify({
       displayName,
-      signInAudience: 'AzureADMultipleOrgs',
+      signInAudience: options.signInAudience,
+      ...(options.serviceManagementReference && {
+        serviceManagementReference: options.serviceManagementReference,
+      }),
     }),
   });
 

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -54,6 +54,8 @@ interface AppCreateOutput {
 interface CreateOptions {
   name?: string;
   endpoint?: string;
+  serviceManagementReference?: string;
+  singleTenant?: boolean;
   env?: string;
   envFile?: string;
   colorIcon?: string;
@@ -77,6 +79,8 @@ export const appCreateCommand = new Command('create')
   .option('--no-secret', '[OPTIONAL] Skip client secret generation (for managed identity or federated credentials)')
   .option('--azure', '[OPTIONAL] Create bot in Azure (requires az CLI)')
   .option('--teams-managed', '[OPTIONAL] Create bot managed by Teams (default)')
+  .option('--service-management-reference <id>', '[OPTIONAL] ServiceTree service ID for Microsoft Entra app attribution')
+  .option('--single-tenant', '[OPTIONAL] Create a single-tenant Microsoft Entra app')
   .option('--subscription <id>', '[OPTIONAL] Azure subscription ID (defaults to az CLI default)')
   .option('--resource-group <name>', 'Azure resource group (required for --azure)')
   .option('--create-resource-group', "[OPTIONAL] Create the resource group if it doesn't exist")
@@ -95,6 +99,8 @@ export const appCreateCommand = new Command('create')
           'Cannot specify both --azure and --teams-managed.'
         );
       }
+      const serviceManagementReference = options.serviceManagementReference?.trim();
+      const signInAudience = options.singleTenant ? 'AzureADMyOrg' : 'AzureADMultipleOrgs';
       const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
       const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
 
@@ -264,6 +270,12 @@ export const appCreateCommand = new Command('create')
 
       // ===== All inputs gathered — confirm before proceeding =====
       const summaryLines: [string, string][] = [['App name', normalizedName]];
+      if (serviceManagementReference) {
+        summaryLines.push(['Service management reference', serviceManagementReference]);
+      }
+      if (options.singleTenant) {
+        summaryLines.push(['Tenant mode', 'Single tenant']);
+      }
       if (azureContext) {
         summaryLines.push(['Subscription', azureContext.subscription]);
         summaryLines.push(['Resource group', azureContext.resourceGroup]);
@@ -321,7 +333,10 @@ export const appCreateCommand = new Command('create')
 
       // Create AAD app via TDP (creates service principal server-side)
       spinner = createSilentSpinner('Creating Azure AD app...', silent).start();
-      const aadApp = await createAadAppViaTdp(tdpToken, normalizedName);
+      const aadApp = await createAadAppViaTdp(tdpToken, normalizedName, {
+        serviceManagementReference,
+        signInAudience,
+      });
       const clientId = aadApp.appId;
       spinner.success({ text: `Created Azure AD app (${clientId})` });
 

--- a/packages/cli/tests/app-command-validation.test.ts
+++ b/packages/cli/tests/app-command-validation.test.ts
@@ -8,6 +8,7 @@ const mockFetchAppDetailsV2 = vi.fn();
 const mockCreateBot = vi.fn();
 const mockCreateAadAppViaTdp = vi.fn();
 const mockCreateManifestZip = vi.fn();
+const mockImportAppPackage = vi.fn();
 
 vi.mock('../src/apps/index.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/apps/index.js')>();
@@ -33,7 +34,7 @@ vi.mock('../src/apps/index.js', async (importOriginal) => {
     createClientSecret: vi.fn().mockResolvedValue({ secretText: 'fake-secret-text' }),
     getAadAppByClientId: vi.fn().mockResolvedValue({ id: 'aad-object-id' }),
     createManifestZip: mockCreateManifestZip,
-    importAppPackage: vi.fn().mockResolvedValue({ teamsAppId: 'fake-teams-app-id' }),
+    importAppPackage: mockImportAppPackage,
     installLink: vi.fn((id: string, tenantId: string) =>
       `https://teams.microsoft.com/l/app/${id}?installAppPackage=true&appTenantId=${tenantId}`
     ),
@@ -119,6 +120,7 @@ describe('shared command validation', () => {
       displayName: 'TestAadApp',
     });
     mockCreateManifestZip.mockReturnValue(Buffer.from('fake-zip'));
+    mockImportAppPackage.mockResolvedValue({ teamsAppId: 'fake-teams-app-id' });
     mockFetchApp.mockResolvedValue({
       appId: 'aad-object-id',
       appName: 'Test App',
@@ -209,7 +211,14 @@ describe('shared command validation', () => {
       { from: 'user' }
     );
 
-    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith('fake-token', 'Test App');
+    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith(
+      'fake-token',
+      'Test App',
+      {
+        serviceManagementReference: undefined,
+        signInAudience: 'AzureADMultipleOrgs',
+      }
+    );
     expect(mockCreateManifestZip).toHaveBeenCalledWith(
       expect.objectContaining({
         botName: 'Test App',
@@ -225,6 +234,61 @@ describe('shared command validation', () => {
       expect.objectContaining({
         appName: 'Test App',
         endpoint: 'https://example.com/api/messages',
+      })
+    );
+  });
+
+  it('creates an app with service management reference and single tenant audience', async () => {
+    const { appCreateCommand } = await import('../src/commands/app/create.js');
+
+    await appCreateCommand.parseAsync(
+      [
+        '--name',
+        'Service Tree Bot',
+        '--endpoint',
+        'https://example.com/api/messages',
+        '--service-management-reference',
+        'service-tree-id',
+        '--single-tenant',
+        '--no-secret',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith(
+      'fake-token',
+      'Service Tree Bot',
+      {
+        serviceManagementReference: 'service-tree-id',
+        signInAudience: 'AzureADMyOrg',
+      }
+    );
+    expect(mockCreateManifestZip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botId: 'fake-client-id',
+        botName: 'Service Tree Bot',
+        endpoint: 'https://example.com/api/messages',
+      })
+    );
+    expect(mockImportAppPackage).toHaveBeenCalledWith('fake-token', Buffer.from('fake-zip'));
+    expect(mockCreateBot).toHaveBeenCalledWith({
+      botId: 'fake-client-id',
+      name: 'Service Tree Bot',
+      endpoint: 'https://example.com/api/messages',
+    });
+    expect(jsonOutput).toEqual(
+      expect.objectContaining({
+        appName: 'Service Tree Bot',
+        teamsAppId: 'fake-teams-app-id',
+        botId: 'fake-client-id',
+        endpoint: 'https://example.com/api/messages',
+        botLocation: 'teams-managed',
+        secretSkipped: true,
+        credentials: {
+          CLIENT_ID: 'fake-client-id',
+          TENANT_ID: 'fake-tenant-id',
+        },
       })
     );
   });

--- a/teams.md/docs/cli/commands/app/create.md
+++ b/teams.md/docs/cli/commands/app/create.md
@@ -22,13 +22,15 @@ teams app create [options]
 | `-e, --endpoint <url>` | [OPTIONAL] Bot messaging endpoint URL |
 | `--env <path>` | [OPTIONAL] Path to credentials file (.env or appsettings.json) |
 | `--env-file <path>` | [OPTIONAL] Alias for --env |
+| `--no-secret` | [OPTIONAL] Skip client secret generation (for managed identity or federated credentials) |
 | `--azure` | [OPTIONAL] Create bot in Azure (requires az CLI) |
 | `--teams-managed` | [OPTIONAL] Create bot managed by Teams (default) |
+| `--service-management-reference <id>` | [OPTIONAL] ServiceTree service ID for Microsoft Entra app attribution |
+| `--single-tenant` | [OPTIONAL] Create a single-tenant Microsoft Entra app |
 | `--subscription <id>` | [OPTIONAL] Azure subscription ID (defaults to az CLI default) |
 | `--resource-group <name>` | Azure resource group (required for --azure) |
 | `--create-resource-group` | [OPTIONAL] Create the resource group if it doesn't exist |
 | `--region <name>` | [OPTIONAL] Azure region for resource group (default: westus2) |
-| `--no-secret` | [OPTIONAL] Skip client secret generation (for managed identity or federated credentials) |
 | `--color-icon <path>` | [OPTIONAL] Path to color icon (192x192 PNG) |
 | `--outline-icon <path>` | [OPTIONAL] Path to outline icon (32x32 PNG) |
 | `--json` | [OPTIONAL] Output as JSON |
@@ -90,6 +92,14 @@ teams app create --name "My Bot" --no-secret
 ```
 
 Only `CLIENT_ID` and `TENANT_ID` are output. You can generate a secret later with [`teams app auth secret create`](./auth-secret-create).
+
+### Service-Attributed Apps
+
+Some tenants require new Microsoft Entra app registrations to be attributed to a service. Use `--service-management-reference` with the ServiceTree service ID, and `--single-tenant` when tenant policy requires a single-tenant app:
+
+```bash
+teams app create --name "My Bot" --service-management-reference <service-id> --single-tenant --no-secret
+```
 
 ### Output
 


### PR DESCRIPTION
Add a way for `teams app create` to pass service attribution into TDP, plus a single-tenant switch for tenants that require it.

Why:
Some tenants block new Entra apps unless they include a ServiceTree service ID, and some also block multi-tenant app registrations. This lets the CLI create the app directly instead of doing portal gymnastics.

Interesting bits:
- New `--service-management-reference <id>` flag passes the ServiceTree ID to TDP.
- New `--single-tenant` flag maps to `AzureADMyOrg`; default remains multi-tenant.
- Renamed `packages/cli/CLAUDE.md` to `AGENTS.md` and added the options-object typing preference.

Tips for reviewers:
Start in `packages/cli/src/commands/app/create.ts`, then `packages/cli/src/apps/tdp.ts`.

Testing:
- `npm -w @microsoft/teams.cli run test -- app-command-validation.test.ts`
- `npx turbo build --filter=@microsoft/teams.cli`
