### PR TITLE
Prepare CLI 3.0.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # Local env files
 .env
+.teams_env
 .env.local
 .env.development.local
 .env.test.local

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -130,7 +130,6 @@ Before creating a PR:
 
 Create AAD apps via TDP's `/aadapp/v2` endpoint (`createAadAppViaTdp` in `src/apps/tdp.ts`), NOT via Graph API directly. TDP's backend creates the service principal server-side, which is required for single-tenant bot registration.
 
-- `signInAudience`: Defaults to `AzureADMultipleOrgs`; `teams app create --single-tenant` uses `AzureADMyOrg` for tenants that require single-tenant app registrations.
 - `isSingleTenant`: Always `true` on bot registration (SFI requirement)
 - TDP returns a different `id` than Graph's object ID — use `getAadAppByClientId` to look up the Graph object ID before calling `addPassword`
 - Graph replication lag may require retries after TDP creates the app

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -47,6 +47,8 @@ Use `createSilentSpinner()` from `src/utils/spinner.ts` (not `createSpinner` fro
 
 Strong, precise types are extremely important. Every interface, output shape, and function signature must be explicitly typed — never fall back to `Record<string, unknown>`, `any`, or untyped parameters when a concrete type is possible. Define dedicated interfaces for command options, JSON output shapes, and API responses. Avoid `as unknown as X` double-casts and `any` types unless absolutely necessary. Prefer fixing the underlying type (adding a field to an interface, using a proper generic, etc.) over casting.
 
+When an options object has a field that callers should consciously decide, prefer a required key with an explicit `| undefined` value over an optional key. Use optional keys only when the field is genuinely not part of the contract for all callers.
+
 ## CLI Options
 
 Prefix truly optional flags with `[OPTIONAL]` in their description:
@@ -128,7 +130,7 @@ Before creating a PR:
 
 Create AAD apps via TDP's `/aadapp/v2` endpoint (`createAadAppViaTdp` in `src/apps/tdp.ts`), NOT via Graph API directly. TDP's backend creates the service principal server-side, which is required for single-tenant bot registration.
 
-- `signInAudience`: Always `AzureADMultipleOrgs` (multi-tenant AAD app)
+- `signInAudience`: Defaults to `AzureADMultipleOrgs`; `teams app create --single-tenant` uses `AzureADMyOrg` for tenants that require single-tenant app registrations.
 - `isSingleTenant`: Always `true` on bot registration (SFI requirement)
 - TDP returns a different `id` than Graph's object ID — use `getAadAppByClientId` to look up the Graph object ID before calling `addPassword`
 - Graph replication lag may require retries after TDP creates the app

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teams.cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Teams Developer CLI for managing Microsoft Teams apps",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/src/apps/manifest-builder.ts
+++ b/packages/cli/src/apps/manifest-builder.ts
@@ -25,6 +25,19 @@ function validateOptionalField(field: AppMetadataField, value: string): string |
  */
 export const PLACEHOLDER_BOT_ID = '00000000-0000-0000-0000-000000000000';
 
+export type ManifestCustomizationField = 'description' | 'icons' | 'scopes' | 'developer';
+
+export const MANIFEST_CUSTOMIZATION_CHOICES = [
+  { name: 'Description', value: 'description' },
+  { name: 'Icons', value: 'icons' },
+  { name: 'Scopes', value: 'scopes' },
+  { name: 'Developer details', value: 'developer' },
+] as const satisfies readonly { name: string; value: ManifestCustomizationField }[];
+
+export function isManifestCustomizationField(value: string): value is ManifestCustomizationField {
+  return MANIFEST_CUSTOMIZATION_CHOICES.some((choice) => choice.value === value);
+}
+
 export interface ManifestCustomization {
   description?: { short: string; full?: string };
   icons?: { colorIconPath?: string; outlineIconPath?: string };
@@ -41,24 +54,16 @@ export interface ManifestCustomization {
  * Interactively collects manifest customization options from the user.
  * Prompts for description, icons, scopes, and developer details.
  */
-export async function collectManifestCustomization(): Promise<ManifestCustomization> {
-  if (!isInteractive()) {
+export async function collectManifestCustomization(
+  fields: ManifestCustomizationField[]
+): Promise<ManifestCustomization> {
+  if (!isInteractive() || fields.length === 0) {
     return {};
   }
 
-  const customizeFields = await checkbox({
-    message: 'Customize manifest fields? (space to select, enter to continue)',
-    choices: [
-      { name: 'Description', value: 'description' },
-      { name: 'Icons', value: 'icons' },
-      { name: 'Scopes', value: 'scopes' },
-      { name: 'Developer details', value: 'developer' },
-    ],
-  });
-
   const result: ManifestCustomization = {};
 
-  if (customizeFields.includes('description')) {
+  if (fields.includes('description')) {
     const shortDesc = await input({
       message: 'Short description:',
       validate: (value) => validateField('shortDescription', value),
@@ -70,7 +75,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
     result.description = { short: shortDesc, full: fullDesc.trim() || undefined };
   }
 
-  if (customizeFields.includes('icons')) {
+  if (fields.includes('icons')) {
     const colorIconPath =
       (await input({ message: 'Color icon path (192x192 PNG, leave empty to skip):' })) ||
       undefined;
@@ -82,7 +87,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
     }
   }
 
-  if (customizeFields.includes('scopes')) {
+  if (fields.includes('scopes')) {
     while (true) {
       const scopes = await checkbox<BotScope>({
         message: 'Select bot scopes:',
@@ -103,7 +108,7 @@ export async function collectManifestCustomization(): Promise<ManifestCustomizat
     }
   }
 
-  if (customizeFields.includes('developer')) {
+  if (fields.includes('developer')) {
     const devName = await input({
       message: 'Developer name:',
       validate: (value) => validateField('developerName', value),

--- a/packages/cli/src/apps/tdp.ts
+++ b/packages/cli/src/apps/tdp.ts
@@ -3,10 +3,21 @@ import { apiFetch } from '../utils/http.js';
 
 const TDP_BASE_URL = 'https://dev.teams.microsoft.com/api';
 
+export type SignInAudience = 'AzureADMyOrg' | 'AzureADMultipleOrgs';
+
+export interface CreateAadAppViaTdpOptions {
+  serviceManagementReference: string | undefined;
+  signInAudience: SignInAudience;
+}
+
 /**
  * Create an AAD app via TDP, which also creates the service principal server-side.
  */
-export async function createAadAppViaTdp(token: string, displayName: string): Promise<AadApp> {
+export async function createAadAppViaTdp(
+  token: string,
+  displayName: string,
+  options: CreateAadAppViaTdpOptions
+): Promise<AadApp> {
   const response = await apiFetch(`${TDP_BASE_URL}/aadapp/v2`, {
     method: 'POST',
     headers: {
@@ -15,7 +26,10 @@ export async function createAadAppViaTdp(token: string, displayName: string): Pr
     },
     body: JSON.stringify({
       displayName,
-      signInAudience: 'AzureADMultipleOrgs',
+      signInAudience: options.signInAudience,
+      ...(options.serviceManagementReference && {
+        serviceManagementReference: options.serviceManagementReference,
+      }),
     }),
   });
 

--- a/packages/cli/src/commands/app/create-advanced.ts
+++ b/packages/cli/src/commands/app/create-advanced.ts
@@ -1,0 +1,65 @@
+import { checkbox, select } from '@inquirer/prompts';
+import {
+  collectManifestCustomization,
+  isManifestCustomizationField,
+  MANIFEST_CUSTOMIZATION_CHOICES,
+  type ManifestCustomization,
+  type ManifestCustomizationField,
+} from '../../apps/index.js';
+import { isInteractive } from '../../utils/interactive.js';
+
+export const SIGN_IN_AUDIENCE_BY_OPTION = {
+  myOrg: 'AzureADMyOrg',
+  multipleOrgs: 'AzureADMultipleOrgs',
+} as const;
+
+export type SignInAudienceOption = keyof typeof SIGN_IN_AUDIENCE_BY_OPTION;
+
+export interface AppCreateAdvancedOptions {
+  manifest: ManifestCustomization;
+  appRegistration?: {
+    signInAudience: SignInAudienceOption;
+  };
+}
+
+type AdvancedOption = ManifestCustomizationField | 'appRegistration';
+
+export function isSignInAudienceOption(value: string): value is SignInAudienceOption {
+  return Object.prototype.hasOwnProperty.call(SIGN_IN_AUDIENCE_BY_OPTION, value);
+}
+
+export async function collectCreateAdvancedOptions(): Promise<AppCreateAdvancedOptions> {
+  if (!isInteractive()) {
+    return { manifest: {} };
+  }
+
+  const advancedOptions = await checkbox<AdvancedOption>({
+    message: 'Advanced options? (space to select, enter to continue)',
+    choices: [
+      ...MANIFEST_CUSTOMIZATION_CHOICES,
+      { name: 'App registration', value: 'appRegistration' },
+    ],
+  });
+
+  const result: AppCreateAdvancedOptions = { manifest: {} };
+  const manifestFields = advancedOptions.filter(isManifestCustomizationField);
+
+  if (manifestFields.length > 0) {
+    result.manifest = await collectManifestCustomization(manifestFields);
+  }
+
+  if (advancedOptions.includes('appRegistration')) {
+    result.appRegistration = {
+      signInAudience: await select<SignInAudienceOption>({
+        message: 'Audience:',
+        default: 'multipleOrgs',
+        choices: [
+          { name: 'Multiple organizations', value: 'multipleOrgs' },
+          { name: 'My organization only', value: 'myOrg' },
+        ],
+      }),
+    };
+  }
+
+  return result;
+}

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -54,6 +54,8 @@ interface AppCreateOutput {
 interface CreateOptions {
   name?: string;
   endpoint?: string;
+  serviceManagementReference?: string;
+  singleTenant?: boolean;
   env?: string;
   envFile?: string;
   colorIcon?: string;
@@ -77,6 +79,8 @@ export const appCreateCommand = new Command('create')
   .option('--no-secret', '[OPTIONAL] Skip client secret generation (for managed identity or federated credentials)')
   .option('--azure', '[OPTIONAL] Create bot in Azure (requires az CLI)')
   .option('--teams-managed', '[OPTIONAL] Create bot managed by Teams (default)')
+  .option('--service-management-reference <id>', '[OPTIONAL] ServiceTree service ID for Microsoft Entra app attribution')
+  .option('--single-tenant', '[OPTIONAL] Create a single-tenant Microsoft Entra app')
   .option('--subscription <id>', '[OPTIONAL] Azure subscription ID (defaults to az CLI default)')
   .option('--resource-group <name>', 'Azure resource group (required for --azure)')
   .option('--create-resource-group', "[OPTIONAL] Create the resource group if it doesn't exist")
@@ -95,6 +99,8 @@ export const appCreateCommand = new Command('create')
           'Cannot specify both --azure and --teams-managed.'
         );
       }
+      const serviceManagementReference = options.serviceManagementReference?.trim();
+      const signInAudience = options.singleTenant ? 'AzureADMyOrg' : 'AzureADMultipleOrgs';
       const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
       const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
 
@@ -264,6 +270,12 @@ export const appCreateCommand = new Command('create')
 
       // ===== All inputs gathered — confirm before proceeding =====
       const summaryLines: [string, string][] = [['App name', normalizedName]];
+      if (serviceManagementReference) {
+        summaryLines.push(['Service management reference', serviceManagementReference]);
+      }
+      if (options.singleTenant) {
+        summaryLines.push(['Tenant mode', 'Single tenant']);
+      }
       if (azureContext) {
         summaryLines.push(['Subscription', azureContext.subscription]);
         summaryLines.push(['Resource group', azureContext.resourceGroup]);
@@ -321,7 +333,10 @@ export const appCreateCommand = new Command('create')
 
       // Create AAD app via TDP (creates service principal server-side)
       spinner = createSilentSpinner('Creating Azure AD app...', silent).start();
-      const aadApp = await createAadAppViaTdp(tdpToken, normalizedName);
+      const aadApp = await createAadAppViaTdp(tdpToken, normalizedName, {
+        serviceManagementReference,
+        signInAudience,
+      });
       const clientId = aadApp.appId;
       spinner.success({ text: `Created Azure AD app (${clientId})` });
 

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -2,7 +2,6 @@ import { input, select } from '@inquirer/prompts';
 import { Command } from 'commander';
 import pc from 'picocolors';
 import {
-  collectManifestCustomization,
   createAadAppViaTdp,
   createClientSecret,
   createManifestZip,
@@ -33,6 +32,12 @@ import { ensureAz, runAz } from '../../utils/az.js';
 import { resolveSubscription, resolveResourceGroup, ensureTenantMatch } from '../../utils/az-prompts.js';
 import { createSilentSpinner } from '../../utils/spinner.js';
 import { openInBrowser, printLinkBanner } from '../../utils/browser.js';
+import {
+  collectCreateAdvancedOptions,
+  isSignInAudienceOption,
+  SIGN_IN_AUDIENCE_BY_OPTION,
+  type SignInAudienceOption,
+} from './create-advanced.js';
 
 interface AppCreateOutput {
   appName: string;
@@ -55,7 +60,7 @@ interface CreateOptions {
   name?: string;
   endpoint?: string;
   serviceManagementReference?: string;
-  singleTenant?: boolean;
+  signInAudience?: string;
   env?: string;
   envFile?: string;
   colorIcon?: string;
@@ -70,6 +75,16 @@ interface CreateOptions {
   json?: boolean;
 }
 
+function parseSignInAudienceOption(value: string): SignInAudienceOption {
+  if (!isSignInAudienceOption(value)) {
+    throw new CliError(
+      'VALIDATION_FORMAT',
+      '--sign-in-audience must be myOrg or multipleOrgs.'
+    );
+  }
+  return value;
+}
+
 export const appCreateCommand = new Command('create')
   .description('Create a new Teams app with bot')
   .option('-n, --name <name>', 'App/bot name')
@@ -80,7 +95,7 @@ export const appCreateCommand = new Command('create')
   .option('--azure', '[OPTIONAL] Create bot in Azure (requires az CLI)')
   .option('--teams-managed', '[OPTIONAL] Create bot managed by Teams (default)')
   .option('--service-management-reference <id>', '[OPTIONAL] ServiceTree service ID for Microsoft Entra app attribution')
-  .option('--single-tenant', '[OPTIONAL] Create a single-tenant Microsoft Entra app')
+  .option('--sign-in-audience <audience>', '[OPTIONAL] Microsoft Entra sign-in audience: myOrg or multipleOrgs')
   .option('--subscription <id>', '[OPTIONAL] Azure subscription ID (defaults to az CLI default)')
   .option('--resource-group <name>', 'Azure resource group (required for --azure)')
   .option('--create-resource-group', "[OPTIONAL] Create the resource group if it doesn't exist")
@@ -100,7 +115,9 @@ export const appCreateCommand = new Command('create')
         );
       }
       const serviceManagementReference = options.serviceManagementReference?.trim();
-      const signInAudience = options.singleTenant ? 'AzureADMyOrg' : 'AzureADMultipleOrgs';
+      let signInAudienceOption = parseSignInAudienceOption(
+        options.signInAudience ?? 'multipleOrgs'
+      );
       const earlyColorIcon = options.colorIcon ? readAndValidateIcon(options.colorIcon, 192) : undefined;
       const earlyOutlineIcon = options.outlineIcon ? readAndValidateIcon(options.outlineIcon, 32) : undefined;
 
@@ -153,7 +170,7 @@ export const appCreateCommand = new Command('create')
 
       const generateSecret = options.secret !== false;
 
-      // Collect manifest customization options
+      // Collect advanced options
       let descriptionOpts: { short: string; full?: string } | undefined;
       let scopeChoices: BotScope[] | undefined;
       let developerOpts:
@@ -166,15 +183,20 @@ export const appCreateCommand = new Command('create')
         | undefined;
 
       if (interactive && !hasFlags && !options.json) {
-        const customization = await collectManifestCustomization();
-        descriptionOpts = customization.description;
-        scopeChoices = customization.scopes;
-        developerOpts = customization.developer;
-        if (customization.icons) {
-          options.colorIcon ??= customization.icons.colorIconPath;
-          options.outlineIcon ??= customization.icons.outlineIconPath;
+        const advancedOptions = await collectCreateAdvancedOptions();
+        descriptionOpts = advancedOptions.manifest.description;
+        scopeChoices = advancedOptions.manifest.scopes;
+        developerOpts = advancedOptions.manifest.developer;
+        signInAudienceOption = parseSignInAudienceOption(
+          options.signInAudience ?? advancedOptions.appRegistration?.signInAudience ?? signInAudienceOption
+        );
+        if (advancedOptions.manifest.icons) {
+          options.colorIcon ??= advancedOptions.manifest.icons.colorIconPath;
+          options.outlineIcon ??= advancedOptions.manifest.icons.outlineIconPath;
         }
       }
+
+      const signInAudience = SIGN_IN_AUDIENCE_BY_OPTION[signInAudienceOption];
 
       // Resolve icon paths (CLI flags take priority, then interactive selection)
       const colorIconPath = options.colorIcon;
@@ -273,8 +295,8 @@ export const appCreateCommand = new Command('create')
       if (serviceManagementReference) {
         summaryLines.push(['Service management reference', serviceManagementReference]);
       }
-      if (options.singleTenant) {
-        summaryLines.push(['Tenant mode', 'Single tenant']);
+      if (options.signInAudience || signInAudienceOption === 'myOrg') {
+        summaryLines.push(['Sign-in audience', signInAudienceOption]);
       }
       if (azureContext) {
         summaryLines.push(['Subscription', azureContext.subscription]);

--- a/packages/cli/tests/app-command-validation.test.ts
+++ b/packages/cli/tests/app-command-validation.test.ts
@@ -238,7 +238,7 @@ describe('shared command validation', () => {
     );
   });
 
-  it('creates an app with service management reference and single tenant audience', async () => {
+  it('creates an app with service management reference and myOrg audience', async () => {
     const { appCreateCommand } = await import('../src/commands/app/create.js');
 
     await appCreateCommand.parseAsync(
@@ -249,7 +249,8 @@ describe('shared command validation', () => {
         'https://example.com/api/messages',
         '--service-management-reference',
         'service-tree-id',
-        '--single-tenant',
+        '--sign-in-audience',
+        'myOrg',
         '--no-secret',
         '--json',
       ],
@@ -291,6 +292,26 @@ describe('shared command validation', () => {
         },
       })
     );
+  });
+
+  it('rejects invalid sign-in audience values before auth', async () => {
+    const { appCreateCommand } = await import('../src/commands/app/create.js');
+
+    await expect(
+      appCreateCommand.parseAsync(
+        ['--name', 'Test App', '--sign-in-audience', 'personal', '--json'],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(jsonOutput).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_FORMAT',
+        message: '--sign-in-audience must be myOrg or multipleOrgs.',
+      },
+    });
+    expect(mockGetAccount).not.toHaveBeenCalled();
   });
 
   it('uses normalized values throughout app update', async () => {

--- a/packages/cli/tests/app-command-validation.test.ts
+++ b/packages/cli/tests/app-command-validation.test.ts
@@ -8,6 +8,7 @@ const mockFetchAppDetailsV2 = vi.fn();
 const mockCreateBot = vi.fn();
 const mockCreateAadAppViaTdp = vi.fn();
 const mockCreateManifestZip = vi.fn();
+const mockImportAppPackage = vi.fn();
 
 vi.mock('../src/apps/index.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/apps/index.js')>();
@@ -33,7 +34,7 @@ vi.mock('../src/apps/index.js', async (importOriginal) => {
     createClientSecret: vi.fn().mockResolvedValue({ secretText: 'fake-secret-text' }),
     getAadAppByClientId: vi.fn().mockResolvedValue({ id: 'aad-object-id' }),
     createManifestZip: mockCreateManifestZip,
-    importAppPackage: vi.fn().mockResolvedValue({ teamsAppId: 'fake-teams-app-id' }),
+    importAppPackage: mockImportAppPackage,
     installLink: vi.fn((id: string, tenantId: string) =>
       `https://teams.microsoft.com/l/app/${id}?installAppPackage=true&appTenantId=${tenantId}`
     ),
@@ -119,6 +120,7 @@ describe('shared command validation', () => {
       displayName: 'TestAadApp',
     });
     mockCreateManifestZip.mockReturnValue(Buffer.from('fake-zip'));
+    mockImportAppPackage.mockResolvedValue({ teamsAppId: 'fake-teams-app-id' });
     mockFetchApp.mockResolvedValue({
       appId: 'aad-object-id',
       appName: 'Test App',
@@ -209,7 +211,14 @@ describe('shared command validation', () => {
       { from: 'user' }
     );
 
-    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith('fake-token', 'Test App');
+    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith(
+      'fake-token',
+      'Test App',
+      {
+        serviceManagementReference: undefined,
+        signInAudience: 'AzureADMultipleOrgs',
+      }
+    );
     expect(mockCreateManifestZip).toHaveBeenCalledWith(
       expect.objectContaining({
         botName: 'Test App',
@@ -225,6 +234,61 @@ describe('shared command validation', () => {
       expect.objectContaining({
         appName: 'Test App',
         endpoint: 'https://example.com/api/messages',
+      })
+    );
+  });
+
+  it('creates an app with service management reference and single tenant audience', async () => {
+    const { appCreateCommand } = await import('../src/commands/app/create.js');
+
+    await appCreateCommand.parseAsync(
+      [
+        '--name',
+        'Service Tree Bot',
+        '--endpoint',
+        'https://example.com/api/messages',
+        '--service-management-reference',
+        'service-tree-id',
+        '--single-tenant',
+        '--no-secret',
+        '--json',
+      ],
+      { from: 'user' }
+    );
+
+    expect(mockCreateAadAppViaTdp).toHaveBeenCalledWith(
+      'fake-token',
+      'Service Tree Bot',
+      {
+        serviceManagementReference: 'service-tree-id',
+        signInAudience: 'AzureADMyOrg',
+      }
+    );
+    expect(mockCreateManifestZip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botId: 'fake-client-id',
+        botName: 'Service Tree Bot',
+        endpoint: 'https://example.com/api/messages',
+      })
+    );
+    expect(mockImportAppPackage).toHaveBeenCalledWith('fake-token', Buffer.from('fake-zip'));
+    expect(mockCreateBot).toHaveBeenCalledWith({
+      botId: 'fake-client-id',
+      name: 'Service Tree Bot',
+      endpoint: 'https://example.com/api/messages',
+    });
+    expect(jsonOutput).toEqual(
+      expect.objectContaining({
+        appName: 'Service Tree Bot',
+        teamsAppId: 'fake-teams-app-id',
+        botId: 'fake-client-id',
+        endpoint: 'https://example.com/api/messages',
+        botLocation: 'teams-managed',
+        secretSkipped: true,
+        credentials: {
+          CLIENT_ID: 'fake-client-id',
+          TENANT_ID: 'fake-tenant-id',
+        },
       })
     );
   });

--- a/packages/cli/tests/create-advanced.test.ts
+++ b/packages/cli/tests/create-advanced.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/utils/interactive.js', () => ({
+  isInteractive: () => true,
+}));
+
+const mockCollectManifestCustomization = vi.fn();
+vi.mock('../src/apps/index.js', () => ({
+  collectManifestCustomization: mockCollectManifestCustomization,
+  MANIFEST_CUSTOMIZATION_CHOICES: [
+    { name: 'Description', value: 'description' },
+    { name: 'Icons', value: 'icons' },
+    { name: 'Scopes', value: 'scopes' },
+    { name: 'Developer details', value: 'developer' },
+  ],
+  isManifestCustomizationField: (value: string) =>
+    ['description', 'icons', 'scopes', 'developer'].includes(value),
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+  checkbox: vi.fn(),
+  select: vi.fn(),
+}));
+
+describe('collectCreateAdvancedOptions', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockCollectManifestCustomization.mockResolvedValue({});
+  });
+
+  it('collects manifest options separately from app registration options', async () => {
+    const { checkbox, select } = await import('@inquirer/prompts');
+    const mockedCheckbox = vi.mocked(checkbox);
+    const mockedSelect = vi.mocked(select);
+
+    mockedCheckbox.mockResolvedValueOnce(['scopes', 'appRegistration'] as never);
+    mockedSelect.mockResolvedValueOnce('myOrg' as never);
+    mockCollectManifestCustomization.mockResolvedValue({
+      scopes: ['personal'],
+    });
+
+    const { collectCreateAdvancedOptions } = await import('../src/commands/app/create-advanced.js');
+
+    const result = await collectCreateAdvancedOptions();
+
+    const advancedPrompt = mockedCheckbox.mock.calls[0][0] as {
+      message: string;
+      choices: Array<{ name: string; value: string }>;
+    };
+    expect(advancedPrompt.message).toBe('Advanced options? (space to select, enter to continue)');
+    expect(advancedPrompt.choices).toEqual([
+      { name: 'Description', value: 'description' },
+      { name: 'Icons', value: 'icons' },
+      { name: 'Scopes', value: 'scopes' },
+      { name: 'Developer details', value: 'developer' },
+      { name: 'App registration', value: 'appRegistration' },
+    ]);
+    expect(mockCollectManifestCustomization).toHaveBeenCalledWith(['scopes']);
+
+    const audiencePrompt = mockedSelect.mock.calls[0][0] as {
+      message: string;
+      choices: Array<{ name: string; value: string }>;
+    };
+    expect(audiencePrompt.message).toBe('Audience:');
+    expect(audiencePrompt.choices).toEqual([
+      { name: 'Multiple organizations', value: 'multipleOrgs' },
+      { name: 'My organization only', value: 'myOrg' },
+    ]);
+
+    expect(result).toEqual({
+      manifest: { scopes: ['personal'] },
+      appRegistration: { signInAudience: 'myOrg' },
+    });
+  });
+});

--- a/packages/cli/tests/manifest-builder-icons.test.ts
+++ b/packages/cli/tests/manifest-builder-icons.test.ts
@@ -17,25 +17,23 @@ vi.mock('@inquirer/prompts', () => ({
   input: vi.fn(),
 }));
 
-describe('collectManifestCustomization icons', () => {
+describe('collectManifestCustomization', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
   });
 
   it('allows an empty full description and falls back to the short description', async () => {
-    const { checkbox, input } = await import('@inquirer/prompts');
-    const mockedCheckbox = vi.mocked(checkbox);
+    const { input } = await import('@inquirer/prompts');
     const mockedInput = vi.mocked(input);
 
-    mockedCheckbox.mockResolvedValueOnce(['description'] as never);
     mockedInput
       .mockResolvedValueOnce('Handles projects for our team' as never)
       .mockResolvedValueOnce('' as never);
 
     const { collectManifestCustomization } = await import('../src/apps/manifest-builder.js');
 
-    const result = await collectManifestCustomization();
+    const result = await collectManifestCustomization(['description']);
 
     const fullDescriptionPrompt = mockedInput.mock.calls[1][0] as {
       validate: (value: string) => string | true;
@@ -47,29 +45,18 @@ describe('collectManifestCustomization icons', () => {
     });
   });
 
-  it('offers Icons as a checkbox choice and returns icon paths when selected', async () => {
-    const { checkbox, input } = await import('@inquirer/prompts');
-    const mockedCheckbox = vi.mocked(checkbox);
+  it('returns icon paths when icons are selected', async () => {
+    const { input } = await import('@inquirer/prompts');
     const mockedInput = vi.mocked(input);
 
-    mockedCheckbox.mockResolvedValueOnce(['icons'] as never);
     mockedInput
       .mockResolvedValueOnce('./color.png' as never)
       .mockResolvedValueOnce('./outline.png' as never);
 
     const { collectManifestCustomization } = await import('../src/apps/manifest-builder.js');
 
-    const result = await collectManifestCustomization();
+    const result = await collectManifestCustomization(['icons']);
 
-    // Verify "Icons" is offered as a choice
-    const checkboxCall = mockedCheckbox.mock.calls[0][0] as {
-      choices: Array<{ name: string; value: string }>;
-    };
-    const iconChoice = checkboxCall.choices.find((c) => c.value === 'icons');
-    expect(iconChoice).toBeDefined();
-    expect(iconChoice!.name).toBe('Icons');
-
-    // Verify icon paths are returned
     expect(result.icons).toEqual({
       colorIconPath: './color.png',
       outlineIconPath: './outline.png',
@@ -77,34 +64,30 @@ describe('collectManifestCustomization icons', () => {
   });
 
   it('omits icons and does not prompt for paths when not selected', async () => {
-    const { checkbox, input } = await import('@inquirer/prompts');
-    const mockedCheckbox = vi.mocked(checkbox);
+    const { input } = await import('@inquirer/prompts');
     const mockedInput = vi.mocked(input);
-
-    mockedCheckbox.mockResolvedValueOnce([] as never);
 
     const { collectManifestCustomization } = await import('../src/apps/manifest-builder.js');
 
-    const result = await collectManifestCustomization();
+    const result = await collectManifestCustomization([]);
 
     expect(result.icons).toBeUndefined();
     expect(mockedInput).not.toHaveBeenCalled();
   });
 
   it('omits icons when both paths are empty', async () => {
-    const { checkbox, input } = await import('@inquirer/prompts');
-    const mockedCheckbox = vi.mocked(checkbox);
+    const { input } = await import('@inquirer/prompts');
     const mockedInput = vi.mocked(input);
 
-    mockedCheckbox.mockResolvedValueOnce(['icons'] as never);
     mockedInput.mockResolvedValueOnce('' as never).mockResolvedValueOnce('' as never);
 
     const { collectManifestCustomization } = await import('../src/apps/manifest-builder.js');
 
-    const result = await collectManifestCustomization();
+    const result = await collectManifestCustomization(['icons']);
 
     expect(result.icons).toBeUndefined();
   });
+
 });
 
 describe('createManifest copilotAgents', () => {

--- a/teams.md/docs/cli/commands/app/create.md
+++ b/teams.md/docs/cli/commands/app/create.md
@@ -26,7 +26,7 @@ teams app create [options]
 | `--azure` | [OPTIONAL] Create bot in Azure (requires az CLI) |
 | `--teams-managed` | [OPTIONAL] Create bot managed by Teams (default) |
 | `--service-management-reference <id>` | [OPTIONAL] ServiceTree service ID for Microsoft Entra app attribution |
-| `--single-tenant` | [OPTIONAL] Create a single-tenant Microsoft Entra app |
+| `--sign-in-audience <audience>` | [OPTIONAL] Microsoft Entra sign-in audience: myOrg or multipleOrgs |
 | `--subscription <id>` | [OPTIONAL] Azure subscription ID (defaults to az CLI default) |
 | `--resource-group <name>` | Azure resource group (required for --azure) |
 | `--create-resource-group` | [OPTIONAL] Create the resource group if it doesn't exist |
@@ -95,10 +95,10 @@ Only `CLIENT_ID` and `TENANT_ID` are output. You can generate a secret later wit
 
 ### Service-Attributed Apps
 
-Some tenants require new Microsoft Entra app registrations to be attributed to a service. Use `--service-management-reference` with the ServiceTree service ID, and `--single-tenant` when tenant policy requires a single-tenant app:
+Some tenants require new Microsoft Entra app registrations to be attributed to a service. Use `--service-management-reference` with the ServiceTree service ID, and `--sign-in-audience myOrg` when tenant policy requires a single-tenant app:
 
 ```bash
-teams app create --name "My Bot" --service-management-reference <service-id> --single-tenant --no-secret
+teams app create --name "My Bot" --service-management-reference <service-id> --sign-in-audience myOrg --no-secret
 ```
 
 ### Output

--- a/teams.md/docs/cli/commands/app/create.md
+++ b/teams.md/docs/cli/commands/app/create.md
@@ -22,13 +22,15 @@ teams app create [options]
 | `-e, --endpoint <url>` | [OPTIONAL] Bot messaging endpoint URL |
 | `--env <path>` | [OPTIONAL] Path to credentials file (.env or appsettings.json) |
 | `--env-file <path>` | [OPTIONAL] Alias for --env |
+| `--no-secret` | [OPTIONAL] Skip client secret generation (for managed identity or federated credentials) |
 | `--azure` | [OPTIONAL] Create bot in Azure (requires az CLI) |
 | `--teams-managed` | [OPTIONAL] Create bot managed by Teams (default) |
+| `--service-management-reference <id>` | [OPTIONAL] ServiceTree service ID for Microsoft Entra app attribution |
+| `--single-tenant` | [OPTIONAL] Create a single-tenant Microsoft Entra app |
 | `--subscription <id>` | [OPTIONAL] Azure subscription ID (defaults to az CLI default) |
 | `--resource-group <name>` | Azure resource group (required for --azure) |
 | `--create-resource-group` | [OPTIONAL] Create the resource group if it doesn't exist |
 | `--region <name>` | [OPTIONAL] Azure region for resource group (default: westus2) |
-| `--no-secret` | [OPTIONAL] Skip client secret generation (for managed identity or federated credentials) |
 | `--color-icon <path>` | [OPTIONAL] Path to color icon (192x192 PNG) |
 | `--outline-icon <path>` | [OPTIONAL] Path to outline icon (32x32 PNG) |
 | `--json` | [OPTIONAL] Output as JSON |
@@ -90,6 +92,14 @@ teams app create --name "My Bot" --no-secret
 ```
 
 Only `CLIENT_ID` and `TENANT_ID` are output. You can generate a secret later with [`teams app auth secret create`](./auth-secret-create).
+
+### Service-Attributed Apps
+
+Some tenants require new Microsoft Entra app registrations to be attributed to a service. Use `--service-management-reference` with the ServiceTree service ID, and `--single-tenant` when tenant policy requires a single-tenant app:
+
+```bash
+teams app create --name "My Bot" --service-management-reference <service-id> --single-tenant --no-secret
+```
 
 ### Output
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "publicReleaseRefSpec": [
     "^refs/heads/release$",
     "^refs/heads/release/v3$",


### PR DESCRIPTION
Prep stable CLI `3.0.1` from the service-attributed app creation work.

Why:
This gets the tenant-policy fix into the stable release branch so folks blocked by ServiceTree attribution or single-tenant policy can create Teams apps again.

Interesting bits:
- Cherry-picks `Add service-attributed app creation (#2884)` onto `release/v3`.
- Bumps `version.json` and `@microsoft/teams.cli` to `3.0.1`.

Tips for reviewers:
Focus on the release branch delta and version bump. The feature change itself was reviewed in #2884.

Testing:
- `npm -w @microsoft/teams.cli run test -- app-command-validation.test.ts`
- `npx turbo build --filter=@microsoft/teams.cli`
