### PR TITLE
docs: SSO troubleshooting, MI setup, and preview status updates

### DIFF
--- a/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
+++ b/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
@@ -31,6 +31,22 @@ Before starting SSO configuration, ensure you have:
   Your `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` stay the same. See [Bot Locations](/cli/concepts/bot-locations) for details.
   :::
 
+## SSO with User-Assigned Managed Identity
+
+If your bot uses **User-Assigned Managed Identity (MI)** authentication, the bot ID is the MI's client ID. Since managed identities don't have client secrets, you need a **separate Entra App Registration** for the OAuth connection used in SSO. In this setup, the IDs map differently:
+
+| Configuration | Value |
+|---------------|-------|
+| Application ID URI (Expose an API) | `api://botid-{botId}` (where `botId` = MI client ID) |
+| `webApplicationInfo.id` in manifest | The **auth app's** client ID (not the bot/MI ID) |
+| `webApplicationInfo.resource` in manifest | `api://botid-{botId}` (must match the Application ID URI) |
+| OAuth connection `ClientId` / `ClientSecret` | From the **auth app** registration |
+| OAuth connection `tokenExchangeUrl` | `api://botid-{botId}` (must match the Application ID URI) |
+
+:::caution
+The Application ID URI on the auth app must use the **bot ID** (MI client ID), not the auth app's own client ID. Teams requires the `botid-` prefix format and matches this URI across the manifest, OAuth connection, and Entra app registration.
+:::
+
 ## Configure the Entra App Registration for SSO
 
 You need an Entra ID App Registration to configure the OAuth Connection in Azure Bot Service. If you don't already have one, follow the [Create the Entra App Registration](../azure-configuration#create-the-entra-app-registration) guide first.
@@ -245,6 +261,18 @@ Expected — all SSO checks pass:
 
 </TabItem>
 </Tabs>
+
+## Cross-Tenant Considerations
+
+SSO requires the Teams client to silently acquire a token for the resource URI configured in `webApplicationInfo.resource`. This token acquisition happens in the context of the **tenant where the Teams app is installed** (sideloaded or published).
+
+If your Entra auth app lives in a different tenant than where the Teams app is installed:
+
+1. The auth app's `signInAudience` must be set to `AzureADMultipleOrgs` (multi-tenant).
+2. Admin consent for the app must be granted **in the tenant where the Teams app is installed**, not just in the tenant where the app registration lives.
+3. The user signed into Teams must be in a tenant that can reach the auth app.
+
+If these conditions are not met, SSO will silently fail and Teams will fall back to the OAuth card sign-in button. See the [Troubleshooting](troubleshooting-sso) guide for details on the fallback behavior.
 
 ## Troubleshooting
 

--- a/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
+++ b/teams.md/docs/main/teams/user-authentication/sso-setup.mdx
@@ -264,15 +264,7 @@ Expected — all SSO checks pass:
 
 ## Cross-Tenant Considerations
 
-SSO requires the Teams client to silently acquire a token for the resource URI configured in `webApplicationInfo.resource`. This token acquisition happens in the context of the **tenant where the Teams app is installed** (sideloaded or published).
-
-If your Entra auth app lives in a different tenant than where the Teams app is installed:
-
-1. The auth app's `signInAudience` must be set to `AzureADMultipleOrgs` (multi-tenant).
-2. Admin consent for the app must be granted **in the tenant where the Teams app is installed**, not just in the tenant where the app registration lives.
-3. The user signed into Teams must be in a tenant that can reach the auth app.
-
-If these conditions are not met, SSO will silently fail and Teams will fall back to the OAuth card sign-in button. See the [Troubleshooting](troubleshooting-sso) guide for details on the fallback behavior.
+If your Entra auth app lives in a different tenant than where the Teams app is installed, see [Cross-Tenant Considerations](troubleshooting-sso#cross-tenant-considerations) in the troubleshooting guide.
 
 ## Troubleshooting
 

--- a/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
+++ b/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
@@ -58,13 +58,16 @@ However, if the **identity that authenticates in the popup differs from the Team
 3. The SDK's built-in handler exchanges the code for a token
 4. The SDK emits a `signin` event
 
+:::caution
+In cross-tenant scenarios where the authenticating identity differs from the Teams session user (for example, signing in with a production tenant account while Teams is logged in as a dev tenant user), the Teams client may not be able to correlate the magic code back to the pending OAuthCard session. In this case, the code arrives as a regular `message` activity instead of a `signin/verifyState` invoke, and the SDK cannot process it. To avoid this, ensure the authenticating identity matches the Teams session, or use one of the options in [Cross-Tenant Considerations](#cross-tenant-considerations) to enable SSO directly.
+:::
+
 **Important:** the `signin()` method in your message handler sends the OAuthCard and returns `undefined` when no cached token exists. It does not wait for the user to complete authentication. To handle the post-sign-in logic, use the `signin` event:
 
 ```typescript
-app.on('message', async ({ signin, isSignedIn, send }) => {
-  if (!isSignedIn) {
-    await signin(); // sends the OAuthCard, returns undefined
-    return;
+app.on('message', async ({ signin, send }) => {
+  if (!(await signin())) {
+    return; // OAuthCard sent; waiting for auth to complete
   }
   await send('You are already signed in!');
 });
@@ -74,6 +77,18 @@ app.event('signin', async ({ send }) => {
   await send('Sign-in complete!');
 });
 ```
+
+## Cross-Tenant Considerations
+
+SSO requires the Teams client to silently acquire a token for the resource URI configured in `webApplicationInfo.resource`. This token acquisition happens in the context of the **tenant where the Teams app is installed** (sideloaded or published).
+
+If your Entra auth app lives in a different tenant than where the Teams app is installed:
+
+1. The auth app's `signInAudience` must be set to `AzureADMultipleOrgs` (multi-tenant).
+2. Admin consent for the app must be granted **in the tenant where the Teams app is installed**, not just in the tenant where the app registration lives.
+3. The user signed into Teams must be in a tenant that can reach the auth app.
+
+If these conditions are not met, SSO will silently fail and Teams will fall back to the OAuth card sign-in button. See [OAuth card fallback and magic code](#oauth-card-fallback-and-magic-code) above for details on the fallback behavior.
 
 ## `resourcematchfailed`
 

--- a/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
+++ b/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
@@ -69,7 +69,7 @@ app.on('message', async ({ signin, isSignedIn, send }) => {
 });
 
 // Fires after SSO (tokenExchange) or magic code (verifyState) completes
-app.event('signin', async ({ send, userGraph }) => {
+app.event('signin', async ({ send }) => {
   await send('Sign-in complete!');
 });
 ```

--- a/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
+++ b/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
@@ -28,6 +28,52 @@ When SSO fails, Teams sends a `signin/failure` invoke activity to your bot with 
 The `userconsentrequired` and `interactionrequired` codes are handled by the Teams client via the OAuth card fallback flow and do not typically reach the bot.
 :::
 
+## `authrequestfailed`
+
+If you see:
+
+> Sign-in failed for user "..." in conversation "...": authrequestfailed -- Failed to handle SSO auth request
+
+This can occur in **cross-tenant** scenarios where the Teams app is installed in one tenant but the Entra auth app lives in another. Common causes:
+
+1. **No admin consent in the Teams app's tenant.** Even if the auth app is multi-tenant (`AzureADMultipleOrgs`), admin consent must be granted in the tenant where the Teams app is sideloaded/installed.
+2. **User identity mismatch.** The user signed into Teams is in a different tenant than expected by the auth app. For example, the Teams user is in a dev tenant but the auth app expects users from a production tenant.
+
+To resolve this, either:
+- Grant admin consent for the multi-tenant auth app in the tenant where the Teams app is installed
+- Install the Teams app in the same tenant as the auth app registration
+
+When `authrequestfailed` occurs, Teams falls back to the OAuth card sign-in flow (sign-in button). See [OAuth card fallback and magic code](#oauth-card-fallback-and-magic-code) below.
+
+## OAuth card fallback and magic code
+
+When SSO fails, Teams falls back to the OAuth card flow: the user clicks a sign-in button, authenticates in a popup, and the popup closes automatically once complete. In this normal fallback, no magic code is shown.
+
+However, if the **identity that authenticates in the popup differs from the Teams conversation user** (for example, signing in with a production tenant account while the Teams client is logged in as a dev tenant user), the Token Service cannot match the redirect state. In this case, the popup displays a **6-digit magic code** and asks the user to paste it into the bot chat.
+
+**The magic code flow is expected behavior, not a bug.** When the user pastes the code into the chat:
+
+1. Teams sends a `signin/verifyState` invoke activity to your bot with the code
+2. The SDK's built-in handler exchanges the code for a token
+3. The SDK emits a `signin` event
+
+**Important:** the `signin()` method in your message handler sends the OAuthCard and returns `undefined` when no cached token exists. It does not wait for the user to complete authentication. To handle the post-sign-in logic, use the `signin` event:
+
+```typescript
+app.on('message', async ({ signin, isSignedIn, send }) => {
+  if (!isSignedIn) {
+    await signin(); // sends the OAuthCard, returns undefined
+    return;
+  }
+  await send('You are already signed in!');
+});
+
+// Fires after SSO (tokenExchange) or magic code (verifyState) completes
+app.event('signin', async ({ send, userGraph }) => {
+  await send('Sign-in complete!');
+});
+```
+
 ## `resourcematchfailed`
 
 If you see a warning in your app logs like:

--- a/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
+++ b/teams.md/docs/main/teams/user-authentication/troubleshooting-sso.mdx
@@ -49,13 +49,14 @@ When `authrequestfailed` occurs, Teams falls back to the OAuth card sign-in flow
 
 When SSO fails, Teams falls back to the OAuth card flow: the user clicks a sign-in button, authenticates in a popup, and the popup closes automatically once complete. In this normal fallback, no magic code is shown.
 
-However, if the **identity that authenticates in the popup differs from the Teams conversation user** (for example, signing in with a production tenant account while the Teams client is logged in as a dev tenant user), the Token Service cannot match the redirect state. In this case, the popup displays a **6-digit magic code** and asks the user to paste it into the bot chat.
+However, if the **identity that authenticates in the popup differs from the Teams conversation user** (for example, signing in with a production tenant account while the Teams client is logged in as a dev tenant user), the Token Service cannot match the redirect state. In this case, the popup displays a **6-digit magic code**.
 
-**The magic code flow is expected behavior, not a bug.** When the user pastes the code into the chat:
+**The magic code flow is expected behavior, not a bug.** To complete it, the user copies the code and pastes it into the chat compose box. The Teams client intercepts the code and routes it as a `signin/verifyState` invoke activity (not a regular message), so your `message` handler is not triggered. The flow is:
 
-1. Teams sends a `signin/verifyState` invoke activity to your bot with the code
-2. The SDK's built-in handler exchanges the code for a token
-3. The SDK emits a `signin` event
+1. User pastes the magic code into the compose box and presses Send
+2. Teams sends a `signin/verifyState` invoke activity to your bot with the code
+3. The SDK's built-in handler exchanges the code for a token
+4. The SDK emits a `signin` event
 
 **Important:** the `signin()` method in your message handler sends the OAuthCard and returns `undefined` when no cached token exists. It does not wait for the user to complete authentication. To handle the post-sign-in logic, use the `signin` event:
 

--- a/teams.md/src/components/include/essentials/sending-messages/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/sending-messages/csharp.incl.md
@@ -160,13 +160,4 @@ await app.Send(conversationId, msg);
 ```
 
 <!-- quoted-replies-preview-note -->
-
-:::tip[.NET]
-In .NET, quoted reply APIs are marked with `[Experimental("ExperimentalTeamsQuotedReplies")]` and will produce a compiler error until you opt in. Suppress the diagnostic inline with `#pragma warning disable ExperimentalTeamsQuotedReplies` or project-wide in your `.csproj`:
-
-```xml
-<PropertyGroup>
-  <NoWarn>$(NoWarn);ExperimentalTeamsQuotedReplies</NoWarn>
-</PropertyGroup>
-```
-:::
+N/A

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -35,7 +35,7 @@ Here is an example of a basic message handler:
 ## Slash Commands
 
 :::info[Preview]
-Slash commands are coming soon in May 2026.
+Slash commands are available in public preview. General availability is planned for a future release.
 :::
 
 Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section. You can opt in with an explicit command list by declaring specific commands using `commandLists` with `triggers: ["slash"]`, which Teams shows in the slash menu when a user types `/`. Without a command list, users can still invoke your agent via `/agent-name` and provide free-form input.

--- a/teams.md/src/pages/templates/essentials/sending-messages/README.mdx
+++ b/teams.md/src/pages/templates/essentials/sending-messages/README.mdx
@@ -40,8 +40,8 @@ Sending a message at `@mentions` a user is as simple including the details of th
 
 ## Targeted Messages
 
-:::info[Coming Soon]
-Targeted messages are coming soon in May 2026.
+:::info[Preview]
+Targeted messages are available in public preview. General availability is planned for a future release.
 :::
 
 Targeted messages, also known as ephemeral messages, are delivered to a specific user in a shared conversation. From a single user's perspective, they appear as regular inline messages in a conversation. Other participants won't see these messages, making them useful for authentication flows, help or error responses, personal reminders, or sharing contextual information without cluttering the group conversation.
@@ -69,10 +69,6 @@ When your agent receives a message in a thread, the conversation context already
 For proactive threading (sending to a thread outside of a handler), see [Proactive Messaging](./proactive-messaging#proactive-threading).
 
 ## Quoted Replies
-
-:::info[Coming Soon]
-Quoted replies are coming soon in May 2026.
-:::
 
 Quoted replies let your agent reference a previous message in the conversation. When a user sends a message that quotes another message, your agent receives structured metadata about the quoted content. Your agent can also send messages that quote previous messages.
 

--- a/teams.md/src/pages/templates/essentials/sending-messages/proactive-messaging.mdx
+++ b/teams.md/src/pages/templates/essentials/sending-messages/proactive-messaging.mdx
@@ -23,8 +23,8 @@ In this example, you see how to get the <LanguageInclude section="conversation-i
 
 ## Targeted Proactive Messages
 
-:::info[Coming Soon]
-Targeted messages are coming soon in May 2026.
+:::info[Preview]
+Targeted messages are available in public preview. General availability is planned for a future release.
 :::
 
 Targeted messages, also known as ephemeral messages, are delivered to a specific user in a shared conversation. From a single user's perspective, they appear as regular inline messages in a conversation. Other participants won't see these messages.


### PR DESCRIPTION
## Summary

Documentation updates driven by customer feedback ([Discussion #2881](https://github.com/microsoft/teams-sdk/discussions/2881), [Issue #2871](https://github.com/microsoft/teams-sdk/issues/2871)).
Fixes #2871 

## SSO Documentation (new content)

- **SSO with User-Assigned Managed Identity**: New section in `sso-setup.mdx` explaining how IDs map when the bot uses MI and a separate auth app registration
- **Cross-Tenant Considerations**: New section covering tenant requirements for SSO to work silently
- **`authrequestfailed` troubleshooting**: New section in `troubleshooting-sso.mdx` for cross-tenant SSO failures
- **OAuth card fallback and magic code**: Documents when/why the magic code appears and the `signin()` + `app.event('signin')` pattern

## Preview Status Updates

- Targeted messages: "coming soon in May 2026" -> "available in public preview"
- Slash commands: same update
- Quoted replies: removed "Coming Soon" callout (now GA)
- Removed C# experimental note for quoted replies (`ExperimentalTeamsQuotedReplies` being removed in companion PRs)

## Companion PRs
- https://github.com/microsoft/teams.ts/pull/621
- https://github.com/microsoft/teams.py/pull/470
- https://github.com/microsoft/teams.net/pull/572