### PR TITLE
[PY] fix: deprecate teams-ai pypi package

### DIFF
--- a/python/packages/ai/README.md
+++ b/python/packages/ai/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> **Deprecated** — This package is no longer maintained. We recommend migrating to [teams.py](https://github.com/microsoft/teams.py), which is the successor to this package.
+
 # Teams AI Library
 
 Welcome to the Teams AI Library Python package! 

--- a/python/packages/ai/pyproject.toml
+++ b/python/packages/ai/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "teams-ai"
-version = "1.8.1"
+version = "1.8.2"
 description = "SDK focused on building AI based applications for Microsoft Teams."
 readme = "README.md"
 authors = [{ name = "Microsoft", email = "teams@microsoft.com"}]
 keywords = ["microsoft", "teams", "ai", "bot"]
+classifiers = ["Development Status :: 7 - Inactive"]
 requires-python = ">=3.9,<4.0"
 dependencies = [
     "botbuilder-core (>=4.15.0,<5.0.0)",


### PR DESCRIPTION
## Summary

This PR deprecates our teams-ai python package 

### Changes
- **pyproject.toml**: Added \Development Status :: 7 - Inactive\ classifier, bumped version to \1.8.2\
- **README.md**: Added deprecation warning banner pointing users to [teams.py](https://github.com/microsoft/teams.py) as the successor

### After merge
A new release needs to be published to PyPI with these changes so the deprecation notice appears on the package page.