### PR TITLE
Rename AI libs to agent frameworks blog title

### DIFF
--- a/teams.md/blog/2026-06-16-ai-libs-to-agent-frameworks/index.md
+++ b/teams.md/blog/2026-06-16-ai-libs-to-agent-frameworks/index.md
@@ -1,6 +1,6 @@
 ---
 slug: ai-libraries-to-agent-frameworks
-title: "Unbundling AI from the Teams SDK: A Cleaner Path to Agents"
+title: "Teams SDK + Agent Frameworks: Better Together"
 date: 2026-06-16
 authors:
   - name: Mehak Bindra


### PR DESCRIPTION
## Summary
- Renames the `2026-06-16-ai-libs-to-agent-frameworks` blog title from "Unbundling AI from the Teams SDK: A Cleaner Path to Agents" to "Teams SDK + Agent Frameworks: Better Together"
- Slug, URL, and content unchanged

## Test plan
- [ ] Verify blog renders with new title at `/blog/ai-libraries-to-agent-frameworks`
- [ ] Confirm blog index/listing reflects the new title

🤖 Generated with [Claude Code](https://claude.com/claude-code)