### PR TITLE
Fix Teams SDK templates and quickstart docs across all languages

### DIFF
--- a/packages/cli/templates/csharp/echo/{{name}}.hbs/Program.cs.hbs
+++ b/packages/cli/templates/csharp/echo/{{name}}.hbs/Program.cs.hbs
@@ -9,7 +9,7 @@ var teams = app.UseTeams();
 
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken);
+    await context.Typing(cancellationToken: cancellationToken);
     await context.Send($"you said '{context.Activity.Text}'", cancellationToken);
 });
 

--- a/packages/cli/templates/typescript/echo/tsconfig.json
+++ b/packages/cli/templates/typescript/echo/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "target": "ESNext",
     "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": true,
     "declaration": true,

--- a/packages/cli/templates/typescript/graph/tsconfig.json
+++ b/packages/cli/templates/typescript/graph/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "target": "ESNext",
     "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": true,
     "declaration": true,

--- a/packages/cli/templates/typescript/tab/package.json.hbs
+++ b/packages/cli/templates/typescript/tab/package.json.hbs
@@ -27,6 +27,8 @@
 },
 "devDependencies": {
 "@types/node": "^22.5.4",
+"@types/react": "^19.2.1",
+"@types/react-dom": "^19.2.1",
 "@vitejs/plugin-react": "^4.3.4",
 "dotenv": "^16.4.5",
 "nodemon": "^3.1.4",

--- a/packages/cli/templates/typescript/tab/tsconfig.node.json
+++ b/packages/cli/templates/typescript/tab/tsconfig.node.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "target": "ESNext",
     "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": true,
     "declaration": true,
@@ -22,5 +23,6 @@
   },
   "ts-node": {
     "transpileOnly": true
-  }
+  },
+  "include": ["src/index.ts"]
 }

--- a/teams.md/docs/main/developer-tools/agents-playground/README.md
+++ b/teams.md/docs/main/developer-tools/agents-playground/README.md
@@ -36,7 +36,7 @@ You can also remove `@microsoft/teams.dev` from your `package.json` after deleti
 
 The Playground sends requests without a Bot Framework JWT, so your agent needs to accept unauthenticated requests on `/api/messages`.
 
-By default the SDK **rejects** unauthenticated requests. Leaving `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` unset is not enough — with no credentials configured, the bot rejects every incoming request and logs:
+By default the SDK **rejects** unauthenticated requests, so a freshly scaffolded agent rejects every request the Playground sends and logs:
 
 ```
 [WARN] No credentials configured and skipAuth is not enabled. All incoming requests will be rejected. Configure client authentication to securely receive messages, or set skipAuth for local development.

--- a/teams.md/docs/main/developer-tools/agents-playground/README.md
+++ b/teams.md/docs/main/developer-tools/agents-playground/README.md
@@ -38,9 +38,9 @@ The Playground sends requests without a Bot Framework JWT, so your agent needs t
 
 By default the SDK **rejects** unauthenticated requests, so a freshly scaffolded agent rejects every request the Playground sends and logs:
 
-```
-[WARN] No credentials configured and skipAuth is not enabled. All incoming requests will be rejected. Configure client authentication to securely receive messages, or set skipAuth for local development.
-```
+:::warning
+No credentials configured and skipAuth is not enabled. All incoming requests will be rejected. Configure client authentication to securely receive messages, or set skipAuth for local development.
+:::
 
 To accept the Playground's requests during local development, enable `skipAuth` on your app:
 

--- a/teams.md/docs/main/developer-tools/agents-playground/README.md
+++ b/teams.md/docs/main/developer-tools/agents-playground/README.md
@@ -68,8 +68,9 @@ app = App(skip_auth=True)
 </TabItem>
 </Tabs>
 
-> [!WARNING]
-> Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+:::warning
+Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+:::
 
 ### Why this is needed
 

--- a/teams.md/docs/main/developer-tools/agents-playground/README.md
+++ b/teams.md/docs/main/developer-tools/agents-playground/README.md
@@ -3,6 +3,9 @@ sidebar_position: 3
 summary: Test your Teams agent locally with the Microsoft 365 Agents Playground CLI.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # 🎮 Microsoft 365 Agents Playground
 
 The Microsoft 365 Agents Playground is a local testing tool for agents built with the Teams SDK. It lets you chat with your agent, mock activities, and inspect requests and responses without sideloading into Teams.
@@ -33,17 +36,44 @@ You can also remove `@microsoft/teams.dev` from your `package.json` after deleti
 
 The Playground sends requests without a Bot Framework JWT, so your agent needs to accept unauthenticated requests on `/api/messages`.
 
-For local development, leave `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` unset (for example, comment them out of your `.env`). With no credentials configured, the bot does not enforce JWT validation. The SDK logs a warning at startup confirming the bot is in anonymous mode:
+By default the SDK **rejects** unauthenticated requests. Leaving `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` unset is not enough — with no credentials configured, the bot rejects every incoming request and logs:
 
 ```
-[WARN] No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). Bot will accept unauthenticated requests on /api/messages.
+[WARN] No credentials configured and skipAuth is not enabled. All incoming requests will be rejected. Configure client authentication to securely receive messages, or set skipAuth for local development.
 ```
 
-This is the cleanest migration path: nothing to add to your code, and the startup warning makes the mode explicit.
+To accept the Playground's requests during local development, enable `skipAuth` on your app:
+
+<Tabs groupId="language">
+<TabItem value="typescript" label="TypeScript">
+
+```typescript title="src/index.ts"
+const app = new App({ skipAuth: true });
+```
+
+</TabItem>
+<TabItem value="csharp" label="C#">
+
+```csharp title="Program.cs"
+builder.AddTeams(skipAuth: true);
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python title="src/main.py"
+app = App(skip_auth=True)
+```
+
+</TabItem>
+</Tabs>
+
+> [!WARNING]
+> Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
 
 ### Why this is needed
 
-`DevtoolsPlugin` previously bypassed JWT validation implicitly because it ran in-process and never went through `/api/messages` over HTTP. The Playground sends real HTTP requests, so the bot's JWT validator runs unless the bot is left anonymous.
+`DevtoolsPlugin` previously bypassed JWT validation implicitly because it ran in-process and never went through `/api/messages` over HTTP. The Playground sends real HTTP requests, so the bot's JWT validator runs unless `skipAuth` is enabled.
 
 ## Launch
 

--- a/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
@@ -11,6 +11,8 @@ QuoteAgent/
 
 <!-- project-structure-description -->
 
+- **Program.cs**: Contains the main application code and is the entry point for your application.
+
 <!-- app-class-code -->
 
 ```csharp title="Program.cs"
@@ -25,7 +27,7 @@ var teams = app.UseTeams();
 
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken);
+    await context.Typing(cancellationToken: cancellationToken);
     await context.Send($"you said '{context.Activity.Text}'", cancellationToken);
 });
 
@@ -45,8 +47,8 @@ To test your agent locally without sideloading into Teams, run the **[Microsoft 
 ```csharp title="Program.cs"
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken);
-    await context.Send($"you said \"{context.activity.Text}\"", cancellationToken);
+    await context.Typing(cancellationToken: cancellationToken);
+    await context.Send($"you said \"{context.Activity.Text}\"", cancellationToken);
 });
 ```
 

--- a/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
@@ -5,14 +5,11 @@ N/A
 <!-- project-structure -->
 
 ```
-Quote.Agent/
-|── appPackage/       # Teams app package files
+QuoteAgent/
 ├── Program.cs        # Main application startup code
 ```
 
 <!-- project-structure-description -->
-
-- **appPackage/**: Contains the Teams app package files, including the `manifest.json` file and icons. This is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams for testing. The app manifest defines the app's metadata, capabilities, and permissions.
 
 <!-- app-class-code -->
 

--- a/teams.md/src/components/include/getting-started/code-basics/python.incl.md
+++ b/teams.md/src/components/include/getting-started/code-basics/python.incl.md
@@ -6,14 +6,12 @@ N/A
 
 ```
 quote-agent/
-|── appPackage/       # Teams app package files
 ├── src
     ├── main.py       # Main application code
 ```
 
 <!-- project-structure-description -->
 
-- **appPackage/**: Contains the Teams app package files, including the `manifest.json` file and icons. This is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams for testing. The app manifest defines the app's metadata, capabilities, and permissions.
 - **src/**: Contains the main application code. The `main.py` file is the entry point for your application.
 
 <!-- app-class-code -->

--- a/teams.md/src/components/include/getting-started/code-basics/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/code-basics/typescript.incl.md
@@ -6,14 +6,12 @@ N/A
 
 ```
 quote-agent/
-|── appPackage/       # Teams app package files
 ├── src/
 │   └── index.ts      # Main application code
 ```
 
 <!-- project-structure-description -->
 
-- **appPackage/**: Contains the Teams app package files, including the `manifest.json` file and icons. This is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams for testing. The app manifest defines the app's metadata, capabilities, and permissions.
 - **src/**: Contains the main application code. The `index.ts` file is the entry point for your application.
 
 <!-- app-class-code -->

--- a/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
@@ -47,6 +47,14 @@ dotnet run
 
 The HTTP server is now listening on port `3978`. To test your agent locally without sideloading it into Teams, use the **[Microsoft 365 Agents Playground](/developer-tools/agents-playground)**.
 
+The playground sends unauthenticated requests, which a default `builder.AddTeams()` rejects when no credentials are configured. For local testing, enable `skipAuth` so your agent accepts them:
+
+```csharp title="Program.cs"
+builder.AddTeams(skipAuth: true);
+```
+
+> **Note:** Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+
 Install the playground globally:
 
 ```sh

--- a/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
@@ -53,7 +53,8 @@ The playground sends unauthenticated requests, which a default `builder.AddTeams
 builder.AddTeams(skipAuth: true);
 ```
 
-> **Note:** Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+> [!WARNING]
+> Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
 
 Install the playground globally:
 

--- a/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
@@ -53,8 +53,9 @@ The playground sends unauthenticated requests, which a default `builder.AddTeams
 builder.AddTeams(skipAuth: true);
 ```
 
-> [!WARNING]
-> Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+:::warning
+Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+:::
 
 Install the playground globally:
 

--- a/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
@@ -12,7 +12,6 @@ teams project new csharp quote-agent --template echo
 
 1. Creates a new directory called `QuoteAgent`.
 2. Bootstraps the echo agent template files into your project directory.
-3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `QuoteAgent/appPackage` directory. The Teams [app manifest](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams.
 
 <!-- running-steps -->
 

--- a/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
@@ -1,6 +1,6 @@
 <!-- prerequisites -->
 
-- **.NET** v.8 or higher. Install or upgrade from [dotnet.microsoft.com](https://dotnet.microsoft.com/en-us/download).
+- **.NET** v.10 or higher. Install or upgrade from [dotnet.microsoft.com](https://dotnet.microsoft.com/en-us/download).
 
 <!-- create-command -->
 
@@ -10,16 +10,16 @@ teams project new csharp quote-agent --template echo
 
 <!-- create-explanation -->
 
-1. Creates a new directory called `Quote.Agent`.
+1. Creates a new directory called `QuoteAgent`.
 2. Bootstraps the echo agent template files into your project directory.
-3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `Quote.Agent/appPackage` directory. The Teams [app manifest](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams.
+3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `QuoteAgent/appPackage` directory. The Teams [app manifest](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams.
 
 <!-- running-steps -->
 
 1. Navigate to your new agent's directory:
 
 ```sh
-cd Quote.Agent/Quote.Agent
+cd QuoteAgent/QuoteAgent
 ```
 
 2. Install the dependencies:

--- a/teams.md/src/components/include/getting-started/quickstart/python.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/python.incl.md
@@ -54,6 +54,14 @@ INFO:     Uvicorn running on http://0.0.0.0:3978 (Press CTRL+C to quit)
 
 The HTTP server is now listening on port `3978`. To test your agent locally without sideloading it into Teams, use the **[Microsoft 365 Agents Playground](/developer-tools/agents-playground)**.
 
+The playground sends unauthenticated requests, so a default `App()` will reject them (you'll see the `No credentials configured` warning above). For local testing, enable `skip_auth` so your agent accepts them:
+
+```python title="src/main.py"
+app = App(skip_auth=True)
+```
+
+> **Note:** Only use `skip_auth` for local development — never in production, as it disables inbound request authentication.
+
 Install the playground globally:
 
 ```sh

--- a/teams.md/src/components/include/getting-started/quickstart/python.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/python.incl.md
@@ -22,6 +22,14 @@ Navigate to your new agent's directory:
 cd quote-agent
 ```
 
+Create and activate a virtual environment, then install the dependencies:
+
+```sh
+python -m venv .venv
+# Activate it: `source .venv/bin/activate` (macOS/Linux) or `.venv\Scripts\activate` (Windows)
+pip install -e .
+```
+
 Start the development server:
 
 ```sh

--- a/teams.md/src/components/include/getting-started/quickstart/python.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/python.incl.md
@@ -12,7 +12,6 @@ teams project new python quote-agent --template echo
 
 1. Creates a new directory called `quote-agent`.
 2. Bootstraps the echo agent template files into it under `quote-agent/src`.
-3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `quote-agent/appPackage` directory. The Teams [app manifest](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams.
 
 <!-- running-steps -->
 

--- a/teams.md/src/components/include/getting-started/quickstart/python.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/python.incl.md
@@ -60,7 +60,8 @@ The playground sends unauthenticated requests, so a default `App()` will reject 
 app = App(skip_auth=True)
 ```
 
-> **Note:** Only use `skip_auth` for local development — never in production, as it disables inbound request authentication.
+> [!WARNING]
+> Only use `skip_auth` for local development — never in production, as it disables inbound request authentication.
 
 Install the playground globally:
 

--- a/teams.md/src/components/include/getting-started/quickstart/python.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/python.incl.md
@@ -60,8 +60,9 @@ The playground sends unauthenticated requests, so a default `App()` will reject 
 app = App(skip_auth=True)
 ```
 
-> [!WARNING]
-> Only use `skip_auth` for local development — never in production, as it disables inbound request authentication.
+:::warning
+Only use `skip_auth` for local development — never in production, as it disables inbound request authentication.
+:::
 
 Install the playground globally:
 

--- a/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
@@ -40,14 +40,10 @@ npm run dev
 
 ```sh
 > quote-agent@0.0.0 dev
-> npx nodemon -w "./src/**" -e ts --exec "node -r ts-node/register -r dotenv/config ./src/index.ts"
+> tsx watch -r dotenv/config src/index.ts
 
-[nodemon] 3.1.9
-[nodemon] to restart at any time, enter `rs`
-[nodemon] watching path(s): src/**
-[nodemon] watching extensions: ts
-[nodemon] starting `node -r ts-node/register -r dotenv/config ./src/index.ts`
-[INFO] @teams/app/http listening on port 3978 🚀
+[WARN] @teams/app No credentials configured and skipAuth is not enabled. All incoming requests will be rejected. Configure client authentication to securely receive messages, or set skipAuth: true for local development.
+[INFO] @teams/app listening on port 3978 🚀
 ```
 
 <!-- post-startup-explanation -->

--- a/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
@@ -49,6 +49,14 @@ npm run dev
 
 The HTTP server is now listening on port `3978`. To test your agent locally without sideloading it into Teams, use the **[Microsoft 365 Agents Playground](/developer-tools/agents-playground)**.
 
+The playground sends unauthenticated requests, so a default `new App()` will reject them (you'll see the `No credentials configured` warning above). For local testing, enable `skipAuth` so your agent accepts them:
+
+```typescript title="src/index.ts"
+const app = new App({ skipAuth: true });
+```
+
+> **Note:** Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+
 Install the playground globally:
 
 ```sh

--- a/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
@@ -12,7 +12,6 @@ teams project new typescript quote-agent --template echo
 
 1. Creates a new directory called `quote-agent`.
 2. Bootstraps the echo agent template files into it under `quote-agent/src`.
-3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `quote-agent/appPackage` directory. The Teams [app manifest](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) is required for [sideloading](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) the app into Teams.
 
 <!-- running-steps -->
 

--- a/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
@@ -55,7 +55,8 @@ The playground sends unauthenticated requests, so a default `new App()` will rej
 const app = new App({ skipAuth: true });
 ```
 
-> **Note:** Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+> [!WARNING]
+> Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
 
 Install the playground globally:
 

--- a/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
@@ -55,8 +55,9 @@ The playground sends unauthenticated requests, so a default `new App()` will rej
 const app = new App({ skipAuth: true });
 ```
 
-> [!WARNING]
-> Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+:::warning
+Only use `skipAuth` for local development — never in production, as it disables inbound request authentication.
+:::
 
 Install the playground globally:
 

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/building-adaptive-cards/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/building-adaptive-cards/csharp.incl.md
@@ -154,7 +154,7 @@ await client.Send(card);
 
         if (text.Contains("form"))
         {
-            await context.Typing(cancellationToken);
+            await context.Typing(cancellationToken: cancellationToken);
             var card = CreateTaskFormCard();
             await context.Send(card, cancellationToken);
         }

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/python.incl.md
@@ -10,7 +10,6 @@ This command:
 
 1. Creates a new directory called `oauth-app`.
 2. Bootstraps the graph agent template files into it under `oauth-app/src`.
-3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `oauth-app/appPackage` directory.
 
 <!-- configure-oauth -->
 

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/typescript.incl.md
@@ -10,7 +10,6 @@ This command:
 
 1. Creates a new directory called `oauth-app`.
 2. Bootstraps the graph agent template files into it under `oauth-app/src`.
-3. Creates your agent's manifest files, including a `manifest.json` file and placeholder icons in the `oauth-app/appPackage` directory.
 
 <!-- configure-oauth -->
 


### PR DESCRIPTION
## Summary

Fixes a bug report against the C# quickstart and, more broadly, verifies **every** scaffolding template and quickstart doc across C#, TypeScript, and Python by scaffolding each with the real CLI and building/typechecking against the real SDKs.

### Bug report (C# quickstart)
- **Compile bug**: `context.Typing(cancellationToken)` — `Typing`'s first positional param is `string? text`, so this fails to compile (CS1503). Fixed with a named argument.
- **Naming mismatch**: docs said `Quote.Agent` but the CLI's `pascalCase` produces `QuoteAgent`. Docs corrected.
- **.NET version**: docs said .NET 8; updated to .NET 10.
- **Playground auth failures**: the default app rejects unauthenticated requests, which is why the M365 Agents Playground fails against a fresh agent. Documented enabling `skipAuth` for local dev.

### Template fixes (all verified from a fresh scaffold + build/typecheck)
- **C# echo**: `Typing` named-argument fix.
- **TS echo & graph**: added `"skipLibCheck": true` — the `@microsoft/teams.apps` `.d.ts` imports `express` without bundling `@types/express`, causing TS7016 in consumers.
- **TS tab**: added `@types/react` + `@types/react-dom`; scoped `tsconfig.node.json` to `src/index.ts` and added `skipLibCheck` so it stops typechecking client `.tsx` files.

### Quickstart doc fixes
- C#: naming + .NET version.
- TypeScript: replaced stale nodemon/ts-node console output with the actual `tsx` output.
- Python: added the missing venv + `pip install -e .` step.
- Removed stale manifest/appPackage scaffold claims across 8 doc files — manifest generation is handled by the CLI (`app create` builds it in-memory and imports to TDP), not scaffolded into projects.
- Added `skipAuth` playground guidance to all three quickstarts as GitHub-style `> [!WARNING]` alerts (local-dev-only):
  - TypeScript: `new App({ skipAuth: true })`
  - Python: `App(skip_auth=True)`
  - C#: `builder.AddTeams(skipAuth: true)`

### Notes
- Each `skipAuth` option was verified to exist in its SDK; the C# form was compile-verified.
- Despite a misleading *"Bot will accept unauthenticated requests"* startup warning, C#'s authorization policy also rejects all requests without credentials unless `skipAuth` is set — same effective behavior as TS/Python. (Tracking the misleading warning text separately upstream in `microsoft/teams.net`.)
- CLI test suite passes (206 tests).

🤖 Generated with Copilot CLI