### PR TITLE
Add plugin.json to standard .github/plugin/ location

### DIFF
--- a/plugins/teams-sdk/.github/plugin/plugin.json
+++ b/plugins/teams-sdk/.github/plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "teams-sdk",
+  "version": "1.3.0",
+  "description": "Create and manage Microsoft Teams bots using the Teams Developer CLI. Covers bot application development (scaffolding bot code), infrastructure setup (bot registration, credentials), SSO configuration, and troubleshooting.",
+  "author": {
+    "name": "Microsoft"
+  },
+  "repository": "https://github.com/microsoft/teams-sdk",
+  "homepage": "https://github.com/microsoft/teams-sdk",
+  "license": "MIT",
+  "keywords": [
+    "teams",
+    "bot",
+    "sdk",
+    "sso",
+    "agents",
+    "developer-cli"
+  ],
+  "skills": [
+    "./skills/teams-dev/"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `plugin.json` to `plugins/teams-sdk/.github/plugin/` — the standard location that Copilot plugin marketplaces (e.g. `github/awesome-copilot`) use for install-time validation.

## Problem

The plugin currently has its manifest at `.claude-plugin/plugin.json`, which is not a recognized location for the Copilot external plugin install smoke test. This causes the `github/awesome-copilot` intake automation to fail with:

> Plugin installed but no plugin.json was found in any recognized location

## Changes

- Adds `plugins/teams-sdk/.github/plugin/plugin.json` with the same metadata as the existing `.claude-plugin/plugin.json`, plus `repository`, `keywords`, and `skills` fields that follow the marketplace schema (matching plugins like `arize-ax` in awesome-copilot).

## Context

- awesome-copilot submission: github/awesome-copilot#2286 (blocked on this)
- vally lint already passes (3/3 checks); only the install smoke test fails due to missing manifest location