### PR TITLE
Update .NET CLI samples to 2.1 preview

### DIFF
--- a/packages/cli/src/commands/project/new/csharp.ts
+++ b/packages/cli/src/commands/project/new/csharp.ts
@@ -27,9 +27,12 @@ const csharpStrategy: ProjectLanguageStrategy = {
   validateProjectName(): void {},
   mapBaseEnvVars(baseEnvVars: Record<string, string>): Record<string, string> {
     const envVars: Record<string, string> = {};
-    if (baseEnvVars.CLIENT_ID) envVars['Teams.ClientId'] = baseEnvVars.CLIENT_ID;
-    if (baseEnvVars.CLIENT_SECRET) envVars['Teams.ClientSecret'] = baseEnvVars.CLIENT_SECRET;
-    if (baseEnvVars.TENANT_ID) envVars['Teams.TenantId'] = baseEnvVars.TENANT_ID;
+    if (baseEnvVars.CLIENT_ID) envVars['AzureAd.ClientId'] = baseEnvVars.CLIENT_ID;
+    if (baseEnvVars.TENANT_ID) envVars['AzureAd.TenantId'] = baseEnvVars.TENANT_ID;
+    if (baseEnvVars.CLIENT_SECRET) {
+      envVars['AzureAd.ClientCredentials.0.SourceType'] = 'ClientSecret';
+      envVars['AzureAd.ClientCredentials.0.ClientSecret'] = baseEnvVars.CLIENT_SECRET;
+    }
     if (baseEnvVars.OPENAI_API_KEY) envVars.OPENAI_API_KEY = baseEnvVars.OPENAI_API_KEY;
     if (baseEnvVars.AZURE_OPENAI_API_KEY)
       envVars.AZURE_OPENAI_API_KEY = baseEnvVars.AZURE_OPENAI_API_KEY;
@@ -64,6 +67,7 @@ export const projectNewCsharpCommand = new Command('csharp')
   .option(`-t, --template <template>`, `App template (${templates.join(', ')})`, 'echo')
   .option('--client-id <id>', '[OPTIONAL] Azure app client ID')
   .option('--client-secret <secret>', '[OPTIONAL] Azure app client secret')
+  .option('--tenant-id <id>', '[OPTIONAL] Azure tenant ID')
   .option('-s, --start', '[OPTIONAL] Auto-start project after creation')
   .option('--json', '[OPTIONAL] Output as JSON')
   .action(

--- a/packages/cli/src/commands/project/shared.ts
+++ b/packages/cli/src/commands/project/shared.ts
@@ -102,7 +102,7 @@ export function appCreateCommandFor(agentName: string, credentialsPath: string):
 }
 
 export function hasCredentialValues(envVars: Record<string, string>): boolean {
-  return Boolean(envVars.CLIENT_ID ?? envVars['Teams.ClientId']);
+  return Boolean(envVars.CLIENT_ID ?? envVars['Teams.ClientId'] ?? envVars['AzureAd.ClientId']);
 }
 
 export async function resolveProjectName(

--- a/packages/cli/src/project/file-ops.ts
+++ b/packages/cli/src/project/file-ops.ts
@@ -77,23 +77,66 @@ export function removeEnvVar(filePath: string, key: string): void {
 
 // --- internal helpers ---
 
-function setNestedValue(obj: Record<string, unknown>, dotPath: string, value?: unknown): void {
+type JsonObject = Record<string, unknown>;
+type JsonArray = unknown[];
+type JsonContainer = JsonObject | JsonArray;
+
+function setNestedValue(obj: JsonObject, dotPath: string, value?: unknown): void {
   const parts = dotPath.split('.');
-  let current: Record<string, unknown> = obj;
+  let current: JsonContainer = obj;
 
   for (let i = 0; i < parts.length; i++) {
     const key = parts[i];
-    if (i === parts.length - 1) {
+    const isLast = i === parts.length - 1;
+
+    if (Array.isArray(current)) {
+      const index = parseArrayIndex(key, dotPath);
+      if (isLast) {
+        if (value === undefined) {
+          current.splice(index, 1);
+        } else {
+          current[index] = value;
+        }
+      } else {
+        const existing = current[index];
+        if (!isJsonContainer(existing)) {
+          current[index] = createContainer(parts[i + 1]);
+        }
+        current = current[index] as JsonContainer;
+      }
+      continue;
+    }
+
+    if (isLast) {
       if (value === undefined) {
         delete current[key];
       } else {
         current[key] = value;
       }
     } else {
-      if (!current[key] || typeof current[key] !== 'object') {
-        current[key] = {};
+      if (!isJsonContainer(current[key])) {
+        current[key] = createContainer(parts[i + 1]);
       }
-      current = current[key] as Record<string, unknown>;
+      current = current[key] as JsonContainer;
     }
   }
+}
+
+function isJsonContainer(value: unknown): value is JsonContainer {
+  return typeof value === 'object' && value !== null;
+}
+
+function createContainer(nextKey: string): JsonContainer {
+  return isArrayIndex(nextKey) ? [] : {};
+}
+
+function isArrayIndex(key: string): boolean {
+  return /^(0|[1-9]\d*)$/.test(key);
+}
+
+function parseArrayIndex(key: string, dotPath: string): number {
+  if (!isArrayIndex(key)) {
+    throw new Error(`Expected array index in path "${dotPath}", got "${key}".`);
+  }
+  return Number(key);
 }

--- a/packages/cli/templates/csharp/echo/{{name}}.hbs/Program.cs.hbs
+++ b/packages/cli/templates/csharp/echo/{{name}}.hbs/Program.cs.hbs
@@ -1,16 +1,16 @@
-using Microsoft.Teams.Apps.Activities;
-using Microsoft.Teams.Apps.Extensions;
-using Microsoft.Teams.Plugins.AspNetCore.Extensions;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
 
-var builder = WebApplication.CreateBuilder(args);
-builder.AddTeams();
-var app = builder.Build();
-var teams = app.UseTeams();
+WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.AddTeamsBotApplication();
+WebApplication app = builder.Build();
+
+TeamsBotApplication teams = app.UseTeamsBotApplication();
 
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken: cancellationToken);
-    await context.Send($"you said '{context.Activity.Text}'", cancellationToken);
+    await context.TypingAsync(cancellationToken: cancellationToken);
+    await context.SendAsync($"you said '{context.Activity.Text}'", cancellationToken);
 });
 
 app.Run();

--- a/packages/cli/templates/csharp/echo/{{name}}.hbs/appsettings.Development.json
+++ b/packages/cli/templates/csharp/echo/{{name}}.hbs/appsettings.Development.json
@@ -2,10 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    },
-    "Microsoft.Teams": {
-      "Level": "info"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Teams": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/packages/cli/templates/csharp/echo/{{name}}.hbs/appsettings.json
+++ b/packages/cli/templates/csharp/echo/{{name}}.hbs/appsettings.json
@@ -2,10 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    },
-    "Microsoft.Teams": {
-      "Level": "info"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Teams": "Information"
     }
   },
   "AllowedHosts": "*"

--- a/packages/cli/templates/csharp/echo/{{name}}.hbs/{{name}}.csproj.hbs
+++ b/packages/cli/templates/csharp/echo/{{name}}.hbs/{{name}}.csproj.hbs
@@ -7,11 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Teams.Plugins.AspNetCore" Version="2.0.*" />
+    <PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview.*" />
   </ItemGroup>
 
 </Project>

--- a/packages/cli/tests/file-ops.test.ts
+++ b/packages/cli/tests/file-ops.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { setJsonValue } from '../src/project/file-ops.js';
+
+interface AzureAdConfig {
+  ClientCredentials: {
+    SourceType?: string;
+    ClientSecret?: string;
+  }[];
+}
+
+interface AppSettings {
+  AzureAd: AzureAdConfig;
+}
+
+describe('file ops', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teams-cli-file-ops-')));
+    filePath = path.join(tempDir, 'appsettings.json');
+    fs.writeFileSync(filePath, '{}\n', 'utf8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates arrays for numeric JSON path segments', () => {
+    setJsonValue(filePath, 'AzureAd.ClientCredentials.0.SourceType', 'ClientSecret');
+    setJsonValue(filePath, 'AzureAd.ClientCredentials.0.ClientSecret', 'secret');
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf8')) as AppSettings;
+    expect(json.AzureAd.ClientCredentials).toEqual([
+      {
+        SourceType: 'ClientSecret',
+        ClientSecret: 'secret',
+      },
+    ]);
+  });
+});

--- a/packages/cli/tests/project-new-csharp.test.ts
+++ b/packages/cli/tests/project-new-csharp.test.ts
@@ -74,4 +74,35 @@ describe('project new csharp', () => {
       })
     );
   });
+
+  it('maps credentials to the .NET 2.1 AzureAd config shape', async () => {
+    const { projectNewCsharpCommand } = await import('../src/commands/project/new/csharp.js');
+    const { scaffoldProject } = await import('../src/project/scaffold.js');
+
+    await projectNewCsharpCommand.parseAsync(
+      [
+        'pokemon-catcher',
+        '--template',
+        'echo',
+        '--client-id',
+        'client-id',
+        '--client-secret',
+        'client-secret',
+        '--tenant-id',
+        'tenant-id',
+      ],
+      { from: 'user' }
+    );
+
+    expect(scaffoldProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: {
+          'AzureAd.ClientId': 'client-id',
+          'AzureAd.TenantId': 'tenant-id',
+          'AzureAd.ClientCredentials.0.SourceType': 'ClientSecret',
+          'AzureAd.ClientCredentials.0.ClientSecret': 'client-secret',
+        },
+      })
+    );
+  });
 });

--- a/packages/cli/tests/project-scaffold-csharp-template.test.ts
+++ b/packages/cli/tests/project-scaffold-csharp-template.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { scaffoldProject } from '../src/project/scaffold.js';
+
+describe('C# scaffold template', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'teams-cli-csharp-template-')));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses the .NET 2.1 preview package and hosting API', async () => {
+    await scaffoldProject({
+      name: 'PokemonCatcher',
+      language: 'csharp',
+      template: 'echo',
+      targetDir: tempDir,
+    });
+
+    const projectDir = path.join(tempDir, 'PokemonCatcher');
+    const csproj = fs.readFileSync(path.join(projectDir, 'PokemonCatcher.csproj'), 'utf8');
+    const program = fs.readFileSync(path.join(projectDir, 'Program.cs'), 'utf8');
+
+    expect(csproj).toContain(
+      '<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview.*" />'
+    );
+    expect(csproj).not.toContain('Microsoft.Teams.Plugins.AspNetCore');
+    expect(program).toContain('builder.Services.AddTeamsBotApplication();');
+    expect(program).toContain('TeamsBotApplication teams = app.UseTeamsBotApplication();');
+    expect(program).toContain('await context.TypingAsync(cancellationToken: cancellationToken);');
+    expect(program).toContain('await context.SendAsync');
+    expect(program).not.toContain('builder.AddTeams();');
+    expect(program).not.toContain('app.UseTeams();');
+  });
+});

--- a/teams.md/docs/main/get-started/quickstart-build.md
+++ b/teams.md/docs/main/get-started/quickstart-build.md
@@ -57,19 +57,19 @@ Continue with the [TypeScript guide](/typescript/getting-started) for events, se
 If you scaffolded with `teams project new csharp`, your `Program.cs` already looks like this:
 
 ```csharp
-using Microsoft.Teams.Apps.Activities;
-using Microsoft.Teams.Apps.Extensions;
-using Microsoft.Teams.Plugins.AspNetCore.Extensions;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
 
-var builder = WebApplication.CreateBuilder(args);
-builder.AddTeams();
-var app = builder.Build();
-var teams = app.UseTeams();
+WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.AddTeamsBotApplication();
+WebApplication app = builder.Build();
+
+TeamsBotApplication teams = app.UseTeamsBotApplication();
 
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken);
-    await context.Send($"you said '{context.Activity.Text}'", cancellationToken);
+    await context.TypingAsync(cancellationToken: cancellationToken);
+    await context.SendAsync($"you said '{context.Activity.Text}'", cancellationToken);
 });
 
 app.Run();

--- a/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
@@ -16,19 +16,19 @@ QuoteAgent/
 <!-- app-class-code -->
 
 ```csharp title="Program.cs"
-using Microsoft.Teams.Apps.Activities;
-using Microsoft.Teams.Apps.Extensions;
-using Microsoft.Teams.Plugins.AspNetCore.Extensions;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
 
-var builder = WebApplication.CreateBuilder(args);
-builder.AddTeams();
-var app = builder.Build();
-var teams = app.UseTeams();
+WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.AddTeamsBotApplication();
+WebApplication app = builder.Build();
+
+TeamsBotApplication teams = app.UseTeamsBotApplication();
 
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken: cancellationToken);
-    await context.Send($"you said '{context.Activity.Text}'", cancellationToken);
+    await context.TypingAsync(cancellationToken: cancellationToken);
+    await context.SendAsync($"you said '{context.Activity.Text}'", cancellationToken);
 });
 
 app.Run();
@@ -47,8 +47,8 @@ To test your agent locally without sideloading into Teams, run the **[Microsoft 
 ```csharp title="Program.cs"
 teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing(cancellationToken: cancellationToken);
-    await context.Send($"you said \"{context.Activity.Text}\"", cancellationToken);
+    await context.TypingAsync(cancellationToken: cancellationToken);
+    await context.SendAsync($"you said \"{context.Activity.Text}\"", cancellationToken);
 });
 ```
 
@@ -71,7 +71,7 @@ of routing logic!
 <!-- app-lifecycle-code -->
 
 ```csharp
-var app = builder.Build();
-app.UseTeams();
+WebApplication app = builder.Build();
+app.UseTeamsBotApplication();
 app.Run();
 ```


### PR DESCRIPTION
## Summary
- Update the C# CLI scaffold to reference Microsoft.Teams.Apps 2.1 preview and use the new hosting APIs
- Write generated C# credentials into the AzureAd config shape expected by the 2.1 SDK
- Refresh matching docs snippets and add regression coverage for the scaffold and JSON config writer

## Validation
- npm run test -- --run tests/project-new-csharp.test.ts tests/project-scaffold-csharp-template.test.ts tests/file-ops.test.ts
- npx turbo build --filter=@microsoft/teams.cli
- Generated PokemonCatcher C# scaffold builds with dotnet build
- Smoke-tested PokemonCatcher in Teams through devtunnel host tstester2