### PR TITLE
Fix Azure Windows pipeline and CLI test failures

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -74,14 +74,33 @@ extends:
             version: '8.x'
           target:
             container: host
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+          target:
+            container: host
 
         - powershell: |
-            # Install nbgv
-            dotnet tool install -g nbgv
-            Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
-            nbgv --version
+            $nugetConfig = "$(Agent.TempDirectory)\NuGet.TeamsSDKPreviews.config"
 
-            # Set cloud build number and variables (resolves detached HEAD in ADO)
+            @'
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
+              </packageSources>
+            </configuration>
+            '@ | Set-Content -Path $nugetConfig -Encoding UTF8
+
+            dotnet nuget list source --configfile $nugetConfig
+
+            dotnet tool install -g nbgv --configfile $nugetConfig
+
+            $toolsPath = Join-Path $env:USERPROFILE ".dotnet\tools"
+            $env:PATH = "$toolsPath;$env:PATH"
+            Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
+
+            nbgv --version
             nbgv cloud
           displayName: 'Install nbgv and set cloud build version'
           target:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/cli/src/commands/project/shared.ts
+++ b/packages/cli/src/commands/project/shared.ts
@@ -92,9 +92,9 @@ export function credentialFilePath(
 
 export function credentialDisplayPath(language: ProjectLanguage, projectName: string): string {
   if (language === 'csharp') {
-    return path.join(projectName, projectName, 'appsettings.Development.json');
+    return path.posix.join(projectName, projectName, 'appsettings.Development.json');
   }
-  return path.join(projectName, '.env');
+  return path.posix.join(projectName, '.env');
 }
 
 export function appCreateCommandFor(agentName: string, credentialsPath: string): string {


### PR DESCRIPTION
## Summary
- Ports the Azure pipeline nbgv install fix from microsoft/teams.ts#650.
- Authenticates to Azure Artifacts before installing nbgv from the TeamsSDKPreviews NuGet feed.
- Makes the CLI build script cross-platform by replacing `rm -rf dist` with a Node `fs.rmSync` clean step for Azure Windows agents.
- Normalizes generated `teams app create --env ...` command hints to use stable POSIX separators while keeping actual credential file paths platform-native.

## Validation
- `npm -w @microsoft/teams.cli test -- project-new-bot-provision.test.ts`
- `npx turbo build --filter=@microsoft/teams.cli`
- `npm -w @microsoft/teams.cli test`
- `git diff --check -- packages/cli/src/commands/project/shared.ts packages/cli/package.json .azdo/publish.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".azdo/publish.yml"); puts "yaml ok"'`
- `rg "NuGetAuthenticate|NuGet.TeamsSDKPreviews.config|dotnet tool install -g nbgv --configfile|TeamsSDKPreviews/nuget" .azdo/publish.yml`