### PR TITLE
Port preview pipeline nbgv auth fix

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -74,14 +74,33 @@ extends:
             version: '8.x'
           target:
             container: host
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+          target:
+            container: host
 
         - powershell: |
-            # Install nbgv
-            dotnet tool install -g nbgv
-            Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
-            nbgv --version
+            $nugetConfig = "$(Agent.TempDirectory)\NuGet.TeamsSDKPreviews.config"
 
-            # Set cloud build number and variables (resolves detached HEAD in ADO)
+            @'
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
+              </packageSources>
+            </configuration>
+            '@ | Set-Content -Path $nugetConfig -Encoding UTF8
+
+            dotnet nuget list source --configfile $nugetConfig
+
+            dotnet tool install -g nbgv --configfile $nugetConfig
+
+            $toolsPath = Join-Path $env:USERPROFILE ".dotnet\tools"
+            $env:PATH = "$toolsPath;$env:PATH"
+            Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
+
+            nbgv --version
             nbgv cloud
           displayName: 'Install nbgv and set cloud build version'
           target:


### PR DESCRIPTION
## What

Ports the Azure pipeline `nbgv` install fix from microsoft/teams.ts#650 to the teams-sdk `preview` branch.

The publish pipeline now authenticates to Azure Artifacts for NuGet and installs `nbgv` from the TeamsSDKPreviews feed via a dedicated temporary NuGet.config before running `nbgv cloud`.

## Notes

- Did not port the teams.ts version bump; preview metadata in teams-sdk is unchanged.
- Did not port the teams.ts `examples/mcp-server/turbo.json` fix because this repo does not contain that example pipeline surface.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".azdo/publish.yml")'`
- `rg -n "NuGetAuthenticate|NuGet.TeamsSDKPreviews.config|dotnet tool install -g nbgv --configfile|TeamsSDKPreviews/nuget" .azdo/publish.yml`