### PR TITLE
Fix preview CLI build clean command on Windows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## What

Follow-up to #2921 for the preview pipeline: fixes the Azure Windows build failure in `@microsoft/teams.cli` by replacing the Unix-only `rm -rf dist && tsc` build script with a cross-platform Node `fs.rmSync` clean step before `tsc`.

## Notes

- #2921 was already merged, so this PR contains only the additional CLI package build-script fix against current `preview`.
- Preserves preview package metadata.

## Validation

- `npm ci` (dependency restore after `tsc` was missing locally)
- `npx turbo build --filter=@microsoft/teams.cli --force`
- `git diff --check`
- `git diff --stat origin/preview...HEAD`