### PR TITLE
Fix CLI build script on Windows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- replace the CLI build clean step with a cross-platform Node `fs.rmSync` call
- preserve existing preview package metadata

## Validation
- `git diff --check -- packages/cli/package.json`
- `npx turbo build --filter=@microsoft/teams.cli`