### PR TITLE
Fix preview CLI path hints on Windows

### DIFF
--- a/packages/cli/src/commands/project/shared.ts
+++ b/packages/cli/src/commands/project/shared.ts
@@ -92,9 +92,9 @@ export function credentialFilePath(
 
 export function credentialDisplayPath(language: ProjectLanguage, projectName: string): string {
   if (language === 'csharp') {
-    return path.join(projectName, projectName, 'appsettings.Development.json');
+    return path.posix.join(projectName, projectName, 'appsettings.Development.json');
   }
-  return path.join(projectName, '.env');
+  return path.posix.join(projectName, '.env');
 }
 
 export function appCreateCommandFor(agentName: string, credentialsPath: string): string {


### PR DESCRIPTION
## Summary
- Use POSIX joining for generated credential display paths in project creation command hints
- Keep actual credential file paths platform-native

## Validation
- npm -w @microsoft/teams.cli test -- project-new-bot-provision.test.ts
- npx turbo build --filter=@microsoft/teams.cli
- git diff --check -- packages/cli/src/commands/project/shared.ts