### PR TITLE
docs: add dynamic typeahead search (application/search) guide

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/csharp.incl.md
@@ -345,7 +345,7 @@ var games = new[] { "Super Mario Odyssey", "Metroid Dread", "Splatoon 3" };
 
 teams.OnSearch((context, cancellationToken) =>
 {
-    var query = context.Activity.Value.QueryText?.ToLowerInvariant() ?? "";
+    var query = context.Activity.Value?.QueryText?.ToLowerInvariant() ?? "";
     var results = games
         .Where(g => g.ToLowerInvariant().Contains(query))
         .Select(g => new SearchResult { Title = g, Value = g })
@@ -356,7 +356,7 @@ teams.OnSearch((context, cancellationToken) =>
         Value = new SearchResponseValue { Results = results }
     };
 
-    return Task.FromResult<InvokeResponse>(new InvokeResponse<SearchResponse>(200, response));
+    return Task.FromResult(new InvokeResponse<SearchResponse>(200, response));
 });
 ```
 

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/csharp.incl.md
@@ -295,3 +295,68 @@ teams.OnAdaptiveCardAction(async (context, cancellationToken) =>
 :::note
 The `data` values come from JSON and need to be extracted using the helper method shown above to handle different JSON element types.
 :::
+
+<!-- dynamic-search-card -->
+
+```csharp
+using Microsoft.Teams.Cards;
+
+private static AdaptiveCard CreateDynamicSearchCard()
+{
+    return new AdaptiveCard
+    {
+        Schema = "http://adaptivecards.io/schemas/adaptive-card.json",
+        Body = new List<CardElement>
+        {
+            new ChoiceSetInput
+            {
+                Id = "game",
+                Label = "Game",
+                Placeholder = "Search for a game",
+                Style = ChoiceSetInputStyle.Filtered,
+                Choices = new List<Choice>()
+            }.WithChoicesData(new QueryData { Dataset = "nintendoGames" })
+        },
+        Actions = new List<Microsoft.Teams.Cards.Action>
+        {
+            new ExecuteAction
+            {
+                Title = "Submit",
+                Data = new Union<string, SubmitActionData>(new SubmitActionData
+                {
+                    NonSchemaProperties = new Dictionary<string, object?>
+                    {
+                        { "action", "submit_game" }
+                    }
+                })
+            }
+        }
+    };
+}
+```
+
+<!-- dynamic-search-handler -->
+
+```csharp
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Handlers;
+
+var games = new[] { "Super Mario Odyssey", "Metroid Dread", "Splatoon 3" };
+
+teams.OnSearch((context, cancellationToken) =>
+{
+    var query = context.Activity.Value.QueryText?.ToLowerInvariant() ?? "";
+    var results = games
+        .Where(g => g.ToLowerInvariant().Contains(query))
+        .Select(g => new SearchResult { Title = g, Value = g })
+        .ToList();
+
+    var response = new SearchResponse
+    {
+        Value = new SearchResponseValue { Results = results }
+    };
+
+    return Task.FromResult<InvokeResponse>(new InvokeResponse<SearchResponse>(200, response));
+});
+```
+

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/python.incl.md
@@ -261,7 +261,7 @@ from microsoft_teams.apps import ActivityContext
 GAMES = ["Super Mario Odyssey", "Metroid Dread", "Splatoon 3"]
 
 
-@app.on_search
+@app.on_card_search
 async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchResponse:
     query = (ctx.activity.value.query_text or "").lower()
     results = [

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/python.incl.md
@@ -220,3 +220,53 @@ async def handle_card_action(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -
 :::note
 The `data` values are accessible as a dictionary and can be accessed using `.get()` method for safe access.
 :::
+<!-- dynamic-search-card -->
+
+```python
+from microsoft_teams.cards import AdaptiveCard
+
+card = AdaptiveCard.model_validate(
+    {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [
+            {
+                "type": "Input.ChoiceSet",
+                "id": "game",
+                "label": "Game",
+                "placeholder": "Search for a game",
+                "style": "filtered",
+                "choices": [],
+                "choices.data": {"type": "Data.Query", "dataset": "nintendoGames"},
+            }
+        ],
+        "actions": [
+            {"type": "Action.Execute", "title": "Submit", "data": {"action": "submit_game"}}
+        ],
+    }
+)
+```
+
+<!-- dynamic-search-handler -->
+
+```python
+from microsoft_teams.api import SearchInvokeActivity
+from microsoft_teams.api.models.search import (
+    SearchInvokeResponseValue,
+    SearchInvokeResult,
+    SearchResponse,
+)
+from microsoft_teams.apps import ActivityContext
+
+GAMES = ["Super Mario Odyssey", "Metroid Dread", "Splatoon 3"]
+
+
+@app.on_search
+async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchResponse:
+    query = (ctx.activity.value.query_text or "").lower()
+    results = [
+        SearchInvokeResult(title=g, value=g) for g in GAMES if query in g.lower()
+    ]
+    return SearchResponse(value=SearchInvokeResponseValue(results=results))
+```
+

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/typescript.incl.md
@@ -284,7 +284,7 @@ import { App } from '@microsoft/teams.apps';
 
 const GAMES = ['Super Mario Odyssey', 'Metroid Dread', 'Splatoon 3'];
 
-app.on('search', async ({ activity }) => {
+app.on('card.search', async ({ activity }) => {
   const query = activity.value.queryText?.toLowerCase() ?? '';
   const results = GAMES.filter((g) => g.toLowerCase().includes(query)).map(
     (g) => ({ title: g, value: g })

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/typescript.incl.md
@@ -250,3 +250,51 @@ app.on('card.action', async ({ activity, send }) => {
 :::note
 The `data` values are not typed and come as `any`, so you will need to cast them to the correct type in this case.
 :::
+
+<!-- dynamic-search-card -->
+
+```typescript
+import { IAdaptiveCard } from '@microsoft/teams.cards';
+
+const card: IAdaptiveCard = {
+  type: 'AdaptiveCard',
+  version: '1.5',
+  body: [
+    {
+      type: 'Input.ChoiceSet',
+      id: 'game',
+      label: 'Game',
+      placeholder: 'Search for a game',
+      style: 'filtered',
+      choices: [],
+      'choices.data': { type: 'Data.Query', dataset: 'nintendoGames' },
+    },
+  ],
+  actions: [
+    { type: 'Action.Execute', title: 'Submit', data: { action: 'submit_game' } },
+  ],
+};
+```
+
+<!-- dynamic-search-handler -->
+
+```typescript
+import { App } from '@microsoft/teams.apps';
+// ...
+
+const GAMES = ['Super Mario Odyssey', 'Metroid Dread', 'Splatoon 3'];
+
+app.on('search', async ({ activity }) => {
+  const query = activity.value.queryText?.toLowerCase() ?? '';
+  const results = GAMES.filter((g) => g.toLowerCase().includes(query)).map(
+    (g) => ({ title: g, value: g })
+  );
+
+  return {
+    statusCode: 200,
+    type: 'application/vnd.microsoft.search.searchResponse',
+    value: { results },
+  };
+});
+```
+

--- a/teams.md/src/pages/templates/in-depth-guides/adaptive-cards/executing-actions.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/adaptive-cards/executing-actions.mdx
@@ -64,7 +64,7 @@ Input Controls provide ways for you to validate. More details can be found on th
 
 ## Dynamic Typeahead Search
 
-An `Input.ChoiceSet` can fetch its choices dynamically as the user types, instead of listing them statically. Replace the static `choices` with a `choices.data` `Data.Query` that names a `dataset`. As the user types, Teams sends your bot an `application/search` invoke, and you return the matching results.
+An `Input.ChoiceSet` can fetch its choices dynamically as the user types, instead of listing them statically. Leave `choices` as an empty array and add a `choices.data` `Data.Query` that names a `dataset`. As the user types, Teams sends your bot an `application/search` invoke, and you return the matching results.
 
 <LanguageInclude section="dynamic-search-card" />
 

--- a/teams.md/src/pages/templates/in-depth-guides/adaptive-cards/executing-actions.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/adaptive-cards/executing-actions.mdx
@@ -61,3 +61,15 @@ Input Controls provide ways for you to validate. More details can be found on th
 <LanguageInclude section="input-validation-example" />
 
 <LanguageInclude section="handlers-section" />
+
+## Dynamic Typeahead Search
+
+An `Input.ChoiceSet` can fetch its choices dynamically as the user types, instead of listing them statically. Replace the static `choices` with a `choices.data` `Data.Query` that names a `dataset`. As the user types, Teams sends your bot an `application/search` invoke, and you return the matching results.
+
+<LanguageInclude section="dynamic-search-card" />
+
+Register a handler for the `application/search` invoke to return results as `{ title, value }` pairs, where `title` is the display text and `value` is what gets submitted when the choice is selected:
+
+<LanguageInclude section="dynamic-search-handler" />
+
+The activity value also carries the query options (`skip`/`top` for paging) and the originating `dataset`, so a single handler can branch on the dataset when several `Input.ChoiceSet` inputs share it.


### PR DESCRIPTION
## Summary

Documents Adaptive Card dynamic typeahead search (`application/search`) in the Executing Actions in-depth guide, across all three languages (TypeScript, Python, C#).

## Changes
- New "Dynamic Typeahead Search" section in `executing-actions.mdx` with shared prose.
- Per-language `dynamic-search-card` / `dynamic-search-handler` fragments (code only; shared prose lives in the `.mdx`).
- C# fragments filled in (previously `N/A`).

## Testing
- `npm run build` (Docusaurus) — compiles clean; all three generated language pages render the new section.

Part of microsoft/teams.ts#252
