### PR TITLE
feat(cli): project-aware credential destination for C# apps

### DIFF
--- a/packages/cli/src/commands/app/auth/secret/create.ts
+++ b/packages/cli/src/commands/app/auth/secret/create.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getAccount, getTokenSilent, teamsDevPortalScopes } from '../../../../auth/index.js';
 import { CliError, wrapAction } from '../../../../utils/errors.js';
 import { pickApp } from '../../../../utils/app-picker.js';
+import { isInteractive } from '../../../../utils/interactive.js';
 import { generateSecret } from './generate.js';
 
 interface SecretCreateOptions {
@@ -48,7 +49,7 @@ export const secretCreateCommand = new Command('create')
         tdpToken,
         appId,
         envPath,
-        interactive: !envPath && !options.json,
+        interactive: isInteractive(),
         json: options.json,
       });
     })

--- a/packages/cli/src/commands/app/auth/secret/generate.ts
+++ b/packages/cli/src/commands/app/auth/secret/generate.ts
@@ -1,8 +1,8 @@
-import { input } from '@inquirer/prompts';
 import { createClientSecret, fetchApp, getAadAppByClientId } from '../../../../apps/index.js';
 import { confirmAction } from '../../../../utils/interactive.js';
 import { getAccount, getTokenSilent, graphScopes } from '../../../../auth/index.js';
-import { isJsonFile, outputCredentials, writeEnvFile, writeJsonCredentials } from '../../../../utils/env.js';
+import { outputCredentials, writeCredentials } from '../../../../utils/env.js';
+import { resolveCredentialDestination } from '../../../../utils/credential-destination.js';
 import { CliError } from '../../../../utils/errors.js';
 import { outputJson } from '../../../../utils/json-output.js';
 import { createSilentSpinner } from '../../../../utils/spinner.js';
@@ -41,11 +41,11 @@ export async function generateSecret(opts: GenerateSecretOptions): Promise<void>
   const silent = !!opts.json;
   let envPath = opts.envPath;
 
-  if (envPath === undefined && opts.interactive) {
-    envPath =
-      (await input({
-        message: 'Path to credentials file, e.g. .env or appsettings.json (leave empty to show in terminal):',
-      })) || undefined;
+  if (envPath === undefined) {
+    envPath = await resolveCredentialDestination({
+      interactive: !!opts.interactive,
+      json: opts.json,
+    });
   }
 
   if (!(await confirmAction('Generate a new client secret?', silent))) {
@@ -96,11 +96,7 @@ export async function generateSecret(opts: GenerateSecretOptions): Promise<void>
     };
 
     if (envPath) {
-      if (isJsonFile(envPath)) {
-        writeJsonCredentials(envPath, credentialValues);
-      } else {
-        writeEnvFile(envPath, credentialValues);
-      }
+      writeCredentials(envPath, credentialValues);
     }
 
     const result: SecretGenerateOutput = {

--- a/packages/cli/src/commands/app/create.ts
+++ b/packages/cli/src/commands/app/create.ts
@@ -11,7 +11,8 @@ import {
   type BotLocation,
 } from '../../apps/index.js';
 import { getAccount } from '../../auth/index.js';
-import { isJsonFile, outputCredentials, writeEnvFile, writeJsonCredentials } from '../../utils/env.js';
+import { outputCredentials, writeCredentials } from '../../utils/env.js';
+import { resolveCredentialDestination } from '../../utils/credential-destination.js';
 import { CliError, wrapAction } from '../../utils/errors.js';
 import { readAndValidateIcon } from '../../utils/icon.js';
 import { outputJson } from '../../utils/json-output.js';
@@ -170,16 +171,13 @@ async function prepareAppCreate(
         })) || undefined
       : undefined);
 
-  const shouldPromptForEnvPath =
-    !runOptions.suppressCredentialOutput && interactive && !hasFlags && !options.json;
-  const envPath =
-    (options.envFile ?? options.env) ??
-    (shouldPromptForEnvPath
-      ? (await input({
-          message:
-            'Path to credentials file, e.g. .env or appsettings.json (leave empty to show in terminal):',
-        })) || undefined
-      : undefined);
+  const envPath = runOptions.suppressCredentialOutput
+    ? (options.envFile ?? options.env)
+    : await resolveCredentialDestination({
+        explicit: options.envFile ?? options.env,
+        interactive: interactive && !hasFlags,
+        json: options.json,
+      });
 
   const generateSecret = options.secret !== false;
   let descriptionOpts: { short: string; full?: string } | undefined;
@@ -374,11 +372,7 @@ async function renderAppCreateResult(
 ): Promise<void> {
   if (options.json) {
     if (envPath) {
-      if (isJsonFile(envPath)) {
-        writeJsonCredentials(envPath, result.credentials);
-      } else {
-        writeEnvFile(envPath, result.credentials);
-      }
+      writeCredentials(envPath, result.credentials);
     }
     outputJson(output);
     return;

--- a/packages/cli/src/utils/credential-destination.ts
+++ b/packages/cli/src/utils/credential-destination.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { input, select } from '@inquirer/prompts';
+
+// Sentinels for non-path picker choices. Null-byte-prefixed so they can never
+// collide with a real filesystem path.
+const CUSTOM = '\0custom';
+const TERMINAL = '\0terminal';
+
+// Standard credential destinations for a .NET project, in the order they are
+// offered interactively. appsettings.json is first to match the default fallback.
+const CSHARP_DESTINATIONS = [
+  'appsettings.json',
+  path.join('Properties', 'launchSettings.json'),
+];
+
+function hasCsproj(dir: string): boolean {
+  try {
+    return fs.readdirSync(dir).some((f) => f.toLowerCase().endsWith('.csproj'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect a C# project by locating the directory that contains a `.csproj` file.
+ * Searches the given directory first, then its immediate subdirectories (a
+ * scaffolded project nests the csproj one level below the solution root).
+ * Returns the absolute path to the project directory, or undefined.
+ */
+export function detectCsharpProjectDir(cwd: string = process.cwd()): string | undefined {
+  if (hasCsproj(cwd)) return cwd;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(cwd, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const subDir = path.join(cwd, entry.name);
+    if (hasCsproj(subDir)) return subDir;
+  }
+
+  return undefined;
+}
+
+/**
+ * Prompt the user to choose where credentials should be written for a detected
+ * C# project. Returns an absolute file path, or undefined to show in terminal.
+ */
+export async function promptCredentialDestination(projectDir: string): Promise<string | undefined> {
+  const choices: Array<{ name: string; value: string }> = CSHARP_DESTINATIONS.map((rel) => {
+    const full = path.join(projectDir, rel);
+    return {
+      name: fs.existsSync(full) ? rel : `${rel} (will be created)`,
+      value: full,
+    };
+  });
+  choices.push({ name: 'Enter a custom path…', value: CUSTOM });
+  choices.push({ name: 'Show in terminal', value: TERMINAL });
+
+  const selected = await select({
+    message: 'Where should the credentials be written?',
+    choices,
+  });
+
+  if (selected === TERMINAL) return undefined;
+  if (selected === CUSTOM) {
+    const custom = await input({ message: 'Path to credentials file:' });
+    return custom.trim() || undefined;
+  }
+  return selected;
+}
+
+export interface ResolveCredentialDestinationOptions {
+  /** Explicit path from --env / --env-file. Always wins when provided. */
+  explicit?: string;
+  /** Whether prompting is allowed (interactive TTY, not scripting/JSON). */
+  interactive: boolean;
+  /** Whether the command is running in --json mode. */
+  json?: boolean;
+  /** Directory to inspect for project structure. Defaults to process.cwd(). */
+  cwd?: string;
+}
+
+/**
+ * Resolve where credentials should be written.
+ *
+ * - Explicit --env path always wins.
+ * - Interactive: prompt with C#-aware suggestions, or a free-text path for
+ *   non-C# projects.
+ * - Non-interactive (default flow): fall back to appsettings.json for a
+ *   detected C# project; otherwise undefined (show in terminal / JSON output).
+ * - JSON mode never writes implicitly — only an explicit --env path is honored.
+ */
+export async function resolveCredentialDestination(
+  opts: ResolveCredentialDestinationOptions
+): Promise<string | undefined> {
+  if (opts.explicit) return opts.explicit;
+
+  const cwd = opts.cwd ?? process.cwd();
+  const projectDir = detectCsharpProjectDir(cwd);
+
+  if (opts.interactive && !opts.json) {
+    if (projectDir) {
+      return promptCredentialDestination(projectDir);
+    }
+    const custom = await input({
+      message:
+        'Path to credentials file, e.g. .env or appsettings.json (leave empty to show in terminal):',
+    });
+    return custom.trim() || undefined;
+  }
+
+  if (projectDir && !opts.json) {
+    return path.join(projectDir, 'appsettings.json');
+  }
+
+  return undefined;
+}

--- a/packages/cli/src/utils/env.ts
+++ b/packages/cli/src/utils/env.ts
@@ -77,17 +77,93 @@ export function isJsonFile(filePath: string): boolean {
   return path.extname(filePath).toLowerCase() === '.json';
 }
 
+export function isLaunchSettingsFile(filePath: string): boolean {
+  return path.basename(filePath).toLowerCase() === 'launchsettings.json';
+}
+
+/**
+ * Write credentials into a .NET launchSettings.json file as environment
+ * variables on the first profile. Uses the legacy double-underscore keys
+ * (Teams__ClientId, Teams__ClientSecret, Teams__TenantId) so ASP.NET
+ * configuration binds them to the Teams settings section.
+ */
+export function writeLaunchSettingsCredentials(filePath: string, values: EnvValues): void {
+  const resolvedPath = path.resolve(filePath);
+
+  let json: Record<string, unknown> = {};
+  if (fs.existsSync(resolvedPath)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf-8'));
+    } catch {
+      throw new CliError('VALIDATION_FORMAT', `Invalid JSON in ${filePath}.`, 'Fix the JSON syntax and try again.');
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new CliError(
+        'VALIDATION_FORMAT',
+        `Expected a JSON object in ${filePath}, got ${Array.isArray(parsed) ? 'array' : typeof parsed}.`,
+        'The file must contain a top-level JSON object (e.g. {}).'
+      );
+    }
+    json = parsed as Record<string, unknown>;
+  }
+
+  let profiles = json.profiles as Record<string, unknown> | undefined;
+  if (
+    !profiles ||
+    typeof profiles !== 'object' ||
+    Array.isArray(profiles) ||
+    Object.keys(profiles).length === 0
+  ) {
+    profiles = { http: { commandName: 'Project', environmentVariables: {} } };
+    json.profiles = profiles;
+  }
+
+  const firstKey = Object.keys(profiles)[0]!;
+  let profile = profiles[firstKey];
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    profile = {};
+    profiles[firstKey] = profile;
+  }
+  const profileObj = profile as Record<string, unknown>;
+
+  let envVars = profileObj.environmentVariables;
+  if (!envVars || typeof envVars !== 'object' || Array.isArray(envVars)) {
+    envVars = {};
+    profileObj.environmentVariables = envVars;
+  }
+  const envVarsObj = envVars as Record<string, unknown>;
+
+  envVarsObj['Teams__ClientId'] = values.CLIENT_ID;
+  if (values.CLIENT_SECRET !== undefined) {
+    envVarsObj['Teams__ClientSecret'] = values.CLIENT_SECRET;
+  }
+  envVarsObj['Teams__TenantId'] = values.TENANT_ID;
+
+  fs.writeFileSync(resolvedPath, JSON.stringify(json, null, 2) + '\n');
+}
+
+/**
+ * Write credentials to a file, dispatching on the file type:
+ * launchSettings.json → profile env vars, other .json → Teams section, else .env.
+ */
+export function writeCredentials(filePath: string, values: EnvValues): void {
+  if (isLaunchSettingsFile(filePath)) {
+    writeLaunchSettingsCredentials(filePath, values);
+  } else if (isJsonFile(filePath)) {
+    writeJsonCredentials(filePath, values);
+  } else {
+    writeEnvFile(filePath, values);
+  }
+}
+
 export function outputCredentials(
   envPath: string | undefined,
   values: EnvValues,
   successMessage: string
 ): void {
   if (envPath) {
-    if (isJsonFile(envPath)) {
-      writeJsonCredentials(envPath, values);
-    } else {
-      writeEnvFile(envPath, values);
-    }
+    writeCredentials(envPath, values);
     logger.info(pc.bold(pc.green(`Credentials written to ${envPath}`)));
   } else {
     logger.info(pc.bold(pc.green(`\n${successMessage}`)));

--- a/packages/cli/src/utils/env.ts
+++ b/packages/cli/src/utils/env.ts
@@ -10,6 +10,11 @@ export interface EnvValues {
   TENANT_ID: string;
 }
 
+/** Ensure the parent directory of a file path exists before writing to it. */
+function ensureParentDir(resolvedPath: string): void {
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+}
+
 export function writeEnvFile(filePath: string, values: EnvValues): void {
   const resolvedPath = path.resolve(filePath);
 
@@ -38,6 +43,12 @@ export function writeEnvFile(filePath: string, values: EnvValues): void {
     }
   }
 
+  // Drop a stale secret so --no-secret never leaves an old CLIENT_SECRET behind.
+  if (values.CLIENT_SECRET === undefined && existing.has('CLIENT_SECRET')) {
+    lines.splice(existing.get('CLIENT_SECRET')!, 1);
+  }
+
+  ensureParentDir(resolvedPath);
   fs.writeFileSync(resolvedPath, lines.join('\n').trim() + '\n');
 }
 
@@ -62,7 +73,9 @@ export function writeJsonCredentials(filePath: string, values: EnvValues): void 
     json = parsed as Record<string, unknown>;
   }
 
-  const existing = (json.Teams as Record<string, unknown>) ?? {};
+  const existing = { ...((json.Teams as Record<string, unknown>) ?? {}) };
+  // Drop a stale secret so --no-secret never leaves an old ClientSecret behind.
+  delete existing.ClientSecret;
   json.Teams = {
     ...existing,
     ClientId: values.CLIENT_ID,
@@ -70,6 +83,7 @@ export function writeJsonCredentials(filePath: string, values: EnvValues): void 
     TenantId: values.TENANT_ID,
   };
 
+  ensureParentDir(resolvedPath);
   fs.writeFileSync(resolvedPath, JSON.stringify(json, null, 2) + '\n');
 }
 
@@ -137,9 +151,13 @@ export function writeLaunchSettingsCredentials(filePath: string, values: EnvValu
   envVarsObj['Teams__ClientId'] = values.CLIENT_ID;
   if (values.CLIENT_SECRET !== undefined) {
     envVarsObj['Teams__ClientSecret'] = values.CLIENT_SECRET;
+  } else {
+    // Drop a stale secret so --no-secret never leaves an old ClientSecret behind.
+    delete envVarsObj['Teams__ClientSecret'];
   }
   envVarsObj['Teams__TenantId'] = values.TENANT_ID;
 
+  ensureParentDir(resolvedPath);
   fs.writeFileSync(resolvedPath, JSON.stringify(json, null, 2) + '\n');
 }
 

--- a/packages/cli/tests/credential-destination.test.ts
+++ b/packages/cli/tests/credential-destination.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  detectCsharpProjectDir,
+  resolveCredentialDestination,
+} from '../src/utils/credential-destination.js';
+
+function mkTempDir(): string {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-creddest-')));
+}
+
+// ── detectCsharpProjectDir ───────────────────────────────────────────
+
+describe('detectCsharpProjectDir', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it('detects a .csproj in the given directory', () => {
+    const dir = mkTempDir();
+    dirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'MyApp.csproj'), '<Project />');
+
+    expect(detectCsharpProjectDir(dir)).toBe(dir);
+  });
+
+  it('detects a .csproj nested one level down (solution root)', () => {
+    const root = mkTempDir();
+    dirs.push(root);
+    fs.writeFileSync(path.join(root, 'MyApp.sln'), '');
+    const inner = path.join(root, 'MyApp');
+    fs.mkdirSync(inner);
+    fs.writeFileSync(path.join(inner, 'MyApp.csproj'), '<Project />');
+
+    expect(detectCsharpProjectDir(root)).toBe(inner);
+  });
+
+  it('returns undefined when there is no .csproj', () => {
+    const dir = mkTempDir();
+    dirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+
+    expect(detectCsharpProjectDir(dir)).toBeUndefined();
+  });
+
+  it('ignores node_modules and dot directories when searching subdirs', () => {
+    const dir = mkTempDir();
+    dirs.push(dir);
+    const nm = path.join(dir, 'node_modules', 'pkg');
+    fs.mkdirSync(nm, { recursive: true });
+    fs.writeFileSync(path.join(nm, 'Hidden.csproj'), '<Project />');
+    const hidden = path.join(dir, '.hidden');
+    fs.mkdirSync(hidden);
+    fs.writeFileSync(path.join(hidden, 'Hidden.csproj'), '<Project />');
+
+    expect(detectCsharpProjectDir(dir)).toBeUndefined();
+  });
+});
+
+// ── resolveCredentialDestination (non-interactive paths) ─────────────
+
+describe('resolveCredentialDestination', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it('returns the explicit path when provided (wins over everything)', async () => {
+    const result = await resolveCredentialDestination({
+      explicit: 'custom/.env',
+      interactive: true,
+      cwd: process.cwd(),
+    });
+    expect(result).toBe('custom/.env');
+  });
+
+  it('falls back to appsettings.json for a C# project in the default flow', async () => {
+    const dir = mkTempDir();
+    dirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'MyApp.csproj'), '<Project />');
+
+    const result = await resolveCredentialDestination({
+      interactive: false,
+      json: false,
+      cwd: dir,
+    });
+    expect(result).toBe(path.join(dir, 'appsettings.json'));
+  });
+
+  it('falls back to appsettings.json in the nested project dir', async () => {
+    const root = mkTempDir();
+    dirs.push(root);
+    const inner = path.join(root, 'MyApp');
+    fs.mkdirSync(inner);
+    fs.writeFileSync(path.join(inner, 'MyApp.csproj'), '<Project />');
+
+    const result = await resolveCredentialDestination({
+      interactive: false,
+      json: false,
+      cwd: root,
+    });
+    expect(result).toBe(path.join(inner, 'appsettings.json'));
+  });
+
+  it('returns undefined for a C# project in JSON mode (no implicit write)', async () => {
+    const dir = mkTempDir();
+    dirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'MyApp.csproj'), '<Project />');
+
+    const result = await resolveCredentialDestination({
+      interactive: false,
+      json: true,
+      cwd: dir,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined (terminal) for a non-C# project in the default flow', async () => {
+    const dir = mkTempDir();
+    dirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+
+    const result = await resolveCredentialDestination({
+      interactive: false,
+      json: false,
+      cwd: dir,
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/env-credentials.test.ts
+++ b/packages/cli/tests/env-credentials.test.ts
@@ -63,6 +63,19 @@ describe('writeEnvFile', () => {
     expect(content).not.toContain('CLIENT_ID=old-value');
     expect(content).toContain('OTHER=keep');
   });
+
+  it('removes an existing CLIENT_SECRET when the secret is undefined', () => {
+    const filePath = tmpFile('.env');
+    files.push(filePath);
+    fs.writeFileSync(filePath, 'CLIENT_ID=old-id\nCLIENT_SECRET=stale-secret\nTENANT_ID=old-tenant\n');
+
+    writeEnvFile(filePath, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' });
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('CLIENT_ID=id-123');
+    expect(content).toContain('TENANT_ID=tenant-456');
+    expect(content).not.toContain('CLIENT_SECRET');
+  });
 });
 
 // ── writeJsonCredentials ─────────────────────────────────────────────
@@ -135,6 +148,27 @@ describe('writeJsonCredentials', () => {
     expect(json.Teams.ClientId).toBe('test-client-id');
     expect(json.Teams.ClientSecret).toBe('test-client-secret');
     expect(json.Teams.TenantId).toBe('test-tenant-id');
+  });
+
+  it('removes an existing ClientSecret when the secret is undefined', () => {
+    const filePath = tmpFile('appsettings.json');
+    files.push(filePath);
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        { Teams: { AppId: 'keep-me', ClientId: 'old-id', ClientSecret: 'stale-secret', TenantId: 'old-tenant' } },
+        null,
+        2
+      )
+    );
+
+    writeJsonCredentials(filePath, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' });
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(json.Teams.AppId).toBe('keep-me');
+    expect(json.Teams.ClientId).toBe('id-123');
+    expect(json.Teams.TenantId).toBe('tenant-456');
+    expect(json.Teams).not.toHaveProperty('ClientSecret');
   });
 });
 

--- a/packages/cli/tests/launch-settings-credentials.test.ts
+++ b/packages/cli/tests/launch-settings-credentials.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  writeLaunchSettingsCredentials,
+  writeCredentials,
+  isLaunchSettingsFile,
+  type EnvValues,
+} from '../src/utils/env.js';
+
+const TEST_VALUES: EnvValues = {
+  CLIENT_ID: 'test-client-id',
+  CLIENT_SECRET: 'test-client-secret',
+  TENANT_ID: 'test-tenant-id',
+};
+
+const tmpDirs: string[] = [];
+
+/** Create a file with an exact basename inside a fresh temp dir. */
+function tmpFile(name: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-launch-'));
+  tmpDirs.push(dir);
+  return path.join(dir, name);
+}
+
+afterEach(() => {
+  for (const d of tmpDirs) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+// ── isLaunchSettingsFile ─────────────────────────────────────────────
+
+describe('isLaunchSettingsFile', () => {
+  it('matches launchSettings.json regardless of case or directory', () => {
+    expect(isLaunchSettingsFile('Properties/launchSettings.json')).toBe(true);
+    expect(isLaunchSettingsFile('launchsettings.json')).toBe(true);
+    expect(isLaunchSettingsFile(path.join('a', 'b', 'LaunchSettings.JSON'))).toBe(true);
+  });
+
+  it('does not match appsettings.json or .env', () => {
+    expect(isLaunchSettingsFile('appsettings.json')).toBe(false);
+    expect(isLaunchSettingsFile('.env')).toBe(false);
+  });
+});
+
+// ── writeLaunchSettingsCredentials ───────────────────────────────────
+
+describe('writeLaunchSettingsCredentials', () => {
+  const files: string[] = [];
+
+  afterEach(() => {
+    for (const f of files) {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    }
+    files.length = 0;
+  });
+
+  it('writes Teams__ env vars into the first profile, preserving existing vars', () => {
+    const filePath = tmpFile('launchSettings.json');
+    files.push(filePath);
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        profiles: {
+          http: {
+            commandName: 'Project',
+            applicationUrl: 'http://localhost:3978',
+            environmentVariables: { ASPNETCORE_ENVIRONMENT: 'Development' },
+          },
+        },
+      })
+    );
+
+    writeLaunchSettingsCredentials(filePath, TEST_VALUES);
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const env = json.profiles.http.environmentVariables;
+    expect(env.ASPNETCORE_ENVIRONMENT).toBe('Development');
+    expect(env.Teams__ClientId).toBe('test-client-id');
+    expect(env.Teams__ClientSecret).toBe('test-client-secret');
+    expect(env.Teams__TenantId).toBe('test-tenant-id');
+    // profile shape preserved
+    expect(json.profiles.http.commandName).toBe('Project');
+    expect(json.profiles.http.applicationUrl).toBe('http://localhost:3978');
+  });
+
+  it('writes only into the first profile, leaving other profiles untouched', () => {
+    const filePath = tmpFile('launchSettings.json');
+    files.push(filePath);
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        profiles: {
+          http: { commandName: 'Project', environmentVariables: {} },
+          https: { commandName: 'Project', environmentVariables: {} },
+        },
+      })
+    );
+
+    writeLaunchSettingsCredentials(filePath, TEST_VALUES);
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(json.profiles.http.environmentVariables.Teams__ClientId).toBe('test-client-id');
+    expect(json.profiles.https.environmentVariables).not.toHaveProperty('Teams__ClientId');
+  });
+
+  it('omits Teams__ClientSecret when the secret is undefined', () => {
+    const filePath = tmpFile('launchSettings.json');
+    files.push(filePath);
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ profiles: { http: { environmentVariables: {} } } })
+    );
+
+    writeLaunchSettingsCredentials(filePath, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' });
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const env = json.profiles.http.environmentVariables;
+    expect(env.Teams__ClientId).toBe('id-123');
+    expect(env.Teams__TenantId).toBe('tenant-456');
+    expect(env).not.toHaveProperty('Teams__ClientSecret');
+  });
+
+  it('creates a minimal launchSettings.json when the file does not exist', () => {
+    const filePath = tmpFile('launchSettings.json');
+    files.push(filePath);
+
+    writeLaunchSettingsCredentials(filePath, TEST_VALUES);
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const firstProfile = json.profiles[Object.keys(json.profiles)[0]];
+    expect(firstProfile.environmentVariables.Teams__ClientId).toBe('test-client-id');
+    expect(firstProfile.environmentVariables.Teams__ClientSecret).toBe('test-client-secret');
+    expect(firstProfile.environmentVariables.Teams__TenantId).toBe('test-tenant-id');
+  });
+});
+
+// ── writeCredentials (dispatch) ──────────────────────────────────────
+
+describe('writeCredentials dispatch', () => {
+  const files: string[] = [];
+
+  afterEach(() => {
+    for (const f of files) {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    }
+    files.length = 0;
+  });
+
+  it('routes launchSettings.json to profile env vars, not a root Teams section', () => {
+    const filePath = tmpFile('launchSettings.json');
+    files.push(filePath);
+    fs.writeFileSync(filePath, JSON.stringify({ profiles: { http: { environmentVariables: {} } } }));
+
+    writeCredentials(filePath, TEST_VALUES);
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(json).not.toHaveProperty('Teams');
+    expect(json.profiles.http.environmentVariables.Teams__ClientId).toBe('test-client-id');
+  });
+
+  it('routes other .json files to the Teams section', () => {
+    const filePath = tmpFile('appsettings.json');
+    files.push(filePath);
+
+    writeCredentials(filePath, TEST_VALUES);
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(json.Teams).toEqual({
+      ClientId: 'test-client-id',
+      ClientSecret: 'test-client-secret',
+      TenantId: 'test-tenant-id',
+    });
+  });
+
+  it('routes non-JSON files to .env format', () => {
+    const filePath = tmpFile('.env');
+    files.push(filePath);
+
+    writeCredentials(filePath, TEST_VALUES);
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('CLIENT_ID=test-client-id');
+    expect(content).toContain('CLIENT_SECRET=test-client-secret');
+    expect(content).toContain('TENANT_ID=test-tenant-id');
+  });
+});

--- a/packages/cli/tests/launch-settings-credentials.test.ts
+++ b/packages/cli/tests/launch-settings-credentials.test.ts
@@ -136,6 +136,46 @@ describe('writeLaunchSettingsCredentials', () => {
     expect(firstProfile.environmentVariables.Teams__ClientSecret).toBe('test-client-secret');
     expect(firstProfile.environmentVariables.Teams__TenantId).toBe('test-tenant-id');
   });
+
+  it('creates the parent directory when it does not exist', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-launch-'));
+    tmpDirs.push(dir);
+    // Properties/ does not exist yet — the picker advertises "(will be created)".
+    const filePath = path.join(dir, 'Properties', 'launchSettings.json');
+
+    writeLaunchSettingsCredentials(filePath, TEST_VALUES);
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const firstProfile = json.profiles[Object.keys(json.profiles)[0]];
+    expect(firstProfile.environmentVariables.Teams__ClientId).toBe('test-client-id');
+  });
+
+  it('removes an existing Teams__ClientSecret when the secret is undefined', () => {
+    const filePath = tmpFile('launchSettings.json');
+    files.push(filePath);
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        profiles: {
+          http: {
+            environmentVariables: {
+              Teams__ClientId: 'old-id',
+              Teams__ClientSecret: 'stale-secret',
+              Teams__TenantId: 'old-tenant',
+            },
+          },
+        },
+      })
+    );
+
+    writeLaunchSettingsCredentials(filePath, { CLIENT_ID: 'id-123', TENANT_ID: 'tenant-456' });
+
+    const json = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const env = json.profiles.http.environmentVariables;
+    expect(env.Teams__ClientId).toBe('id-123');
+    expect(env.Teams__TenantId).toBe('tenant-456');
+    expect(env).not.toHaveProperty('Teams__ClientSecret');
+  });
 });
 
 // ── writeCredentials (dispatch) ──────────────────────────────────────


### PR DESCRIPTION
## What

When creating an app or generating a client secret, the CLI now decides **where** to write the credentials instead of always defaulting to `.env`/`appsettings.json`. This matters for C# projects, where credentials can live in different files.

Affected commands: `teams app create`, `teams app auth secret create`.

## Behavior

**Choosing the destination**
- **Interactive + C# project detected** (a `.csproj` in the cwd or one level down) → prompts with suggestions:
  - `appsettings.json`
  - `Properties/launchSettings.json`
  - Enter a custom path
  - Show in terminal
- **Interactive + non-C#** → free-text path prompt (empty = show in terminal). *(unchanged)*
- **Non-interactive / scripting** (`--name`, piped stdin, `TEAMS_NO_INTERACTIVE`) → falls back to `appsettings.json` for a detected C# project; otherwise prints to the terminal.
- **`--env` / `--env-file`** → explicit path always wins, no prompt.
- **`--json`** → never writes implicitly; only an explicit `--env` writes a file.

**How each destination is written** (legacy `Teams` config shape, works with the current teams.net runtime):
- `appsettings*.json` → `"Teams": { ClientId, ClientSecret, TenantId }`
- `Properties/launchSettings.json` → `Teams__ClientId` / `Teams__ClientSecret` / `Teams__TenantId` env vars on the **first** profile (other profiles and existing vars preserved)
- anything else (`.env`) → `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID`

`ClientSecret` is omitted when no secret is generated (e.g. `--no-secret`). Existing files are merged, not clobbered; invalid JSON fails cleanly with no partial write.

## Testing

- **New unit tests** – file writers (`.env`, Teams section, `launchSettings.json`), C# project detection, and non-interactive destination resolution.
- **Automated E2E** against the compiled build covering every non-interactive path: destination resolution, format dispatch, and merge / preserve / create / edge cases (29 checks, all passing).
- **CLI smoke** – `--help` for both commands; non-interactive `app auth secret` prints help.
- **Full suite** – 237 passed / 34 skipped; `tsc --noEmit` clean.
- **Interactive picker flows** (C# suggestions, non-C# free-text) — validated manually.

Out of scope: the `project new csharp` scaffold is unchanged, and migrating off the legacy `Teams` config shape is deferred until the runtime readers support the newer `AzureAd`/`ClientCredentials` format.

## DEMO

<img width="836" height="636" alt="20260731-1552-46 5797958" src="https://github.com/user-attachments/assets/1d2aed42-84ad-40c1-bec0-a3ed01fd8e01" />

