### PR TITLE
docs: correct Microsoft.Teams.Cards status in 2.1 preview blog post

### DIFF
--- a/teams.md/blog/2026-05-19-announcing-teams-sdk-dotnet-2-1-preview/index.md
+++ b/teams.md/blog/2026-05-19-announcing-teams-sdk-dotnet-2-1-preview/index.md
@@ -280,11 +280,12 @@ The 2.1 preview consolidates into three packages. The following 2.0 packages hav
 | Removed package | Alternative |
 |---|---|
 | `Microsoft.Teams.AI` / `Microsoft.Teams.AI.Models.OpenAI` | `Microsoft.Extensions.AI`|
-| `Microsoft.Teams.Cards` | Use `TeamsActivityBuilder` with `AddAdaptiveCardAttachment()` |
 | `Microsoft.Teams.Extensions.Graph` | `Microsoft.Graph` |
 | `Microsoft.Teams.Apps.Testing` | Use standard .NET DI mocking |
 | `Microsoft.Teams.Common` (logging, HTTP) | Use `Microsoft.Extensions.Logging` and `HttpClient` via DI |
 | `Microsoft.Teams.Plugins.*` | Plugin architecture removed — use standard ASP.NET Core middleware and DI |
+
+`Microsoft.Teams.Cards` is still published and works with the 2.1 preview — keep using it to author Adaptive Cards. The only change is how you attach a card: `Send(AdaptiveCard)` and `Reply(AdaptiveCard)` overloads aren't available yet, so use `TeamsActivityBuilder` with `AddAdaptiveCardAttachment()` instead.
 
 For the full list of API changes, see the [Migration Guide](https://github.com/microsoft/teams.net/blob/main/core/docs/MigrationGuide.md).
 


### PR DESCRIPTION
## Summary

The [.NET 2.1 preview announcement](https://microsoft.github.io/teams-sdk/blog/announcing-teams-sdk-dotnet-2-1-preview/#migration-from-teams-sdk-20) lists `Microsoft.Teams.Cards` under **Packages no longer available**, but that package has not been removed - it is still built and packed in microsoft/teams.net (`Libraries/Microsoft.Teams.Cards`, no `IsPackable=false`, unlike `Microsoft.Teams.AI`, `Microsoft.Teams.AI.Models.OpenAI`, and `Microsoft.Teams.Plugins.AspNetCore.DevTools`).

What is actually missing is only the `Send(AdaptiveCard)` / `Reply(AdaptiveCard)` convenience overloads, which are intentionally deferred to avoid a core dependency on `Microsoft.Teams.Cards`.

## Changes

- Removed the `Microsoft.Teams.Cards` row from the removed-package table.
- Added a note clarifying that `Microsoft.Teams.Cards` still works with the 2.1 preview, and that cards should be attached via `TeamsActivityBuilder` + `AddAdaptiveCardAttachment()`.

## Follow-up

`core/docs/MigrationGuide.md` in microsoft/teams.net has the same inaccuracy (`| Microsoft.Teams.Cards | Not available |`) and should be corrected separately.