### PR TITLE
docs: polish Teams SDK .NET 2.1 guidance

### DIFF
--- a/teams.md/src/components/include/essentials/app-authentication/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/app-authentication/csharp.incl.md
@@ -18,19 +18,19 @@ TENANT_ID=your-tenant-id
 </TabItem>
 <TabItem value="core" label="SDK 2.1 (current)" default>
 
-Set the following environment variables in your application:
+Configure the following settings in `appsettings.json`:
 
-```json title="Properties/launchSettings.json"
+```json title="appsettings.json"
 {
-  "profiles": {
-    "MyBot": {
-      "environmentVariables": {
-        "AzureAd__ClientId": "your-client-id-here",
-        "AzureAd__TenantId": "your-tenant-id",
-        "AzureAd__ClientCredentials__0__SourceType": "ClientSecret",
-        "AzureAd__ClientCredentials__0__ClientSecret": "your-client-secret-here"
+  "AzureAd": {
+    "ClientId": "your-client-id-here",
+    "TenantId": "your-tenant-id",
+    "ClientCredentials": [
+      {
+        "SourceType": "ClientSecret",
+        "ClientSecret": "your-client-secret-here"
       }
-    }
+    ]
   }
 }
 ```
@@ -91,19 +91,15 @@ Set the following environment variables:
 </TabItem>
 <TabItem value="core" label="SDK 2.1 (current)" default>
 
-Your application should automatically use User Assigned Managed Identity authentication when you provide the `ClientId` environment variable without a `ClientSecret`.
+Your application should automatically use User Assigned Managed Identity authentication when you provide the `ClientId` without a `ClientSecret`.
 
-Set the following environment variables in your application:
+Configure the following settings in `appsettings.json`:
 
-```json title="Properties/launchSettings.json"
+```json title="appsettings.json"
 {
-  "profiles": {
-    "MyBot": {
-      "environmentVariables": {
-        "AzureAd__ClientId": "your-client-id-here",
-        "AzureAd__TenantId": "your-tenant-id"
-      }
-    }
+  "AzureAd": {
+    "ClientId": "your-client-id-here",
+    "TenantId": "your-tenant-id"
   }
 }
 ```
@@ -168,33 +164,33 @@ Set the following environment variables:
 </TabItem>
 <TabItem value="core" label="SDK 2.1 (current)" default>
 
-Depending on the type of managed identity you select, set the environment variables accordingly.
+Depending on the type of managed identity you select, configure the corresponding settings in `appsettings.json`.
 
-```json title="Properties/launchSettings.json"
+```json title="appsettings.json"
 {
-  "profiles": {
-    "MyBot": {
-      "environmentVariables": {
-        "AzureAd__ClientId": "your-app-client-id-here",
-        "AzureAd__TenantId": "your-tenant-id",
-        "AzureAd__ClientCredentials__0__SourceType": "SignedAssertionFromManagedIdentity",
-        "AzureAd__ClientCredentials__0__ManagedIdentityClientId": "your-managed-identity-client-id-here"
+  "AzureAd": {
+    "ClientId": "your-app-client-id-here",
+    "TenantId": "your-tenant-id",
+    "ClientCredentials": [
+      {
+        "SourceType": "SignedAssertionFromManagedIdentity",
+        "ManagedIdentityClientId": "your-managed-identity-client-id-here"
       }
-    }
+    ]
   }
 }
 ```
 
-For system-assigned identity, set:
+For system-assigned identity, omit `ManagedIdentityClientId`:
 
-```json title="Properties/launchSettings.json"
+```json title="appsettings.json"
 {
-  "profiles": {
-    "MyBot": {
-      "environmentVariables": {
-        "AzureAd__ClientId": "your-app-client-id-here",
-        "AzureAd__TenantId": "your-tenant-id",
-        "AzureAd__ClientCredentials__0__SourceType": "SignedAssertionFromManagedIdentity"
+  "AzureAd": {
+    "ClientId": "your-app-client-id-here",
+    "TenantId": "your-tenant-id",
+    "ClientCredentials": [
+      {
+        "SourceType": "SignedAssertionFromManagedIdentity"
       }
     }
   }

--- a/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
@@ -69,7 +69,30 @@ teams.OnMessage(async (context, cancellationToken) =>
 </Tabs>
 
 <!-- activity-handlers-next -->
-N/A
+
+In SDK 2.1, activity handlers no longer form a next()-style processing chain. Instead, every handler that matches an activity is invoked in the order it was registered, and one handler cannot prevent subsequent matching handlers from running. If you need to intercept, short-circuit, or wrap request processing (for example, to stop execution when a condition is met), implement `ITurnMiddleware` and control whether to call `nextTurn(...)`. See [turn middleware](../middleware-and-errors) for details.
+
+:::note[SDK 2.0 (Legacy)]
+In SDK 2.0, activity handlers are chained. Call `context.Next()` to continue to the next matching handler; return without it to stop the chain. Registration order determines handler execution order.
+
+```csharp
+app.OnMessage(async (context, cancellationToken) =>
+{
+    if (context.Activity.Text == "/help")
+    {
+        await context.Send("Here are all the ways I can help you...", cancellationToken);
+        return; // stop chain
+    }
+
+    await context.Next(); // continue chain
+});
+
+app.OnMessage(async (context, cancellationToken) =>
+{
+    await context.Send($"Hello! you said {context.Activity.Text}", cancellationToken);
+});
+```
+:::
 
 <!-- activity-reference-footer -->
 

--- a/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/csharp.incl.md
@@ -107,6 +107,7 @@ The playground opens at [http://localhost:56150](http://localhost:56150). Send a
 ```sh
 dotnet add package Microsoft.Teams.Apps
 ```
+// Then register the Teams services on your existing app.
 
 <!-- manual-code -->
 
@@ -114,10 +115,7 @@ dotnet add package Microsoft.Teams.Apps
 using Microsoft.Teams.Apps;
 
 var builder = WebApplication.CreateBuilder(args);
-
-// Register the Teams services on your existing app
 builder.Services.AddTeamsBotApplication();
-
 var app = builder.Build();
 
 // Maps POST /api/messages onto your existing ASP.NET Core app
@@ -130,7 +128,7 @@ teams.OnMessage(async (context, cancellationToken) =>
 
 app.Run();
 ```
-
+`app.UseTeamsBotApplication()` registers the Teams endpoint onto your existing ASP.NET Core app. 
 <!-- manual-more -->
 
 N/A

--- a/teams.md/src/components/include/getting-started/quickstart/python.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/python.incl.md
@@ -85,6 +85,7 @@ The playground opens at [http://localhost:56150](http://localhost:56150). Send a
 ```sh
 pip install microsoft-teams-apps
 ```
+Then initialize the Teams app with your existing server:
 
 <!-- manual-code -->
 
@@ -119,6 +120,7 @@ async def main():
 
 asyncio.run(main())
 ```
+`app.initialize()` registers the Teams endpoint on your server without starting a new one — you keep full control of your server lifecycle.
 
 <!-- manual-more -->
 

--- a/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/getting-started/quickstart/typescript.incl.md
@@ -80,6 +80,7 @@ The playground opens at [http://localhost:56150](http://localhost:56150). Send a
 ```sh
 npm i @microsoft/teams.apps
 ```
+Then initialize the Teams app with your existing server:
 
 <!-- manual-code -->
 
@@ -109,6 +110,7 @@ await app.initialize();
 // Start your server as usual
 server.listen(3978);
 ```
+`app.initialize()` registers the Teams endpoint on your server without starting a new one — you keep full control of your server lifecycle.
 
 <!-- manual-more -->
 

--- a/teams.md/src/pages/templates/essentials/app-authentication/README.mdx
+++ b/teams.md/src/pages/templates/essentials/app-authentication/README.mdx
@@ -41,7 +41,7 @@ The Teams SDK automatically detects which authentication method to use based on 
 <Language language="csharp">
 
 :::info[SDK 2.1]
-SDK 2.1 uses the Microsoft Authentication Library (MSAL) through standard ASP.NET Core configuration. That is why the C# configuration uses `AzureAd` and `AzureAd__*` environment variables instead of the SDK 2.0 `CLIENT_*` settings. The same configuration shape supports client secrets, managed identities, and federated identity credentials.
+With SDK 2.1, developers can authenticate their bot with any supported Microsoft Entra authentication solution. Configure the credential in the `AzureAd` section of `appsettings.json` using the [`Microsoft.Identity.Web` credential format](https://learn.microsoft.com/en-us/entra/msidweb/authentication/credentials-overview#configure-credentials-in-appsettingsjson). This supports client secrets, managed identities, and federated identity credentials.
 :::
 
 </Language>

--- a/teams.md/src/pages/templates/essentials/app-authentication/README.mdx
+++ b/teams.md/src/pages/templates/essentials/app-authentication/README.mdx
@@ -41,7 +41,7 @@ The Teams SDK automatically detects which authentication method to use based on 
 <Language language="csharp">
 
 :::info[SDK 2.1]
-With SDK 2.1, developers can authenticate their bot with any supported Microsoft Entra authentication solution. Configure the credential in the `AzureAd` section of `appsettings.json` using the [`Microsoft.Identity.Web` credential format](https://learn.microsoft.com/en-us/entra/msidweb/authentication/credentials-overview#configure-credentials-in-appsettingsjson). This supports client secrets, managed identities, and federated identity credentials.
+SDK 2.1 uses MSAL with standard ASP.NET Core configuration. Developers can authenticate their bot with any supported Microsoft Entra authentication solution by configuring the app according to the [`Microsoft.Identity.Web` credential format](https://learn.microsoft.com/en-us/entra/msidweb/authentication/credentials-overview#configure-credentials-in-appsettingsjson).
 :::
 
 </Language>

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -75,33 +75,4 @@ Slash commands arrive as normal message activities with the targeted flag set on
 
 <LanguageInclude section="activity-handlers-next" />
 
-<Language language="csharp">
-
-In SDK 2.1, activity handlers are **not** a `next()`-style chain — all matching handlers run in their registration order, and one handler does not stop the others from running. To short-circuit or wrap the pipeline (for example to stop processing on a condition), use turn middleware (`ITurnMiddleware`) and control flow by whether you `await nextTurn(...)`.
-
-
-:::note[SDK 2.0 (Legacy)]
-In SDK 2.0, activity handlers are chained. Call `context.Next()` to continue to the next matching handler; return without it to stop the chain. Registration order determines handler execution order.
-
-```csharp
-app.OnMessage(async (context, cancellationToken) =>
-{
-    if (context.Activity.Text == "/help")
-    {
-        await context.Send("Here are all the ways I can help you...", cancellationToken);
-        return; // stop chain
-    }
-
-    await context.Next(); // continue chain
-});
-
-app.OnMessage(async (context, cancellationToken) =>
-{
-    await context.Send($"Hello! you said {context.Activity.Text}", cancellationToken);
-});
-```
-:::
-
-</Language>
-
 <LanguageInclude section="activity-reference-footer" />

--- a/teams.md/src/pages/templates/getting-started/quickstart.mdx
+++ b/teams.md/src/pages/templates/getting-started/quickstart.mdx
@@ -60,11 +60,7 @@ If you already have a project and want to add Teams support, install the SDK dir
 
 <LanguageInclude section="manual-install" />
 
-Then initialize the Teams app with your existing server:
-
 <LanguageInclude section="manual-code" />
-
-`app.initialize()` registers the Teams endpoint on your server without starting a new one — you keep full control of your server lifecycle.
 
 <LanguageInclude section="manual-more" />
 

--- a/teams.md/src/pages/templates/migrations/v2-dotnet.mdx
+++ b/teams.md/src/pages/templates/migrations/v2-dotnet.mdx
@@ -303,7 +303,7 @@ graphAuth.OnSignInFailure(async (context, failure, cancellationToken) =>
 
 SDK 2.1 state is cleaner: call `options.UseState()` and use `context.State.ConversationState` / `context.State.UserState` in handlers.
 
-It is also easy to scale. `UseState()` uses the standard ASP.NET Core `IDistributedCache` abstraction under the hood with an in-memory default for local development, and you can move to shared state by registering a distributed cache provider such as Redis without changing your handler state logic.
+It is also easy to scale. `UseState()` uses the standard ASP.NET Core `IDistributedCache` abstraction under the hood with an in-memory default for local development, and you can move to shared state by registering a distributed cache provider (for example Redis) without changing your handler state logic.
 
 <Tabs groupId="dotnet-state-migration" defaultValue="current">
 <TabItem value="legacy" label="SDK 2.0 (Legacy)">
@@ -609,7 +609,7 @@ using Microsoft.Teams.Apps;
 using Microsoft.Teams.Core;
 using Microsoft.Teams.Core.Schema;
 
-internal sealed class MyMiddleware : ITurnMiddleware
+internal sealed class LoggingMiddleware : ITurnMiddleware
 {
     public async Task OnTurnAsync(
         BotApplication botApplication,
@@ -617,12 +617,12 @@ internal sealed class MyMiddleware : ITurnMiddleware
         NextTurn nextTurn,
         CancellationToken cancellationToken = default)
     {
-        ....
+        Console.WriteLine($"Processing activity: {activity}");
         await nextTurn(cancellationToken);
     }
 }
 
-teams.UseMiddleware(new MyMiddleware());
+teams.UseMiddleware(new LoggingMiddleware());
 ```
 
 ## 12. Update local dev auth behavior


### PR DESCRIPTION
## Summary
- clarify Microsoft Entra authentication configuration for SDK 2.1
- direct developers to the Microsoft.Identity.Web credential format
- use appsettings.json as the documented configuration format

## Validation
- Documentation build passes