### PR TITLE
fix(cli): use stable Microsoft.Teams.Apps 2.1.0

### DIFF
--- a/packages/cli/templates/csharp/echo/{{name}}.hbs/{{name}}.csproj.hbs
+++ b/packages/cli/templates/csharp/echo/{{name}}.hbs/{{name}}.csproj.hbs
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview.*" />
+    <PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/packages/cli/tests/project-scaffold-csharp-template.test.ts
+++ b/packages/cli/tests/project-scaffold-csharp-template.test.ts
@@ -15,7 +15,7 @@ describe('C# scaffold template', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('uses the .NET 2.1 preview package and hosting API', async () => {
+  it('uses the stable .NET 2.1 package and hosting API', async () => {
     await scaffoldProject({
       name: 'PokemonCatcher',
       language: 'csharp',
@@ -28,7 +28,7 @@ describe('C# scaffold template', () => {
     const program = fs.readFileSync(path.join(projectDir, 'Program.cs'), 'utf8');
 
     expect(csproj).toContain(
-      '<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview.*" />'
+      '<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0" />'
     );
     expect(csproj).not.toContain('Microsoft.Teams.Plugins.AspNetCore');
     expect(program).toContain('builder.Services.AddTeamsBotApplication();');


### PR DESCRIPTION
## Summary
- update the C# echo template to reference stable `Microsoft.Teams.Apps` 2.1.0
- update scaffold coverage to assert the stable package version

## Testing
- `npx turbo build --filter=@microsoft/teams.cli`
- `npm -w @microsoft/teams.cli test -- --run tests/project-scaffold-csharp-template.test.ts`
- scaffolded the C# echo template through the compiled CLI and built it with .NET 10
- sent an echo message end-to-end through Microsoft 365 Agents Playground

## Test suite note
`npm -w @microsoft/teams.cli test` passed 240 tests; unrelated `web-app-info-update.test.ts` subprocess assertions crash on this Windows environment with exit code `0xC0000409`.