### PR TITLE
Docs: Add file receive (personal scope) docs

### DIFF
--- a/teams.md/scripts/generate-language-docs.ts
+++ b/teams.md/scripts/generate-language-docs.ts
@@ -163,7 +163,8 @@ function processLanguageIncludeTags(
               }
             }
           }
-          return languageComponents.join('\n');
+          // Inline variants must be joined without a separator: a newline between them survives as whitespace once the non-matching languages render nothing, producing a stray space before any following punctuation.
+          return languageComponents.join(isBlock ? '\n' : '');
         } catch (error) {
           console.warn(`generate-language-docs warning: Error parsing inline content: ${error}`);
           return match; // Return original tag on error

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
@@ -83,9 +83,9 @@ while ((read = await stream.ReadAsync(buffer, cancellationToken)) > 0)
 | `Scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
 | `Source` | Where the SDK found the file. Currently always `botActivity`. |
 | `WebUrl` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |
-| `Raw` | The original wire attachment (the metadata object, not the bytes) — see [Accessing the raw attachment](#accessing-the-raw-attachment). |
+| `Raw` | The original wire attachment (the metadata object, not the bytes) — see [Access the raw attachment](#access-the-raw-attachment). |
 
-<!-- reusing-snapshot -->
+<!-- reusing-downloaded-file -->
 
 ```csharp
 DownloadedFile downloaded = await file.DownloadAsync(cancellationToken);

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
@@ -55,7 +55,7 @@ if (file is not null)
 <!-- saving-to-disk -->
 
 ```csharp
-await file.SaveAsAsync("./uploads/report.pdf", cancellationToken);
+await file.SaveAsAsync("./downloads/report.pdf", cancellationToken);
 ```
 
 <!-- streaming -->

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
@@ -1,0 +1,147 @@
+<!-- accessing-files -->
+
+```csharp
+teamsApp.OnMessage(async (context, cancellationToken) =>
+{
+    IList<IncomingFile> uploaded = await context.Files.ListAsync(cancellationToken);
+
+    if (uploaded.Count == 0)
+    {
+        await context.ReplyAsync("Send me a file and I will read it.", cancellationToken);
+        return;
+    }
+
+    string names = string.Join(", ", uploaded.Select(f => f.Name));
+    await context.ReplyAsync($"You sent {uploaded.Count} file(s): {names}", cancellationToken);
+});
+```
+
+<!-- first-file -->
+
+```csharp
+IncomingFile? file = await context.Files.FirstAsync(cancellationToken);
+
+if (file is not null)
+{
+    await context.ReplyAsync($"Reading {file.Name}...", cancellationToken);
+}
+```
+
+<!-- reading-download -->
+
+```csharp
+IncomingFile? file = await context.Files.FirstAsync(cancellationToken);
+
+if (file is not null)
+{
+    DownloadedFile downloaded = await file.DownloadAsync(cancellationToken);
+
+    await context.ReplyAsync($"Downloaded {downloaded.Filename} ({downloaded.Bytes.Length} bytes, {downloaded.ContentType})", cancellationToken);
+}
+```
+
+<!-- reading-text -->
+
+```csharp
+IncomingFile? file = await context.Files.FirstAsync(cancellationToken);
+
+if (file is not null)
+{
+    string contents = await file.TextAsync(cancellationToken: cancellationToken);
+    await context.ReplyAsync($"The file starts with: {contents[..Math.Min(100, contents.Length)]}", cancellationToken);
+}
+```
+
+<!-- saving-to-disk -->
+
+```csharp
+await file.SaveAsAsync("./uploads/report.pdf", cancellationToken);
+```
+
+<!-- streaming -->
+
+```csharp
+await using Stream stream = await file.StreamAsync(cancellationToken);
+
+byte[] buffer = new byte[8192];
+int read;
+while ((read = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+{
+    // process each chunk (e.g. pipe to a parser)
+}
+```
+
+<!-- metadata-table -->
+
+| Property | Description |
+|---|---|
+| `UniqueId` | The OneDrive/SharePoint drive-item id, when the platform provides it. Present only for files backed by ODSP storage. |
+| `Name` | File name including its extension (e.g. `report.pdf`). |
+| `Extension` | File extension without the dot (e.g. `pdf`), from the platform-supplied `fileType`. Absent when the platform omits it. |
+| `ContentType` | The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned downloaded file, not written back here. |
+| `Scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
+| `Source` | Where the SDK found the file. Currently always `botActivity`. |
+| `WebUrl` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |
+| `Raw` | The original wire attachment (the metadata object, not the bytes) — see [Accessing the raw attachment](#accessing-the-raw-attachment). |
+
+<!-- reusing-snapshot -->
+
+```csharp
+DownloadedFile downloaded = await file.DownloadAsync(cancellationToken);
+
+string text = downloaded.Text();                               // decode as UTF-8
+byte[] bytes = downloaded.Bytes;                               // the raw bytes
+await downloaded.SaveAsAsync("./copy.bin", cancellationToken); // write to disk, no re-fetch
+```
+
+<!-- downloaded-table -->
+
+| Property / method | Description |
+|---|---|
+| `Bytes` | The buffered file bytes as a `byte[]`. |
+| `ContentType` | MIME type resolved from the download response header, or the incoming file's metadata type if the response omits one. Falls back to `application/octet-stream` when neither provides a type, so this is never empty. |
+| `Filename` | The resolved file name. |
+| `SourceUrl` | The URL the bytes were fetched from. |
+| `Text(encoding?)` | Decode the bytes as UTF-8 (or a given encoding). Lossy; never throws. |
+| `SaveAsAsync(path)` | Write the buffered bytes to a local path (no re-fetch). |
+
+<!-- errors-import -->
+
+```csharp
+using Microsoft.Teams.Apps.Files;
+```
+
+<!-- errors-handling -->
+
+```csharp
+try
+{
+    DownloadedFile downloaded = await file.DownloadAsync(cancellationToken);
+    // ...
+}
+catch (FileUrlExpiredException err) when (err.Reason == FileUrlExpiredReason.FirstFetch)
+{
+    await context.ReplyAsync("That file link has expired before it could be read.", cancellationToken);
+}
+catch (FileScopeNotSupportedException err)
+{
+    await context.ReplyAsync($"Downloading files from {err.Scope} conversations is not supported yet.", cancellationToken);
+}
+```
+
+<!-- raw-attachment -->
+
+```csharp
+using System.Text.Json;
+
+IncomingFile? file = await context.Files.FirstAsync(cancellationToken);
+
+if (file is not null)
+{
+    // `Raw` is the untyped wire attachment: the escape hatch when you need a
+    // field the typed surface does not expose. Here we serialize the whole
+    // attachment to inspect exactly what the platform sent.
+    string wire = JsonSerializer.Serialize(file.Raw);
+    await context.ReplyAsync($"raw attachment: {wire}", cancellationToken);
+}
+```

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
@@ -3,16 +3,16 @@
 ```csharp
 teamsApp.OnMessage(async (context, cancellationToken) =>
 {
-    IList<IncomingFile> uploaded = await context.Files.ListAsync(cancellationToken);
+    IList<IncomingFile> attached = await context.Files.ListAsync(cancellationToken);
 
-    if (uploaded.Count == 0)
+    if (attached.Count == 0)
     {
         await context.ReplyAsync("Send me a file and I will read it.", cancellationToken);
         return;
     }
 
-    string names = string.Join(", ", uploaded.Select(f => f.Name));
-    await context.ReplyAsync($"You sent {uploaded.Count} file(s): {names}", cancellationToken);
+    string names = string.Join(", ", attached.Select(f => f.Name));
+    await context.ReplyAsync($"You sent {attached.Count} file(s): {names}", cancellationToken);
 });
 ```
 

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
@@ -67,7 +67,8 @@ byte[] buffer = new byte[8192];
 int read;
 while ((read = await stream.ReadAsync(buffer, cancellationToken)) > 0)
 {
-    // process each chunk (e.g. pipe to a parser)
+    // process only the bytes read this iteration (e.g. pipe to a parser)
+    ReadOnlyMemory<byte> chunk = buffer.AsMemory(0, read);
 }
 ```
 

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/csharp.incl.md
@@ -79,7 +79,7 @@ while ((read = await stream.ReadAsync(buffer, cancellationToken)) > 0)
 | `UniqueId` | The OneDrive/SharePoint drive-item id, when the platform provides it. Present only for files backed by ODSP storage. |
 | `Name` | File name including its extension (e.g. `report.pdf`). |
 | `Extension` | File extension without the dot (e.g. `pdf`), from the platform-supplied `fileType`. Absent when the platform omits it. |
-| `ContentType` | The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned downloaded file, not written back here. |
+| `ContentType` | The file's MIME type, when the source provides one. Always unset for files received from a bot activity (every file today): the `file.download.info` attachment carries no MIME type, only the extension surfaced as `Extension`. To learn the type of the bytes you actually received, read `ContentType` on the downloaded file, which is resolved from the download response. |
 | `Scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
 | `Source` | Where the SDK found the file. Currently always `botActivity`. |
 | `WebUrl` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
@@ -46,7 +46,7 @@ if file:
 <!-- saving-to-disk -->
 
 ```python
-await file.save_as("./uploads/report.pdf")
+await file.save_as("./downloads/report.pdf")
 ```
 
 <!-- streaming -->

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
@@ -1,0 +1,122 @@
+<!-- accessing-files -->
+
+```python
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    uploaded = await ctx.files.list()
+
+    if not uploaded:
+        await ctx.reply("Send me a file and I will read it.")
+        return
+
+    names = ", ".join(f.name for f in uploaded)
+    await ctx.reply(f"You sent {len(uploaded)} file(s): {names}")
+```
+
+<!-- first-file -->
+
+```python
+file = await ctx.files.first()
+
+if file:
+    await ctx.reply(f"Reading {file.name}...")
+```
+
+<!-- reading-download -->
+
+```python
+file = await ctx.files.first()
+
+if file:
+    downloaded = await file.download()
+
+    await ctx.reply(f"Downloaded {downloaded.filename} ({len(downloaded.bytes)} bytes, {downloaded.content_type})")
+```
+
+<!-- reading-text -->
+
+```python
+file = await ctx.files.first()
+
+if file:
+    contents = await file.text()
+    await ctx.reply(f"The file starts with: {contents[:100]}")
+```
+
+<!-- saving-to-disk -->
+
+```python
+await file.save_as("./uploads/report.pdf")
+```
+
+<!-- streaming -->
+
+```python
+async for chunk in file.stream():
+    ...  # process each chunk (e.g. pipe to a parser)
+```
+
+<!-- metadata-table -->
+
+| Property | Description |
+|---|---|
+| `unique_id` | The OneDrive/SharePoint drive-item id, when the platform provides it. Present only for files backed by ODSP storage. |
+| `name` | File name including its extension (e.g. `report.pdf`). |
+| `extension` | File extension without the dot (e.g. `pdf`), from the platform-supplied `file_type`. Absent when the platform omits it. |
+| `content_type` | The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned downloaded file, not written back here. |
+| `scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
+| `source` | Where the SDK found the file. Currently always `botActivity`. |
+| `web_url` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |
+| `raw` | The original wire attachment (the metadata object, not the bytes) — see [Accessing the raw attachment](#accessing-the-raw-attachment). |
+
+<!-- reusing-snapshot -->
+
+```python
+downloaded = await file.download()
+
+text = downloaded.text()               # decode as UTF-8
+data = downloaded.bytes                # the raw bytes
+await downloaded.save_as("./copy.bin") # write to disk, no re-fetch
+```
+
+<!-- downloaded-table -->
+
+| Property / method | Description |
+|---|---|
+| `bytes` | The buffered file bytes. |
+| `content_type` | MIME type resolved from the download response header, or the incoming file's metadata type if the response omits one. Falls back to `application/octet-stream` when neither provides a type, so this is never empty. |
+| `filename` | The resolved file name. |
+| `source_url` | The URL the bytes were fetched from. |
+| `text(encoding="utf-8")` | Decode the bytes as UTF-8 (or a given encoding). Lossy; never throws. |
+| `save_as(path)` | Write the buffered bytes to a local path (no re-fetch). |
+
+<!-- errors-import -->
+
+```python
+from microsoft_teams.apps import FileScopeNotSupportedError, FileUrlExpiredError
+```
+
+<!-- errors-handling -->
+
+```python
+try:
+    downloaded = await file.download()
+    # ...
+except FileUrlExpiredError as err:
+    if err.reason == "first_fetch":
+        await ctx.reply("That file link has expired before it could be read.")
+except FileScopeNotSupportedError as err:
+    await ctx.reply(f"Downloading files from {err.scope} conversations is not supported yet.")
+```
+
+<!-- raw-attachment -->
+
+```python
+file = await ctx.files.first()
+
+if file:
+    # `raw` is the untyped wire attachment: the escape hatch when you need a
+    # field the typed surface does not expose. Here we log the whole attachment
+    # to inspect exactly what the platform sent.
+    ctx.logger.debug("raw file attachment: %s", file.raw)
+```

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
@@ -3,14 +3,14 @@
 ```python
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
-    uploaded = await ctx.files.list()
+    attached = await ctx.files.list()
 
-    if not uploaded:
+    if not attached:
         await ctx.reply("Send me a file and I will read it.")
         return
 
-    names = ", ".join(f.name for f in uploaded)
-    await ctx.reply(f"You sent {len(uploaded)} file(s): {names}")
+    names = ", ".join(f.name for f in attached)
+    await ctx.reply(f"You sent {len(attached)} file(s): {names}")
 ```
 
 <!-- first-file -->

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
@@ -67,9 +67,9 @@ async for chunk in file.stream():
 | `scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
 | `source` | Where the SDK found the file. Currently always `botActivity`. |
 | `web_url` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |
-| `raw` | The original wire attachment (the metadata object, not the bytes) — see [Accessing the raw attachment](#accessing-the-raw-attachment). |
+| `raw` | The original wire attachment (the metadata object, not the bytes) — see [Access the raw attachment](#access-the-raw-attachment). |
 
-<!-- reusing-snapshot -->
+<!-- reusing-downloaded-file -->
 
 ```python
 downloaded = await file.download()

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/python.incl.md
@@ -63,7 +63,7 @@ async for chunk in file.stream():
 | `unique_id` | The OneDrive/SharePoint drive-item id, when the platform provides it. Present only for files backed by ODSP storage. |
 | `name` | File name including its extension (e.g. `report.pdf`). |
 | `extension` | File extension without the dot (e.g. `pdf`), from the platform-supplied `file_type`. Absent when the platform omits it. |
-| `content_type` | The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned downloaded file, not written back here. |
+| `content_type` | The file's MIME type, when the source provides one. Always unset for files received from a bot activity (every file today): the `file.download.info` attachment carries no MIME type, only the extension surfaced as `extension`. To learn the type of the bytes you actually received, read `content_type` on the downloaded file, which is resolved from the download response. |
 | `scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
 | `source` | Where the SDK found the file. Currently always `botActivity`. |
 | `web_url` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
@@ -1,0 +1,132 @@
+<!-- accessing-files -->
+
+```typescript
+app.on('message', async ({ files, send }) => {
+  const uploaded = await files.list();
+
+  if (uploaded.length === 0) {
+    await send('Send me a file and I will read it.');
+    return;
+  }
+
+  await send(`You sent ${uploaded.length} file(s): ${uploaded.map((f) => f.name).join(', ')}`);
+});
+```
+
+<!-- first-file -->
+
+```typescript
+const file = await files.first();
+
+if (file) {
+  await send(`Reading ${file.name}...`);
+}
+```
+
+<!-- reading-download -->
+
+```typescript
+const file = await files.first();
+
+if (file) {
+  const downloaded = await file.download();
+
+  await send(`Downloaded ${downloaded.filename} (${downloaded.bytes.length} bytes, ${downloaded.contentType})`);
+}
+```
+
+<!-- reading-text -->
+
+```typescript
+const file = await files.first();
+
+if (file) {
+  const contents = await file.text();
+  await send(`The file starts with: ${contents.slice(0, 100)}`);
+}
+```
+
+<!-- saving-to-disk -->
+
+```typescript
+await file.saveAs('./uploads/report.pdf');
+```
+
+<!-- streaming -->
+
+```typescript
+const stream = await file.stream();
+
+for await (const chunk of stream) {
+  // process each chunk (e.g. pipe to a parser)
+}
+```
+
+<!-- metadata-table -->
+
+| Property | Description |
+|---|---|
+| `uniqueId` | The OneDrive/SharePoint drive-item id, when the platform provides it. Present only for files backed by ODSP storage. |
+| `name` | File name including its extension (e.g. `report.pdf`). |
+| `extension` | File extension without the dot (e.g. `pdf`), from the platform-supplied `fileType`. Absent when the platform omits it. |
+| `contentType` | The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned downloaded file, not written back here. |
+| `scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
+| `source` | Where the SDK found the file. Currently always `botActivity`. |
+| `webUrl` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |
+| `raw` | The original wire attachment (the metadata object, not the bytes) — see [Accessing the raw attachment](#accessing-the-raw-attachment). |
+
+<!-- reusing-snapshot -->
+
+```typescript
+const downloaded = await file.download();
+
+const text = downloaded.text();          // decode as UTF-8
+const buffer = downloaded.arrayBuffer(); // the raw bytes
+await downloaded.saveAs('./copy.bin');   // write to disk, no re-fetch
+```
+
+<!-- downloaded-table -->
+
+| Property / method | Description |
+|---|---|
+| `bytes` | The buffered file bytes as a `Uint8Array`. |
+| `contentType` | MIME type resolved from the download response header, or the incoming file's metadata type if the response omits one. Falls back to `application/octet-stream` when neither provides a type, so this is never empty. |
+| `filename` | The resolved file name. |
+| `sourceUrl` | The URL the bytes were fetched from. |
+| `text(encoding?)` | Decode the bytes as UTF-8 (or a given encoding). Lossy; never throws. |
+| `arrayBuffer()` | Return the bytes as an `ArrayBuffer`. |
+| `saveAs(path)` | Write the buffered bytes to a local path (no re-fetch). |
+
+<!-- errors-import -->
+
+```typescript
+import { FileScopeNotSupportedError, FileUrlExpiredError } from '@microsoft/teams.apps';
+```
+
+<!-- errors-handling -->
+
+```typescript
+try {
+  const downloaded = await file.download();
+  // ...
+} catch (err) {
+  if (err instanceof FileUrlExpiredError && err.reason === 'firstFetch') {
+    await send('That file link has expired before it could be read.');
+  } else if (err instanceof FileScopeNotSupportedError) {
+    await send(`Downloading files from ${err.scope} conversations is not supported yet.`);
+  }
+}
+```
+
+<!-- raw-attachment -->
+
+```typescript
+const file = await files.first();
+
+if (file) {
+  // `raw` is the untyped wire attachment: the escape hatch when you need a
+  // field the typed surface does not expose. Here we log the whole attachment
+  // to inspect exactly what the platform sent.
+  log.debug('raw file attachment', file.raw);
+}
+```

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
@@ -73,9 +73,9 @@ for await (const chunk of stream) {
 | `scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
 | `source` | Where the SDK found the file. Currently always `botActivity`. |
 | `webUrl` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |
-| `raw` | The original wire attachment (the metadata object, not the bytes) — see [Accessing the raw attachment](#accessing-the-raw-attachment). |
+| `raw` | The original wire attachment (the metadata object, not the bytes) — see [Access the raw attachment](#access-the-raw-attachment). |
 
-<!-- reusing-snapshot -->
+<!-- reusing-downloaded-file -->
 
 ```typescript
 const downloaded = await file.download();

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
@@ -69,7 +69,7 @@ for await (const chunk of stream) {
 | `uniqueId` | The OneDrive/SharePoint drive-item id, when the platform provides it. Present only for files backed by ODSP storage. |
 | `name` | File name including its extension (e.g. `report.pdf`). |
 | `extension` | File extension without the dot (e.g. `pdf`), from the platform-supplied `fileType`. Absent when the platform omits it. |
-| `contentType` | The file's MIME type, when Teams provides it with the file; otherwise unset. The type resolved from the download response is on the returned downloaded file, not written back here. |
+| `contentType` | The file's MIME type, when the source provides one. Always unset for files received from a bot activity (every file today): the `file.download.info` attachment carries no MIME type, only the extension surfaced as `extension`. To learn the type of the bytes you actually received, read `contentType` on the downloaded file, which is resolved from the download response. |
 | `scope` | The conversation scope the file arrived in (`personal`, `groupChat`, or `channel`). |
 | `source` | Where the SDK found the file. Currently always `botActivity`. |
 | `webUrl` | A browsable link to the file in OneDrive/SharePoint, when known. Not a fetchable download URL. |

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
@@ -49,7 +49,7 @@ if (file) {
 <!-- saving-to-disk -->
 
 ```typescript
-await file.saveAs('./uploads/report.pdf');
+await file.saveAs('./downloads/report.pdf');
 ```
 
 <!-- streaming -->

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-files/typescript.incl.md
@@ -2,14 +2,14 @@
 
 ```typescript
 app.on('message', async ({ files, send }) => {
-  const uploaded = await files.list();
+  const attached = await files.list();
 
-  if (uploaded.length === 0) {
+  if (attached.length === 0) {
     await send('Send me a file and I will read it.');
     return;
   }
 
-  await send(`You sent ${uploaded.length} file(s): ${uploaded.map((f) => f.name).join(', ')}`);
+  await send(`You sent ${attached.length} file(s): ${attached.map((f) => f.name).join(', ')}`);
 });
 ```
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
@@ -1,0 +1,27 @@
+---
+sidebar_position: 1
+title: 'File Handling'
+suppressLanguageIncludeWarning: true
+---
+
+# File Handling
+
+This section covers how your app receives files and reads their bytes.
+
+:::info[Preview]
+File handling is being rolled out incrementally. Today the SDK supports **receiving** uploaded files in personal (1:1) chats via the TypeScript, Python, and C# SDKs.
+:::
+
+## Files vs. attachments
+
+In personal scope, everything a user sends alongside a message arrives in `activity.attachments`: uploaded files, but also Adaptive Cards, `@mentions`, link previews, and other non-file content. A **file** is the specific subset of attachments that represents an uploaded document, one whose `contentType` is `file.download.info`.
+
+The `ctx.files` accessor is the uploaded-file view over that raw array. It maps each uploaded file to a lazy handle you can download from, and skips everything else. The original `activity.attachments` array is always available when you need the raw payload or a non-file attachment.
+
+## In this section
+
+- **[Receiving Files](./receiving-files)** — read files a user uploads to your app, stream or download their bytes, and handle unsupported scopes and expired links.
+
+## Resources
+
+- [Files in Teams bots](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4)

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
@@ -14,9 +14,9 @@ File handling is being rolled out incrementally. Today the SDK supports **receiv
 
 ## Files vs. attachments
 
-In personal scope, everything a user sends alongside a message arrives in `activity.attachments`: uploaded files, but also Adaptive Cards, `@mentions`, link previews, and other non-file content. A **file** is the specific subset of attachments that represents an uploaded document, one whose `contentType` is `file.download.info`.
+In personal scope, everything a user sends alongside a message arrives in <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} />: uploaded files, but also Adaptive Cards, `@mentions`, link previews, and other non-file content. A **file** is the specific subset of attachments that represents an uploaded document, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
 
-The `ctx.files` accessor is the uploaded-file view over that raw array. It maps each uploaded file to a lazy handle you can download from, and skips everything else. The original `activity.attachments` array is always available when you need the raw payload or a non-file attachment.
+The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor is the uploaded-file view over that raw array. It maps each uploaded file to a lazy handle you can download from, and skips everything else. The original <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> array is always available when you need the raw payload or a non-file attachment.
 
 ## In this section
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
@@ -9,18 +9,18 @@ suppressLanguageIncludeWarning: true
 This section covers how your app receives files and reads their bytes.
 
 :::info[Preview]
-File handling is being rolled out incrementally. Today the SDK supports **receiving** uploaded files in personal (1:1) chats via the TypeScript, Python, and C# SDKs.
+File handling is being rolled out incrementally. Today the SDK supports **receiving** files attached to messages in personal (1:1) chats via the TypeScript, Python, and C# SDKs.
 :::
 
 ## Files vs. attachments
 
-In personal scope, everything a user sends alongside a message arrives in <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} />: uploaded files, but also Adaptive Cards, `@mentions`, link previews, and other non-file content. A **file** is the specific subset of attachments that represents an uploaded document, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
+In personal scope, <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> carries every non-text part of a received message: files the user attached, but also Adaptive Cards, `@mentions`, link previews, and other content the client or the platform adds. A **file** is the specific subset of attachments that describes a document the user attached, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
 
-The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor is the uploaded-file view over that raw array. It maps each uploaded file to a lazy handle you can download from, and skips everything else. The original <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> array is always available when you need the raw payload or a non-file attachment.
+The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor is the attached-file view over that raw array. It maps each attached file to a lazy handle you can download from, and skips everything else. The original <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> array is always available when you need the raw payload or a non-file attachment.
 
 ## In this section
 
-- **[Receiving Files](./receiving-files)** — read files a user uploads to your app, stream or download their bytes, and handle unsupported scopes and expired links.
+- **[Receiving Files](./receiving-files)** — read files a user attaches to a message, stream or download their bytes, and handle unsupported scopes and expired links.
 
 ## Resources
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/_category_.json
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "File Handling",
+  "position": 14,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
@@ -9,14 +9,14 @@ suppressLanguageIncludeWarning: true
 
 # Receiving Files
 
-When a user uploads a file to your agent, it arrives on the incoming activity. The `ctx.files` accessor gives you a typed, lazy handle to each uploaded file so you can read its bytes on demand.
+When a user uploads a file to your agent, it arrives on the incoming activity. The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor gives you a typed, lazy handle to each uploaded file so you can read its bytes on demand.
 
 :::info[Preview]
-This API covers file downloads in **personal (1:1) chats**, where an uploaded file arrives on the activity with a short-lived, pre-authorized download link. In **channels**, the uploaded file isn't delivered to the bot on the activity — Teams drops the attachment — so those files follow a separate, Microsoft Graph–based retrieval path. Group-chat behavior varies by how the file is stored. See [Conversation scope support](#conversation-scope-support).
+This API covers file downloads in **personal (1:1) chats**, where an uploaded file arrives on the activity with a short-lived, pre-authorized download link. In **channels**, the uploaded file isn't delivered to the bot on the activity (Teams drops the attachment), so those files follow a separate, Microsoft Graph-based retrieval path. Group-chat behavior varies by how the file is stored. See [Conversation scope support](#conversation-scope-support).
 :::
 
 :::warning[Prerequisite: enable file support in your manifest]
-Teams only routes uploaded files to your bot when your app manifest opts in. Set `supportsFiles` to `true` on your bot entry, otherwise `ctx.files.list()` is always empty and no file activity reaches your handler:
+Teams only routes uploaded files to your bot when your app manifest opts in. Set `supportsFiles` to `true` on your bot entry, otherwise <LanguageInclude content={{"typescript": "`ctx.files.list()`", "python": "`ctx.files.list()`", "csharp": "`context.Files.ListAsync()`"}} /> is always empty and no file activity reaches your handler:
 
 ```json
 "bots": [
@@ -31,38 +31,38 @@ Teams only routes uploaded files to your bot when your app manifest opts in. Set
 
 ## Accessing uploaded files
 
-`ctx.files` is available on every activity context. Use `list()` to get all uploaded files on the current message, or `first()` for the common single-file case:
+The accessor <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> is available on every activity context. Use <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> to get all uploaded files on the current message, or <LanguageInclude content={{"typescript": "`first()`", "python": "`first()`", "csharp": "`FirstAsync()`"}} /> for the common single-file case:
 
 <LanguageInclude section="accessing-files" />
 
-`list()` returns the uploaded files in the same order they arrived. It never throws: activities with no attachments (or non-message activities) return an empty list, and malformed file entries are skipped rather than failing the whole batch.
+Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> returns the uploaded files in the same order they arrived. It never throws: activities with no attachments (or non-message activities) return an empty list, and malformed file entries are skipped rather than failing the whole batch.
 
 <LanguageInclude section="first-file" />
 
 ## Reading a file
 
-Nothing is downloaded until you ask for bytes. The most common path is `download()`, which fetches the whole file and buffers it into a snapshot you own:
+Nothing is downloaded until you ask for bytes. The most common path is <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, which fetches the whole file and buffers it into a snapshot you own:
 
 <LanguageInclude section="reading-download" />
 
-For text files, `text()` is a shortcut for `download()` followed by decoding:
+For text files, <LanguageInclude content={{"typescript": "`text()`", "python": "`text()`", "csharp": "`TextAsync()`"}} /> is a shortcut for <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> followed by decoding:
 
 <LanguageInclude section="reading-text" />
 
 :::note
-`text()` decodes the downloaded bytes as UTF-8 by default, and is lossy: bytes that are not valid for the encoding become the replacement character (`U+FFFD`) instead of throwing. To decode a different encoding, pass <LanguageInclude content={{"typescript": "an encoding name (e.g. `file.text('latin1')`)", "python": "an encoding name (e.g. `file.text(\"latin1\")`)", "csharp": "an `Encoding` (e.g. `file.TextAsync(Encoding.Latin1)`)"}} />. For binary files, read the raw bytes instead.
+Decoding with <LanguageInclude content={{"typescript": "`text()`", "python": "`text()`", "csharp": "`TextAsync()`"}} /> reads the downloaded bytes as UTF-8 by default, and is lossy: bytes that are not valid for the encoding become the replacement character (`U+FFFD`) instead of throwing. To decode a different encoding, pass <LanguageInclude content={{"typescript": "an encoding name (e.g. `file.text('latin1')`)", "python": "an encoding name (e.g. `file.text(\"latin1\")`)", "csharp": "an `Encoding` (e.g. `file.TextAsync(Encoding.Latin1)`)"}} />. For binary files, read the raw bytes instead.
 :::
 
-To save a file to disk without holding it all in memory, use `saveAs()`, which streams straight to the path:
+To save a file to disk without holding it all in memory, use <LanguageInclude content={{"typescript": "`saveAs()`", "python": "`save_as()`", "csharp": "`SaveAsAsync()`"}} />, which streams straight to the path:
 
 <LanguageInclude section="saving-to-disk" />
 
-For large files or streaming pipelines, `stream()` hands you the raw byte stream so you can process it as it arrives:
+For large files or streaming pipelines, <LanguageInclude content={{"typescript": "`stream()`", "python": "`stream()`", "csharp": "`StreamAsync()`"}} /> hands you the raw byte stream so you can process it as it arrives:
 
 <LanguageInclude section="streaming" />
 
 :::note
-An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to `download()`, `text()`, `stream()`, or `saveAs()` fetches the file again. To read the same file several ways, call `download()` once and reuse the returned snapshot (see [Reusing a downloaded snapshot](#reusing-a-downloaded-snapshot)). This matters because a file's download link is short-lived: the URL embeds its own pre-authorized `tempauth` credential, which can expire between reads.
+An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, <LanguageInclude content={{"typescript": "`text()`", "python": "`text()`", "csharp": "`TextAsync()`"}} />, <LanguageInclude content={{"typescript": "`stream()`", "python": "`stream()`", "csharp": "`StreamAsync()`"}} />, or <LanguageInclude content={{"typescript": "`saveAs()`", "python": "`save_as()`", "csharp": "`SaveAsAsync()`"}} /> fetches the file again. To read the same file several ways, call <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> once and reuse the returned snapshot (see [Reusing a downloaded snapshot](#reusing-a-downloaded-snapshot)). This matters because a file's download link is short-lived: the URL embeds its own pre-authorized `tempauth` credential, which can expire between reads.
 :::
 
 ## File metadata
@@ -73,7 +73,7 @@ Each <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`Inc
 
 ## Reusing a downloaded snapshot
 
-`download()` returns a downloaded-file snapshot: a point-in-time, in-memory copy you own. Its readers are synchronous and never re-download, so hold one snapshot to read the same bytes several ways:
+Calling <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> returns a downloaded-file snapshot: a point-in-time, in-memory copy you own. Its readers never re-download, so hold one snapshot to read the same bytes several ways:
 
 <LanguageInclude section="reusing-snapshot" />
 
@@ -85,28 +85,28 @@ Byte retrieval can fail for a few well-defined reasons. Both error types are exp
 
 <LanguageInclude section="errors-import" />
 
-- **File URL expired** — the file's short-lived download link expired before the bytes could be fetched. Its reason distinguishes the two cases:
+- **File URL expired**: the file's short-lived download link expired before the bytes could be fetched. Its reason distinguishes the two cases:
   - *first fetch*: the link had already lapsed on the first read attempt, so no bytes were retrieved.
   - *re-read*: an earlier download succeeded, but a later re-read through the same handle came too late. Avoid this by downloading once and reusing the snapshot.
-- **File scope not supported** — `download()` was called on a file from a conversation scope this API doesn't fetch bytes for (anything other than personal 1:1). Exposes the scope.
+- **File scope not supported**: <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> was called on a file from a conversation scope this API doesn't fetch bytes for (anything other than personal 1:1). Exposes the scope.
 
 <LanguageInclude section="errors-handling" />
 
 ## Accessing the raw attachment
 
-Every file the accessor returns retains its original wire attachment on `raw`, for diagnostics or for the rare case where you need a field the typed surface does not expose:
+Every file the accessor returns retains its original wire attachment on <LanguageInclude content={{"typescript": "`raw`", "python": "`raw`", "csharp": "`Raw`"}} />, for diagnostics or for the rare case where you need a field the typed surface does not expose:
 
 <LanguageInclude section="raw-attachment" />
 
-Attachments that are **not** uploaded files (Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by `list()` and therefore have no `IncomingFile`. Reach those directly through `ctx.activity.attachments`.
+Attachments that are **not** uploaded files (Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> and therefore have no <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} />. Reach those directly through <LanguageInclude content={{"typescript": "`ctx.activity.attachments`", "python": "`ctx.activity.attachments`", "csharp": "`context.Activity.Attachments`"}} />.
 
 ## Conversation scope support
 
-`list()` surfaces the uploaded files Teams delivers on the incoming activity. Today that is the **personal (1:1)** chat path, where the file arrives with a short-lived, pre-authorized download link.
+Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> surfaces the uploaded files Teams delivers on the incoming activity. Today that is the **personal (1:1)** chat path, where the file arrives with a short-lived, pre-authorized download link.
 
-In **channels**, the uploaded file isn't delivered to the bot on the activity — Teams drops the attachment — so `list()` doesn't surface it; channel files follow a separate, Microsoft Graph–based retrieval path. Group-chat behavior varies by how the file is stored. When `download()`, `stream()`, `text()`, or `saveAs()` is called on a surfaced file whose scope isn't personal (1:1), it raises the file-scope-not-supported error.
+In **channels**, the uploaded file isn't delivered to the bot on the activity (Teams drops the attachment), so <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> doesn't surface it; channel files follow a separate, Microsoft Graph-based retrieval path. Group-chat behavior varies by how the file is stored. When <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, <LanguageInclude content={{"typescript": "`stream()`", "python": "`stream()`", "csharp": "`StreamAsync()`"}} />, <LanguageInclude content={{"typescript": "`text()`", "python": "`text()`", "csharp": "`TextAsync()`"}} />, or <LanguageInclude content={{"typescript": "`saveAs()`", "python": "`save_as()`", "csharp": "`SaveAsAsync()`"}} /> is called on a surfaced file whose scope isn't personal (1:1), it raises the file-scope-not-supported error.
 
-Downloading in personal (1:1) chats is identity-agnostic: the file arrives with a pre-authorized link that needs no token, so a traditional bot and an agentic user call the same `download()` with the same behavior.
+Downloading in personal (1:1) chats is identity-agnostic: the file arrives with a pre-authorized link that needs no token, so a traditional bot and an agentic user call the same <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> with the same behavior.
 
 ## Next steps
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
@@ -31,15 +31,13 @@ Teams only offers users the option to attach a file in 1:1 with a bot when your 
 
 ## Access attached files
 
-The accessor <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> is available on every activity context, but only inbound message activities carry attachments, so it is empty everywhere else. Use <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> to get all files attached to the current message, or <LanguageInclude content={{"typescript": "`first()`", "python": "`first()`", "csharp": "`FirstAsync()`"}} /> for the common single-file case:
+The accessor <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> is available on every activity context, but only inbound message activities carry attachments, so it is empty everywhere else. Use <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> to get all files attached to the current message, or <LanguageInclude content={{"typescript": "`first()`", "python": "`first()`", "csharp": "`FirstAsync()`"}} /> for the common single-file case. Both hand back the file's metadata rather than its contents, so listing is cheap even when the attached files are large:
 
 <LanguageInclude section="accessing-files" />
 
 Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> returns the attached files in the same order they arrived. It never throws: activities with no attachments (or non-message activities) return an empty list, and malformed file entries are skipped rather than failing the whole batch.
 
 <LanguageInclude section="first-file" />
-
-Both calls hand back metadata only. Nothing is fetched over the network until you ask for bytes, so listing files is cheap even when the attachments are large.
 
 ### File metadata
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
@@ -1,0 +1,113 @@
+---
+sidebar_position: 2
+title: 'Receiving Files'
+sidebar_label: 'Receiving Files'
+summary: Read files a user uploads to your Teams app. List uploaded files on an incoming message, download or stream their bytes, and handle expired links and unsupported scopes.
+languages: ['python', 'typescript', 'csharp']
+suppressLanguageIncludeWarning: true
+---
+
+# Receiving Files
+
+When a user uploads a file to your agent, it arrives on the incoming activity. The `ctx.files` accessor gives you a typed, lazy handle to each uploaded file so you can read its bytes on demand.
+
+:::info[Preview]
+This API covers file downloads in **personal (1:1) chats**, where an uploaded file arrives on the activity with a short-lived, pre-authorized download link. In **channels**, the uploaded file isn't delivered to the bot on the activity — Teams drops the attachment — so those files follow a separate, Microsoft Graph–based retrieval path. Group-chat behavior varies by how the file is stored. See [Conversation scope support](#conversation-scope-support).
+:::
+
+:::warning[Prerequisite: enable file support in your manifest]
+Teams only routes uploaded files to your bot when your app manifest opts in. Set `supportsFiles` to `true` on your bot entry, otherwise `ctx.files.list()` is always empty and no file activity reaches your handler:
+
+```json
+"bots": [
+  {
+    "botId": "${{BOT_ID}}",
+    "scopes": ["personal"],
+    "supportsFiles": true
+  }
+]
+```
+:::
+
+## Accessing uploaded files
+
+`ctx.files` is available on every activity context. Use `list()` to get all uploaded files on the current message, or `first()` for the common single-file case:
+
+<LanguageInclude section="accessing-files" />
+
+`list()` returns the uploaded files in the same order they arrived. It never throws: activities with no attachments (or non-message activities) return an empty list, and malformed file entries are skipped rather than failing the whole batch.
+
+<LanguageInclude section="first-file" />
+
+## Reading a file
+
+Nothing is downloaded until you ask for bytes. The most common path is `download()`, which fetches the whole file and buffers it into a snapshot you own:
+
+<LanguageInclude section="reading-download" />
+
+For text files, `text()` is a shortcut for `download()` followed by decoding:
+
+<LanguageInclude section="reading-text" />
+
+:::note
+`text()` decodes the downloaded bytes as UTF-8 by default, and is lossy: bytes that are not valid for the encoding become the replacement character (`U+FFFD`) instead of throwing. To decode a different encoding, pass <LanguageInclude content={{"typescript": "an encoding name (e.g. `file.text('latin1')`)", "python": "an encoding name (e.g. `file.text(\"latin1\")`)", "csharp": "an `Encoding` (e.g. `file.TextAsync(Encoding.Latin1)`)"}} />. For binary files, read the raw bytes instead.
+:::
+
+To save a file to disk without holding it all in memory, use `saveAs()`, which streams straight to the path:
+
+<LanguageInclude section="saving-to-disk" />
+
+For large files or streaming pipelines, `stream()` hands you the raw byte stream so you can process it as it arrives:
+
+<LanguageInclude section="streaming" />
+
+:::note
+An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to `download()`, `text()`, `stream()`, or `saveAs()` fetches the file again. To read the same file several ways, call `download()` once and reuse the returned snapshot (see [Reusing a downloaded snapshot](#reusing-a-downloaded-snapshot)). This matters because a file's download link is short-lived and can expire between reads.
+:::
+
+## File metadata
+
+Each <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> carries metadata describing the upload, populated from what the platform reports:
+
+<LanguageInclude section="metadata-table" />
+
+## Reusing a downloaded snapshot
+
+`download()` returns a downloaded-file snapshot: a point-in-time, in-memory copy you own. Its readers are synchronous and never re-download, so hold one snapshot to read the same bytes several ways:
+
+<LanguageInclude section="reusing-snapshot" />
+
+<LanguageInclude section="downloaded-table" />
+
+## Handling errors
+
+Byte retrieval can fail for a few well-defined reasons. Both error types are exported from the SDK:
+
+<LanguageInclude section="errors-import" />
+
+- **File URL expired** — the file's short-lived download link expired before the bytes could be fetched. Its reason distinguishes the two cases:
+  - *first fetch*: the link had already lapsed on the first read attempt, so no bytes were retrieved.
+  - *re-read*: an earlier download succeeded, but a later re-read through the same handle came too late. Avoid this by downloading once and reusing the snapshot.
+- **File scope not supported** — `download()` was called on a file from a conversation scope this API doesn't fetch bytes for (anything other than personal 1:1). Exposes the scope.
+
+<LanguageInclude section="errors-handling" />
+
+## Accessing the raw attachment
+
+Every file the accessor returns retains its original wire attachment on `raw`, for diagnostics or for the rare case where you need a field the typed surface does not expose:
+
+<LanguageInclude section="raw-attachment" />
+
+Attachments that are **not** uploaded files (Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by `list()` and therefore have no `IncomingFile`. Reach those directly through `ctx.activity.attachments`.
+
+## Conversation scope support
+
+`list()` surfaces the uploaded files Teams delivers on the incoming activity. Today that is the **personal (1:1)** chat path, where the file arrives with a short-lived, pre-authorized download link.
+
+In **channels**, the uploaded file isn't delivered to the bot on the activity — Teams drops the attachment — so `list()` doesn't surface it; channel files follow a separate, Microsoft Graph–based retrieval path. Group-chat behavior varies by how the file is stored. When `download()`, `stream()`, `text()`, or `saveAs()` is called on a surfaced file whose scope isn't personal (1:1), it raises the file-scope-not-supported error.
+
+Downloading in personal (1:1) chats is identity-agnostic: the file arrives with a pre-authorized link that needs no token, so a traditional bot and an agentic user call the same `download()` with the same behavior.
+
+## Next steps
+
+- See [Files in Teams bots](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4) for the platform-side upload model.

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
@@ -62,7 +62,7 @@ For large files or streaming pipelines, `stream()` hands you the raw byte stream
 <LanguageInclude section="streaming" />
 
 :::note
-An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to `download()`, `text()`, `stream()`, or `saveAs()` fetches the file again. To read the same file several ways, call `download()` once and reuse the returned snapshot (see [Reusing a downloaded snapshot](#reusing-a-downloaded-snapshot)). This matters because a file's download link is short-lived and can expire between reads.
+An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to `download()`, `text()`, `stream()`, or `saveAs()` fetches the file again. To read the same file several ways, call `download()` once and reuse the returned snapshot (see [Reusing a downloaded snapshot](#reusing-a-downloaded-snapshot)). This matters because a file's download link is short-lived: the URL embeds its own pre-authorized `tempauth` credential, which can expire between reads.
 :::
 
 ## File metadata

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
@@ -2,21 +2,22 @@
 sidebar_position: 2
 title: 'Receiving Files'
 sidebar_label: 'Receiving Files'
-summary: Read files a user uploads to your Teams app. List uploaded files on an incoming message, download or stream their bytes, and handle expired links and unsupported scopes.
+summary: Read files a user attaches to a message in your Teams app. List attached files on an incoming message, download or stream their bytes, and handle expired links and unsupported scopes.
 languages: ['python', 'typescript', 'csharp']
 suppressLanguageIncludeWarning: true
 ---
 
 # Receiving Files
 
-When a user uploads a file to your agent, it arrives on the incoming activity. The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor gives you a typed, lazy handle to each uploaded file so you can read its bytes on demand.
+Teams users can send files to agents by attaching them to chat messages. When users send files to an agent in 1:1 chat, they arrive as part of the context of the received message activity. <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> provides lazy access to the metadata and bytes of each attached file.
 
-:::info[Preview]
-This API covers file downloads in **personal (1:1) chats**, where an uploaded file arrives on the activity with a short-lived, pre-authorized download link. In **channels**, the uploaded file isn't delivered to the bot on the activity (Teams drops the attachment), so those files follow a separate, Microsoft Graph-based retrieval path. Group-chat behavior varies by how the file is stored. See [Conversation scope support](#conversation-scope-support).
-:::
+An attached file is not delivered inline with the message. Teams stores the file in the sender's OneDrive or SharePoint and hands your agent a small metadata attachment describing it, including a short-lived, pre-authorized URL in personal scopes. Reading the contents means fetching the bytes from that URL over the network, so the SDK defers that work until you ask for it.
 
-:::warning[Prerequisite: enable file support in your manifest]
-Teams only routes uploaded files to your bot when your app manifest opts in. Set `supportsFiles` to `true` on your bot entry, otherwise <LanguageInclude content={{"typescript": "`ctx.files.list()`", "python": "`ctx.files.list()`", "csharp": "`context.Files.ListAsync()`"}} /> is always empty and no file activity reaches your handler:
+This API covers file downloads in **personal (1:1) chats**. In **channels**, the attached file isn't delivered to the bot on the activity, so those files follow a separate, Microsoft Graph-based retrieval path. Group-chat behavior varies by how the file is stored. See [Conversation scope support](#conversation-scope-support).
+
+## Enable file support in your manifest
+
+Teams only offers users the option to attach a file in 1:1 with a bot when your app manifest opts in. Set `supportsFiles` to `true` on your bot entry; without it the compose box shows no attach affordance for your agent, no file reaches your handler, and <LanguageInclude content={{"typescript": "`ctx.files.list()`", "python": "`ctx.files.list()`", "csharp": "`context.Files.ListAsync()`"}} /> is always empty:
 
 ```json
 "bots": [
@@ -27,21 +28,28 @@ Teams only routes uploaded files to your bot when your app manifest opts in. Set
   }
 ]
 ```
-:::
 
-## Accessing uploaded files
+## Access attached files
 
-The accessor <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> is available on every activity context. Use <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> to get all uploaded files on the current message, or <LanguageInclude content={{"typescript": "`first()`", "python": "`first()`", "csharp": "`FirstAsync()`"}} /> for the common single-file case:
+The accessor <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> is available on every activity context, but only inbound message activities carry attachments, so it is empty everywhere else. Use <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> to get all files attached to the current message, or <LanguageInclude content={{"typescript": "`first()`", "python": "`first()`", "csharp": "`FirstAsync()`"}} /> for the common single-file case:
 
 <LanguageInclude section="accessing-files" />
 
-Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> returns the uploaded files in the same order they arrived. It never throws: activities with no attachments (or non-message activities) return an empty list, and malformed file entries are skipped rather than failing the whole batch.
+Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> returns the attached files in the same order they arrived. It never throws: activities with no attachments (or non-message activities) return an empty list, and malformed file entries are skipped rather than failing the whole batch.
 
 <LanguageInclude section="first-file" />
 
-## Reading a file
+Both calls hand back metadata only. Nothing is fetched over the network until you ask for bytes, so listing files is cheap even when the attachments are large.
 
-Nothing is downloaded until you ask for bytes. The most common path is <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, which fetches the whole file and buffers it into a snapshot you own:
+### File metadata
+
+Each <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> carries metadata describing the file, populated from what the platform reports:
+
+<LanguageInclude section="metadata-table" />
+
+## Read a file
+
+The most common path is <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, which fetches the whole file and buffers it into an in-memory copy you own:
 
 <LanguageInclude section="reading-download" />
 
@@ -61,25 +69,13 @@ For large files or streaming pipelines, <LanguageInclude content={{"typescript":
 
 <LanguageInclude section="streaming" />
 
-:::note
-An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, <LanguageInclude content={{"typescript": "`text()`", "python": "`text()`", "csharp": "`TextAsync()`"}} />, <LanguageInclude content={{"typescript": "`stream()`", "python": "`stream()`", "csharp": "`StreamAsync()`"}} />, or <LanguageInclude content={{"typescript": "`saveAs()`", "python": "`save_as()`", "csharp": "`SaveAsAsync()`"}} /> fetches the file again. To read the same file several ways, call <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> once and reuse the returned snapshot (see [Reusing a downloaded snapshot](#reusing-a-downloaded-snapshot)). This matters because a file's download link is short-lived: the URL embeds its own pre-authorized `tempauth` credential, which can expire between reads.
-:::
+An <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> handle holds no cached bytes: each call to <LanguageInclude content={{"typescript": "`download()`, `text()`, `stream()`, or `saveAs()`", "python": "`download()`, `text()`, `stream()`, or `save_as()`", "csharp": "`DownloadAsync()`, `TextAsync()`, `StreamAsync()`, or `SaveAsAsync()`"}} /> fetches the file again. This matters because a file's download link is short-lived: the URL embeds its own pre-authorized `tempauth` credential, which can expire between reads. To read the same file several ways, call <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> once and reuse the downloaded file it returns, which is a point-in-time copy whose readers never re-fetch:
 
-## File metadata
-
-Each <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} /> carries metadata describing the upload, populated from what the platform reports:
-
-<LanguageInclude section="metadata-table" />
-
-## Reusing a downloaded snapshot
-
-Calling <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> returns a downloaded-file snapshot: a point-in-time, in-memory copy you own. Its readers never re-download, so hold one snapshot to read the same bytes several ways:
-
-<LanguageInclude section="reusing-snapshot" />
+<LanguageInclude section="reusing-downloaded-file" />
 
 <LanguageInclude section="downloaded-table" />
 
-## Handling errors
+## Handle errors
 
 Byte retrieval can fail for a few well-defined reasons. Both error types are exported from the SDK:
 
@@ -87,27 +83,27 @@ Byte retrieval can fail for a few well-defined reasons. Both error types are exp
 
 - **File URL expired**: the file's short-lived download link expired before the bytes could be fetched. Its reason distinguishes the two cases:
   - *first fetch*: the link had already lapsed on the first read attempt, so no bytes were retrieved.
-  - *re-read*: an earlier download succeeded, but a later re-read through the same handle came too late. Avoid this by downloading once and reusing the snapshot.
+  - *re-read*: an earlier download succeeded, but a later re-read through the same handle came too late. Avoid this by downloading once and reusing the downloaded file.
 - **File scope not supported**: <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> was called on a file from a conversation scope this API doesn't fetch bytes for (anything other than personal 1:1). Exposes the scope.
 
 <LanguageInclude section="errors-handling" />
 
-## Accessing the raw attachment
+## Access the raw attachment
 
 Every file the accessor returns retains its original wire attachment on <LanguageInclude content={{"typescript": "`raw`", "python": "`raw`", "csharp": "`Raw`"}} />, for diagnostics or for the rare case where you need a field the typed surface does not expose:
 
 <LanguageInclude section="raw-attachment" />
 
-Attachments that are **not** uploaded files (Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> and therefore have no <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} />. Reach those directly through <LanguageInclude content={{"typescript": "`ctx.activity.attachments`", "python": "`ctx.activity.attachments`", "csharp": "`context.Activity.Attachments`"}} />.
+Attachments that are **not** files (Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> and therefore have no <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} />. Reach those directly through <LanguageInclude content={{"typescript": "`ctx.activity.attachments`", "python": "`ctx.activity.attachments`", "csharp": "`context.Activity.Attachments`"}} />.
 
 ## Conversation scope support
 
-Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> surfaces the uploaded files Teams delivers on the incoming activity. Today that is the **personal (1:1)** chat path, where the file arrives with a short-lived, pre-authorized download link.
+Listing with <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> surfaces the files Teams delivers on the incoming activity. Today that is the **personal (1:1)** chat path, where the file arrives with a short-lived, pre-authorized download link.
 
-In **channels**, the uploaded file isn't delivered to the bot on the activity (Teams drops the attachment), so <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> doesn't surface it; channel files follow a separate, Microsoft Graph-based retrieval path. Group-chat behavior varies by how the file is stored. When <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} />, <LanguageInclude content={{"typescript": "`stream()`", "python": "`stream()`", "csharp": "`StreamAsync()`"}} />, <LanguageInclude content={{"typescript": "`text()`", "python": "`text()`", "csharp": "`TextAsync()`"}} />, or <LanguageInclude content={{"typescript": "`saveAs()`", "python": "`save_as()`", "csharp": "`SaveAsAsync()`"}} /> is called on a surfaced file whose scope isn't personal (1:1), it raises the file-scope-not-supported error.
+In **channels**, the attached file isn't delivered to the bot on the activity (Teams drops the attachment), so <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> doesn't surface it; channel files follow a separate, Microsoft Graph-based retrieval path. Group-chat behavior varies by how the file is stored. When <LanguageInclude content={{"typescript": "`download()`, `stream()`, `text()`, or `saveAs()`", "python": "`download()`, `stream()`, `text()`, or `save_as()`", "csharp": "`DownloadAsync()`, `StreamAsync()`, `TextAsync()`, or `SaveAsAsync()`"}} /> is called on a surfaced file whose scope isn't personal (1:1), it raises the file-scope-not-supported error.
 
 Downloading in personal (1:1) chats is identity-agnostic: the file arrives with a pre-authorized link that needs no token, so a traditional bot and an agentic user call the same <LanguageInclude content={{"typescript": "`download()`", "python": "`download()`", "csharp": "`DownloadAsync()`"}} /> with the same behavior.
 
 ## Next steps
 
-- See [Files in Teams bots](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4) for the platform-side upload model.
+- See [Files in Teams bots](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4) for the platform-side file model.


### PR DESCRIPTION
- Add a new File Handling guide for how an app receives files uploaded by a user in personal scope. Documents usage of `ctx.files`, metadata, download methods, and the `tempauth` url. 
- Creates a new section  `in-depth-guides/file-handling/` with `receiving-files.mdx`  guide.
- Manifest prerequisite: callout that  `supportsFiles: true`  is required or `list()` is always empty.