### PR TITLE
docs: add Azure OpenAI and Anthropic AI quickstarts

### DIFF
--- a/teams.md/docs/main/get-started/quickstart-build.md
+++ b/teams.md/docs/main/get-started/quickstart-build.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: "Quickstart: Build your first bot"
+title: 'Quickstart: Build your first bot'
 summary: Wire up a message handler in TypeScript, C#, or Python with the Teams SDK.
 ---
 
@@ -35,13 +35,13 @@ app.on('message', async ({ send, activity }) => {
 app.start(process.env.PORT || 3978).catch(console.error);
 ```
 
-| Part | Purpose |
-|---|---|
-| `new App()` | Reads credentials from `.env` automatically |
-| `app.on('message', ...)` | Registers a handler for incoming messages |
+| Part                       | Purpose                                            |
+| -------------------------- | -------------------------------------------------- |
+| `new App()`                | Reads credentials from `.env` automatically        |
+| `app.on('message', ...)`   | Registers a handler for incoming messages          |
 | `send({ type: 'typing' })` | Shows the typing indicator while you build a reply |
-| `send(...)` | Replies in the same conversation |
-| `app.start(port)` | Starts the HTTP server on the given port |
+| `send(...)`                | Replies in the same conversation                   |
+| `app.start(port)`          | Starts the HTTP server on the given port           |
 
 Run it:
 
@@ -132,6 +132,28 @@ python src/main.py
 ```
 
 Continue with the [Python guide](/python/getting-started) for events, sending messages, Adaptive Cards, AI, and more.
+
+</TabItem>
+</Tabs>
+
+## Add AI
+
+Keep the Teams message handler as your channel boundary, then connect the model or agent framework that fits your application.
+
+<Tabs groupId="language">
+<TabItem value="typescript" label="TypeScript" default>
+
+Use the [AI agent quickstart](/typescript/in-depth-guides/ai-integrations/agent-quickstart) to run the same Teams agent with either Azure OpenAI or Anthropic Claude. The sample includes streaming, MCP tools, citations, clarification cards, follow-up prompts, and feedback.
+
+</TabItem>
+<TabItem value="csharp" label="C#">
+
+Use the [AI agent quickstart](/csharp/in-depth-guides/ai-integrations/agent-quickstart) to run the validated `IChatClient` sample with either Azure OpenAI or Anthropic Claude, then continue with [Build an agent in Teams](/csharp/in-depth-guides/ai-integrations/build-agent).
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+Use the [AI agent quickstart](/python/in-depth-guides/ai-integrations/agent-quickstart) to run the validated Agent Framework sample with either Azure OpenAI or Anthropic Claude, then continue with [Build an agent in Teams](/python/in-depth-guides/ai-integrations/build-agent).
 
 </TabItem>
 </Tabs>

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/a2a/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/a2a/csharp.incl.md
@@ -1,6 +1,6 @@
 <!-- intro -->
 
-This guide is based on [`core/samples/A2ABot`](https://github.com/microsoft/teams.net/tree/main/core/samples/A2ABot): two SDK 2.1 bots run the same code with different config and hand users off through A2A.
+This guide is based on [`samples/A2ABot`](https://github.com/microsoft/teams.net/tree/main/samples/A2ABot): two SDK 2.1 bots run the same code with different config and hand users off through A2A.
 
 <!-- agent-card -->
 

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/a2a/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/a2a/python.incl.md
@@ -1,6 +1,6 @@
 <!-- intro -->
 
-Both bots run the **same code**, differentiated entirely by environment variables (name, description, self/peer URLs). They use the [`a2a-sdk`](https://github.com/a2aproject/a2a-python) for the protocol and `agent_framework` for the LLM agent.
+Both bots run the **same code**, differentiated entirely by environment variables (name, description, self/peer URLs). They use the [`a2a-sdk`](https://github.com/a2aproject/a2a-python) for the protocol and `agent_framework` for the LLM agent. The checked-in sample configures Agent Framework's Azure OpenAI connector, but the A2A and Teams handoff flow is independent of that backend.
 
 Full source: [examples/a2a](https://github.com/microsoft/teams.py/tree/main/examples/a2a).
 

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/a2a/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/a2a/typescript.incl.md
@@ -1,6 +1,6 @@
 <!-- intro -->
 
-Both bots run the **same code**, differentiated entirely by environment variables (name, description, self/peer URLs). They use [`@a2a-js/sdk`](https://www.npmjs.com/package/@a2a-js/sdk) for the protocol and the OpenAI SDK for the LLM agent.
+Both bots run the **same code**, differentiated entirely by environment variables (name, description, self/peer URLs). They use [`@a2a-js/sdk`](https://www.npmjs.com/package/@a2a-js/sdk) for the protocol. The checked-in sample uses the OpenAI SDK for its model loop, but A2A and the Teams handoff flow are independent of that provider.
 
 Full source: [examples/a2a](https://github.com/microsoft/teams.ts/tree/main/examples/a2a).
 
@@ -20,12 +20,14 @@ function buildAgentCard(config: Config): AgentCard {
     capabilities: {},
     defaultInputModes: ['application/json'],
     defaultOutputModes: ['text/plain'],
-    skills: [{
-      id: 'handoff',
-      name: 'Handoff',
-      description: `Accepts handoffs of users from peer bots. Specialty: ${config.description}`,
-      tags: ['a2a', 'teams', 'handoff'],
-    }],
+    skills: [
+      {
+        id: 'handoff',
+        name: 'Handoff',
+        description: `Accepts handoffs of users from peer bots. Specialty: ${config.description}`,
+        tags: ['a2a', 'teams', 'handoff'],
+      },
+    ],
   };
 }
 ```
@@ -48,9 +50,12 @@ export function isHandoffMessage(value: unknown): value is HandoffMessage {
   const v = value as Record<string, unknown>;
   return (
     v.kind === 'handoff' &&
-    typeof v.aadObjectId === 'string' && v.aadObjectId.length > 0 &&
-    typeof v.tenantId === 'string' && v.tenantId.length > 0 &&
-    typeof v.serviceUrl === 'string' && v.serviceUrl.length > 0 &&
+    typeof v.aadObjectId === 'string' &&
+    v.aadObjectId.length > 0 &&
+    typeof v.tenantId === 'string' &&
+    v.tenantId.length > 0 &&
+    typeof v.serviceUrl === 'string' &&
+    v.serviceUrl.length > 0 &&
     typeof v.summary === 'string'
   );
 }
@@ -83,7 +88,12 @@ function buildHandoffTool(): RunnableToolFunction<{ summary: string }> {
           // Called from a handoff greeting (no identity) — guard against ping-pong.
           return 'handoff_to_peer is unavailable in this context.';
         }
-        const payload: HandoffMessage = { kind: 'handoff', from: config.name, ...identity, summary: args.summary };
+        const payload: HandoffMessage = {
+          kind: 'handoff',
+          from: config.name,
+          ...identity,
+          summary: args.summary,
+        };
         await a2aClient.sendHandoff(payload);
         return 'Handoff confirmed. The peer will message the user directly.';
       },
@@ -188,7 +198,10 @@ const a2aHandler = new DefaultRequestHandler(
   new HandoffAgentExecutor(app, agent, config, log)
 );
 expressApp.use('/.well-known/agent-card.json', agentCardHandler({ agentCardProvider: a2aHandler }));
-expressApp.use('/a2a', jsonRpcHandler({ requestHandler: a2aHandler, userBuilder: UserBuilder.noAuthentication }));
+expressApp.use(
+  '/a2a',
+  jsonRpcHandler({ requestHandler: a2aHandler, userBuilder: UserBuilder.noAuthentication })
+);
 
 // Register /api/messages without starting an internal server — we own the http.Server.
 await app.initialize();

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/agent-quickstart/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/agent-quickstart/csharp.incl.md
@@ -1,0 +1,104 @@
+<!-- prerequisites -->
+
+- .NET 10 SDK
+- The [Teams Developer CLI](/cli/)
+- A development tunnel with a public HTTPS URL
+- A Teams bot registration
+- Either an Azure OpenAI deployment or an Anthropic API key
+
+<!-- get-sample -->
+
+```bash
+git clone https://github.com/microsoft/teams.net.git
+cd teams.net
+dotnet restore samples/ExtAIBot/ExtAIBot.csproj
+```
+
+The working application is in `samples/ExtAIBot`.
+
+<!-- register-app -->
+
+```bash
+npm install -g @microsoft/teams.cli
+teams login
+teams app create \
+  --name "ext-ai-bot" \
+  --endpoint "https://<your-tunnel>/api/messages" \
+  --json
+```
+
+Configure the returned bot credentials through the standard `AzureAd` configuration section:
+
+```bash
+export AzureAd__TenantId=<tenant-id>
+export AzureAd__ClientId=<client-id>
+export AzureAd__ClientCredentials__0__SourceType=ClientSecret
+export AzureAd__ClientCredentials__0__ClientSecret=<client-secret>
+```
+
+<!-- run-sample -->
+
+```bash
+dotnet run --project samples/ExtAIBot/ExtAIBot.csproj
+```
+
+<!-- provider-config -->
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI" default>
+
+```bash
+export AI_PROVIDER=azure-openai
+export AzureOpenAI__Endpoint=https://<resource-name>.openai.azure.com
+export AzureOpenAI__ApiKey=<api-key>
+export AzureOpenAI__Deployment=<deployment-name>
+```
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```bash
+export AI_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=<api-key>
+export ANTHROPIC_MODEL=<supported-claude-model>
+```
+
+  </TabItem>
+</Tabs>
+
+Keep API keys on the server. Both providers use the public Microsoft Learn MCP server.
+
+<!-- provider-boundary -->
+
+The Teams application consumes `IChatClient`; provider selection happens once during dependency injection:
+
+```csharp
+string provider = config["AI_PROVIDER"] ?? "azure-openai";
+IChatClient client = provider switch
+{
+    "anthropic" => new AnthropicClient(new ClientOptions
+    {
+        ApiKey = config["ANTHROPIC_API_KEY"]
+            ?? throw new InvalidOperationException("ANTHROPIC_API_KEY is required.")
+    })
+        .AsIChatClient(config["ANTHROPIC_MODEL"]
+            ?? throw new InvalidOperationException("ANTHROPIC_MODEL is required.")),
+    "azure-openai" => new AzureOpenAIClient(
+            new Uri(config["AzureOpenAI:Endpoint"]
+                ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.")),
+            new ApiKeyCredential(config["AzureOpenAI:ApiKey"]
+                ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.")))
+        .GetChatClient(config["AzureOpenAI:Deployment"]
+            ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required."))
+        .AsIChatClient(),
+    _ => throw new InvalidOperationException($"Unsupported AI_PROVIDER '{provider}'."),
+};
+
+return client.AsBuilder().UseFunctionInvocation().Build();
+```
+
+`Agent`, `ExtAIBotApp`, MCP tools, streaming, citations, cards, and feedback remain provider-neutral.
+
+<!-- sample-link -->
+
+Browse the complete [`ExtAIBot` sample](https://github.com/microsoft/teams.net/tree/main/samples/ExtAIBot).

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/agent-quickstart/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/agent-quickstart/python.incl.md
@@ -1,0 +1,101 @@
+<!-- prerequisites -->
+
+- Python 3.11 or later
+- [UV](https://docs.astral.sh/uv/)
+- The [Teams Developer CLI](/cli/)
+- A development tunnel with a public HTTPS URL
+- A Teams bot registration
+- Either an Azure OpenAI deployment or an Anthropic API key
+
+<!-- get-sample -->
+
+```bash
+git clone https://github.com/microsoft/teams.py.git
+cd teams.py
+uv sync --package ai-agentframework
+```
+
+The working application is in `examples/ai-mcp`.
+
+<!-- register-app -->
+
+```bash
+npm install -g @microsoft/teams.cli
+teams login
+teams app create \
+  --name "ai-mcp" \
+  --endpoint "https://<your-tunnel>/api/messages" \
+  --env examples/ai-mcp/.env \
+  --json
+```
+
+The CLI writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` to the sample's `.env` file.
+
+<!-- run-sample -->
+
+```bash
+cd examples/ai-mcp
+uv run python src/main.py
+```
+
+<!-- provider-config -->
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI" default>
+
+```env
+AI_PROVIDER=azure-openai
+AZURE_OPENAI_ENDPOINT=https://<resource-name>.openai.azure.com
+AZURE_OPENAI_API_KEY=<api-key>
+AZURE_OPENAI_MODEL=<deployment-name>
+```
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```env
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=<api-key>
+ANTHROPIC_MODEL=<supported-claude-model>
+ANTHROPIC_MAX_TOKENS=4096
+```
+
+  </TabItem>
+</Tabs>
+
+Keep API keys on the server. Both providers use the public Microsoft Learn MCP server.
+
+<!-- provider-boundary -->
+
+Microsoft Agent Framework owns the provider boundary. Startup selects a client, then constructs the same `Agent` with the same tools and middleware:
+
+```python
+provider = getenv("AI_PROVIDER", "azure-openai").strip().lower()
+
+if provider == "anthropic":
+    client = AnthropicClient(
+        api_key=_require_env("ANTHROPIC_API_KEY"),
+        model=_require_env("ANTHROPIC_MODEL"),
+    )
+elif provider == "azure-openai":
+    client = OpenAIChatClient(
+        model=_require_env("AZURE_OPENAI_MODEL"),
+        azure_endpoint=_require_env("AZURE_OPENAI_ENDPOINT"),
+        api_key=_require_env("AZURE_OPENAI_API_KEY"),
+    )
+else:
+    raise ValueError(f"Unsupported AI_PROVIDER {provider!r}.")
+
+agent = Agent(
+    client=client,
+    instructions=INSTRUCTIONS,
+    tools=[*local_tools, *mcp_tools],
+    middleware=[tool_logger],
+)
+```
+
+The Teams handlers, `AgentSession` memory, streaming, citations, cards, feedback, and follow-up presentation remain unchanged.
+
+<!-- sample-link -->
+
+Browse the complete [`ai-mcp` sample](https://github.com/microsoft/teams.py/tree/main/examples/ai-mcp).

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/agent-quickstart/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/agent-quickstart/typescript.incl.md
@@ -1,0 +1,138 @@
+<!-- prerequisites -->
+
+- Node.js 20 or later
+- The [Teams Developer CLI](/cli/)
+- A development tunnel with a public HTTPS URL
+- A Teams bot registration
+- Either an Azure OpenAI deployment or an Anthropic API key
+
+<!-- get-sample -->
+
+```bash
+git clone https://github.com/microsoft/teams.ts.git
+cd teams.ts
+npm install
+```
+
+The working application is in `examples/ai-mcp`.
+
+<!-- register-app -->
+
+```bash
+npm install -g @microsoft/teams.cli
+teams login
+teams app create \
+  --name "ai-mcp" \
+  --endpoint "https://<your-tunnel>/api/messages" \
+  --env examples/ai-mcp/.env \
+  --json
+```
+
+<!-- run-sample -->
+
+```bash
+npm run dev --workspace=@examples/ai-mcp
+```
+
+Expected startup output includes:
+
+```text
+Connected to MCP server https://learn.microsoft.com/api/mcp; discovered 3 tools.
+listening on port 3978
+```
+
+<!-- provider-config -->
+
+:::note[Anthropic SDK choice]
+This sample uses Anthropic's TypeScript **Messages SDK**. The Claude Agent SDK is a separate higher-level runtime and is not required for this integration.
+:::
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI" default>
+
+```env
+AI_PROVIDER=azure-openai
+AZURE_OPENAI_ENDPOINT=https://<resource-name>.openai.azure.com
+AZURE_OPENAI_API_KEY=<api-key>
+AZURE_OPENAI_MODEL_DEPLOYMENT_NAME=<deployment-name>
+AZURE_OPENAI_API_VERSION=2024-10-21
+```
+
+`AZURE_OPENAI_MODEL_DEPLOYMENT_NAME` is the deployment name configured on your Azure resource.
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```env
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=<api-key>
+ANTHROPIC_MODEL=<supported-claude-model>
+ANTHROPIC_MAX_TOKENS=4096
+```
+
+  </TabItem>
+</Tabs>
+
+Keep API keys on the server. Both providers use the public Microsoft Learn MCP server by default.
+
+<!-- provider-boundary -->
+
+The Teams handlers depend on one provider-neutral contract:
+
+```typescript
+export interface IAgentRunner {
+  run(conversationId: string, userText: string, stream: IStreamer): Promise<AgentRunResult>;
+}
+```
+
+The message and card-action handlers know only about this interface:
+
+```typescript
+const result = await agent.run(activity.conversation.id, userText, stream);
+shipResult(result, stream, activity.from.id);
+```
+
+Provider selection happens once during startup. Each implementation receives the same MCP tools and logger.
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI">
+
+```typescript
+const deployment = required('AZURE_OPENAI_MODEL_DEPLOYMENT_NAME');
+const agent: IAgentRunner = new Agent({
+  client: new AzureOpenAI({
+    endpoint: required('AZURE_OPENAI_ENDPOINT'),
+    apiKey: required('AZURE_OPENAI_API_KEY'),
+    deployment,
+    apiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-10-21',
+  }),
+  deploymentName: deployment,
+  mcpTools,
+  log,
+});
+```
+
+The implementation uses `chat.completions.runTools()` to stream text and execute tools.
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```typescript
+const agent: IAgentRunner = new AnthropicAgent({
+  client: new Anthropic({
+    apiKey: required('ANTHROPIC_API_KEY'),
+  }),
+  model: required('ANTHROPIC_MODEL'),
+  mcpTools,
+  log,
+});
+```
+
+The implementation uses `messages.stream()`, executes returned `tool_use` blocks, appends matching `tool_result` blocks, and continues until Claude returns final text.
+
+  </TabItem>
+</Tabs>
+
+<!-- sample-link -->
+
+Browse the complete [`ai-mcp` sample](https://github.com/microsoft/teams.ts/tree/main/examples/ai-mcp).

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/csharp.incl.md
@@ -1,14 +1,14 @@
 <!-- intro -->
 
-This guide walks through building a Teams agent with the [Microsoft.Extensions.AI](https://learn.microsoft.com/dotnet/ai/ai-extensions) abstractions against Azure OpenAI. The Teams SDK handles activity routing, streaming, and Teams-native affordances like Adaptive Cards and feedback controls, while `IChatClient` and tools provide the model and agent loop.
+This guide uses the provider-neutral [Microsoft.Extensions.AI](https://learn.microsoft.com/dotnet/ai/ai-extensions) `IChatClient` abstraction. The checked-in sample can register Azure OpenAI or Anthropic Claude, while the Teams handlers, tools, history, and response presentation depend only on `IChatClient`.
 
-In a Teams app, `IChatClient` runs the agent loop, including model calls, tool invocations, and conversation history, while the Teams SDK handles activity routing, streaming, and Teams-native affordances like Adaptive Cards and feedback controls.
+In a Teams app, the selected `IChatClient` implementation runs model calls and function invocation, while the Teams SDK handles activity routing, streaming, and Teams-native affordances like Adaptive Cards and feedback controls.
 
-The pattern is based on [`core/samples/ExtAIBot`](https://github.com/microsoft/teams.net/tree/main/core/samples/ExtAIBot).
+The pattern is based on [`samples/ExtAIBot`](https://github.com/microsoft/teams.net/tree/main/samples/ExtAIBot).
 
 <!-- define-agent -->
 
-Register the Teams application, chat client, and agent services with ASP.NET Core dependency injection:
+Register the Teams application, selected chat client, and agent services with ASP.NET Core dependency injection:
 
 ```csharp
 WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
@@ -17,13 +17,28 @@ builder.Services.AddTeamsBotApplication<ExtAIBotApp>();
 builder.Services.AddSingleton<IChatClient>(sp =>
 {
     IConfiguration config = sp.GetRequiredService<IConfiguration>();
-    string endpoint = config["AzureOpenAI:Endpoint"] ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.");
-    string apiKey = config["AzureOpenAI:ApiKey"] ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.");
-    string deployment = config["AzureOpenAI:Deployment"] ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required.");
+    string provider = config["AI_PROVIDER"] ?? "azure-openai";
+    IChatClient client = provider switch
+    {
+        "anthropic" => new AnthropicClient(new ClientOptions
+        {
+            ApiKey = config["ANTHROPIC_API_KEY"]
+                ?? throw new InvalidOperationException("ANTHROPIC_API_KEY is required.")
+        })
+            .AsIChatClient(config["ANTHROPIC_MODEL"]
+                ?? throw new InvalidOperationException("ANTHROPIC_MODEL is required.")),
+        "azure-openai" => new AzureOpenAIClient(
+                new Uri(config["AzureOpenAI:Endpoint"]
+                    ?? throw new InvalidOperationException("AzureOpenAI:Endpoint is required.")),
+                new ApiKeyCredential(config["AzureOpenAI:ApiKey"]
+                    ?? throw new InvalidOperationException("AzureOpenAI:ApiKey is required.")))
+            .GetChatClient(config["AzureOpenAI:Deployment"]
+                ?? throw new InvalidOperationException("AzureOpenAI:Deployment is required."))
+            .AsIChatClient(),
+        _ => throw new InvalidOperationException($"Unsupported AI_PROVIDER '{provider}'."),
+    };
 
-    return new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
-        .GetChatClient(deployment)
-        .AsIChatClient()
+    return client
         .AsBuilder()
         .UseFunctionInvocation()
         .Build();

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/python.incl.md
@@ -1,22 +1,35 @@
 <!-- intro -->
 
-This guide walks through building a Teams agent with [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/) (MAF) — Microsoft's open-source SDK for AI agents. MAF gives you typed primitives — `Agent`, `tool`, `AgentSession`, `FunctionMiddleware` — that wrap the underlying model API, the tool-dispatch loop, and conversation history into composable pieces, so you don't hand-roll chat completions or thread tool calls yourself. It works against multiple model backends (OpenAI, Azure OpenAI, and others) and scales from a single chat agent up to coordinated multi-agent workflows.
+This guide uses [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/) (MAF) as the boundary between Teams and the model backend. MAF provides typed primitives — `Agent`, `tool`, `AgentSession`, and `FunctionMiddleware` — for tool dispatch, conversation history, and streaming.
 
-In a Teams app, MAF runs the agent loop (model calls, tool invocations, and per-conversation memory) while the Teams SDK handles activity routing, streaming, and Teams-native affordances like Adaptive Cards and feedback controls.
+The checked-in `ai-mcp` sample installs the Azure OpenAI and Anthropic connectors. The Teams handlers and Teams-native response features depend on the framework's `Agent`, not directly on either provider connector.
 
 Full source: [examples/ai-mcp](https://github.com/microsoft/teams.py/tree/main/examples/ai-mcp).
 
 <!-- define-agent -->
 
+Select a provider during startup, then construct the same Agent Framework `Agent`:
+
 ```python
 from agent_framework import Agent
+from agent_framework.anthropic import AnthropicClient
 from agent_framework.openai import OpenAIChatClient
 
-client = OpenAIChatClient(
-    model=getenv("AZURE_OPENAI_MODEL"),
-    azure_endpoint=getenv("AZURE_OPENAI_ENDPOINT"),
-    api_key=getenv("AZURE_OPENAI_API_KEY"),
-)
+provider = getenv("AI_PROVIDER", "azure-openai").strip().lower()
+
+if provider == "anthropic":
+    client = AnthropicClient(
+        model=getenv("ANTHROPIC_MODEL"),
+        api_key=getenv("ANTHROPIC_API_KEY"),
+    )
+elif provider == "azure-openai":
+    client = OpenAIChatClient(
+        model=getenv("AZURE_OPENAI_MODEL"),
+        azure_endpoint=getenv("AZURE_OPENAI_ENDPOINT"),
+        api_key=getenv("AZURE_OPENAI_API_KEY"),
+    )
+else:
+    raise ValueError(f"Unsupported AI_PROVIDER {provider!r}.")
 
 agent = Agent(
     client=client,

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/typescript.incl.md
@@ -1,187 +1,263 @@
 <!-- intro -->
 
-This guide walks through building a Teams agent with the [OpenAI SDK](https://github.com/openai/openai-node) against Azure OpenAI. The TypeScript SDK stays agnostic about the intelligence layer — you bring the model client and the tool-call loop, and the Teams SDK handles activity routing, streaming, and Teams-native affordances like Adaptive Cards and feedback controls.
+This guide uses the multi-provider [`ai-mcp` sample](https://github.com/microsoft/teams.ts/tree/main/examples/ai-mcp). Azure OpenAI and Anthropic Claude share the same Teams handlers, MCP connection, local tools, citations, cards, and feedback. Only the provider implementation owns model-specific messages and tool-loop behavior.
 
-The agent loop here is driven by the OpenAI SDK's `runTools()` helper, which auto-executes each tool's `function` callback and feeds the result back to the model until it produces final text — so you don't hand-roll the tool-dispatch loop yourself.
-
-:::note
-This sample is bound to the OpenAI chat-completions wire protocol — Azure OpenAI and vanilla OpenAI both work; non-OpenAI providers do not.
-:::
-
-Full source: [examples/ai-mcp](https://github.com/microsoft/teams.ts/tree/main/examples/ai-mcp).
+Set `AI_PROVIDER=azure-openai` or `AI_PROVIDER=anthropic`. The rest of the Teams application remains unchanged.
 
 <!-- define-agent -->
 
-The "agent" is the model client plus a system prompt. The OpenAI SDK's `AzureOpenAI` client is the model backend, and `runTools()` (shown below) is the loop that drives instructions and tools together.
+The handlers depend on a small provider-neutral contract:
+
+```typescript
+export interface IAgentRunner {
+  run(conversationId: string, userText: string, stream: IStreamer): Promise<AgentRunResult>;
+}
+```
+
+Create the implementation that matches your configured provider:
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI">
 
 ```typescript
 import { AzureOpenAI } from 'openai';
 
-const client = new AzureOpenAI({
-  endpoint: process.env.AZURE_OPENAI_ENDPOINT!,
-  apiKey: process.env.AZURE_OPENAI_API_KEY!,
-  deployment: process.env.AZURE_OPENAI_MODEL_DEPLOYMENT_NAME!,
-  apiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-10-21',
+const deployment = required('AZURE_OPENAI_MODEL_DEPLOYMENT_NAME');
+const agent: IAgentRunner = new Agent({
+  client: new AzureOpenAI({
+    endpoint: required('AZURE_OPENAI_ENDPOINT'),
+    apiKey: required('AZURE_OPENAI_API_KEY'),
+    deployment,
+    apiVersion: process.env.AZURE_OPENAI_API_VERSION || '2024-10-21',
+  }),
+  deploymentName: deployment,
+  mcpTools,
+  log,
 });
-
-const SYSTEM_PROMPT = 'You are a helpful Teams assistant.';
 ```
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+
+const agent: IAgentRunner = new AnthropicAgent({
+  client: new Anthropic({
+    apiKey: required('ANTHROPIC_API_KEY'),
+  }),
+  model: required('ANTHROPIC_MODEL'),
+  mcpTools,
+  log,
+});
+```
+
+  </TabItem>
+</Tabs>
 
 <!-- local-tool -->
 
-Tools are declared as `RunnableToolFunction`s — the OpenAI SDK runs each tool's `function` callback during the tool loop. The callback pushes the card into a per-turn bucket the handler inspects after the run completes, and returns a short placeholder string.
+Keep tool behavior independent of the model provider. The clarification tool validates its input, creates the card, and returns text that can be sent back to either model:
 
 ```typescript
-import type { RunnableToolFunction } from 'openai/lib/RunnableFunction';
-import { AdaptiveCard, ChoiceSetInput, ExecuteAction, SubmitData, TextBlock } from '@microsoft/teams.cards';
-
-type ClarificationArgs = { question: string; options: string[] };
-
-export const CLARIFICATION_VERB = 'clarification';
-export const CLARIFICATION_INPUT_ID = 'clarificationChoice';
-
-function buildClarificationTool(pendingCards: AdaptiveCard[]): RunnableToolFunction<ClarificationArgs> {
-  return {
-    type: 'function',
-    function: {
-      name: 'request_clarification',
-      description: 'Show an Adaptive Card asking the user to clarify their request when ambiguous.',
-      parameters: {
-        type: 'object',
-        properties: {
-          question: { type: 'string', description: 'The clarification question to ask the user.' },
-          options: {
-            type: 'array',
-            items: { type: 'string' },
-            description: '2-4 candidate interpretations the user can pick between.',
-          },
-        },
-        required: ['question', 'options'],
-        additionalProperties: false,
-      },
-      function: async (args: ClarificationArgs) => {
-        pendingCards.push(buildClarificationCard(args));
-        return 'Clarification card attached.';
-      },
-      parse: (raw: string) => JSON.parse(raw) as ClarificationArgs,
+export const CLARIFICATION_TOOL_SCHEMA = {
+  type: 'object',
+  properties: {
+    question: { type: 'string' },
+    options: {
+      type: 'array',
+      items: { type: 'string' },
     },
-  };
+  },
+  required: ['question', 'options'],
+  additionalProperties: false,
+};
+
+async function executeClarificationTool(
+  input: unknown,
+  pendingCards: AdaptiveCard[]
+): Promise<string> {
+  if (!isClarificationArgs(input)) {
+    throw new Error('request_clarification requires a question and 2-4 options.');
+  }
+  pendingCards.push(buildClarificationCard(input));
+  return 'Clarification card attached.';
 }
 
-function buildClarificationCard(args: ClarificationArgs): AdaptiveCard {
-  return new AdaptiveCard(
-    new TextBlock(args.question, { weight: 'Bolder', size: 'Medium', wrap: true }),
-    new ChoiceSetInput(...args.options.map((opt) => ({ title: opt, value: opt })))
-      .withId(CLARIFICATION_INPUT_ID)
-      .withIsRequired(true)
-  ).withActions(
-    new ExecuteAction({ title: 'Submit' })
-      .withData(new SubmitData(CLARIFICATION_VERB))
-      .withAssociatedInputs('auto')
+function isClarificationArgs(value: unknown): value is ClarificationArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const input = value as Record<string, unknown>;
+  return (
+    typeof input.question === 'string' &&
+    Array.isArray(input.options) &&
+    input.options.length >= 2 &&
+    input.options.length <= 4 &&
+    input.options.every((option) => typeof option === 'string')
   );
 }
 ```
 
-See [clarification cards](./teams-enhancements#clarification-cards) for how the user's choice flows back in.
+Adapt the same schema at the provider boundary:
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI">
+
+```typescript
+const tool: RunnableToolFunction<ClarificationArgs> = {
+  type: 'function',
+  function: {
+    name: 'request_clarification',
+    description: 'Ask the user to clarify an ambiguous request.',
+    parameters: CLARIFICATION_TOOL_SCHEMA,
+    function: (input) => executeClarificationTool(input, pendingCards),
+    parse: (raw) => JSON.parse(raw) as ClarificationArgs,
+  },
+};
+```
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```typescript
+const tool: Anthropic.Tool = {
+  name: 'request_clarification',
+  description: 'Ask the user to clarify an ambiguous request.',
+  input_schema: {
+    ...CLARIFICATION_TOOL_SCHEMA,
+    type: 'object',
+  },
+};
+```
+
+When Claude returns this tool name, call `executeClarificationTool(toolUse.input, pendingCards)`. The runtime guard validates Anthropic's `unknown` input before the card is built.
+
+  </TabItem>
+</Tabs>
 
 <!-- mcp-tools -->
 
-Connect to the MCP server once at startup, list its tools, and wrap each one as a `RunnableToolFunction`. The callback invokes the server and returns the result text to the model.
+Connect to the MCP server once, retain its provider-neutral definitions, and centralize execution:
 
 ```typescript
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import type { RunnableToolFunction } from 'openai/lib/RunnableFunction';
-
 const client = new Client({ name: 'ai-mcp-sample', version: '0.0.0' });
-await client.connect(new StreamableHTTPClientTransport(new URL('https://learn.microsoft.com/api/mcp')));
+await client.connect(
+  new StreamableHTTPClientTransport(new URL('https://learn.microsoft.com/api/mcp'))
+);
 
-const { tools } = await client.listTools();
-
-const mcpTools: RunnableToolFunction<Record<string, unknown>>[] = tools.map((tool) => ({
-  type: 'function',
-  function: {
-    name: tool.name,
-    description: tool.description ?? '',
-    parameters: (tool.inputSchema as Record<string, unknown>) ?? { type: 'object' },
-    function: async (args: Record<string, unknown>) => {
-      const result = await client.callTool({ name: tool.name, arguments: args });
-      return stringifyResult(result.content);
-    },
-    parse: (raw: string) => JSON.parse(raw) as Record<string, unknown>,
-  },
+const listed = await client.listTools();
+const tools = listed.tools.map((tool) => ({
+  name: tool.name,
+  description: tool.description ?? '',
+  parameters: tool.inputSchema,
 }));
+
+async function executeMcpTool(name: string, input: Record<string, unknown>): Promise<string> {
+  const result = await client.callTool({ name, arguments: input });
+  const text = stringifyResult(result.content);
+  citations.tryExtract(text);
+  return text;
+}
 ```
+
+For Azure OpenAI, expose each schema as `function.parameters`. For Anthropic, expose it as `input_schema`. Both adapters call the same `executeMcpTool` function.
 
 <!-- running -->
 
-`runTools()` sends the request with your tool definitions, auto-invokes any tool the model calls, re-prompts with the result, and repeats until the model produces final text. `content` events fire for each text delta — forward them straight to the Teams stream.
+The Teams handler is identical for both providers:
 
 ```typescript
-const runner = client.chat.completions.runTools({
-  model: deployment,
-  messages: history,
-  tools: [clarificationTool, ...mcpTools],
-  stream: true,
+app.on('message', async ({ activity, stream }) => {
+  const userText = activity.stripMentionsText().text ?? '';
+  const result = await agent.run(activity.conversation.id, userText, stream);
+  shipResult(result, stream, activity.from.id);
 });
-
-runner.on('content', (delta: string) => stream.emit(delta));
-await runner.done();
 ```
+
+Each provider calls `stream.emit(delta)` as text arrives. The handler receives a common `AgentRunResult` containing final text, citations, follow-up prompts, and any pending clarification card.
 
 <!-- memory -->
 
-Keep one `ChatCompletionMessageParam[]` per Teams conversation. After each run, sync the runner's view — it includes the system, user, and every tool-call / tool-result / assistant message added during the loop — back into your map so the next turn sees the full prior context.
+Each provider keeps its native message format in a per-conversation map and serializes concurrent turns for the same conversation.
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI">
 
 ```typescript
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
-
 const histories = new Map<string, ChatCompletionMessageParam[]>();
 
-function getOrCreateHistory(convId: string): ChatCompletionMessageParam[] {
-  let history = histories.get(convId);
-  if (!history) {
-    history = [{ role: 'system', content: SYSTEM_PROMPT }];
-    histories.set(convId, history);
-  }
-  return history;
-}
-
-// after runner.done():
-const ran = runner.messages as ChatCompletionMessageParam[];
-history.splice(0, history.length, ...ran);
+const runner = client.chat.completions.runTools({
+  model: deployment,
+  messages: history,
+  tools,
+  stream: true,
+});
+runner.on('content', (delta) => stream.emit(delta));
+await runner.done();
+history.splice(0, history.length, ...runner.messages);
 ```
+
+`runTools()` appends assistant tool calls and tool results while it executes the loop.
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```typescript
+const histories = new Map<string, Anthropic.MessageParam[]>();
+
+const modelStream = client.messages
+  .stream({
+    model,
+    max_tokens: 4096,
+    system: SYSTEM_PROMPT,
+    messages: history,
+    tools,
+  })
+  .on('text', (delta) => stream.emit(delta));
+
+const response = await modelStream.finalMessage();
+history.push({ role: 'assistant', content: toAssistantContent(response.content) });
+```
+
+If the response contains `tool_use` blocks, execute them, append matching `tool_result` blocks as a user message, and call `messages.stream()` again. Stop when the response contains no client tool calls.
+
+  </TabItem>
+</Tabs>
 
 <!-- citations -->
 
-The extraction lives in a small `CitationCollector`. Each MCP tool callback feeds its raw result into `tryExtract`, which parses the search payload and assigns every source a stable 1-based position. The same collector instance is captured by every tool call on a turn.
+The extraction lives in a small `CitationCollector`. Every MCP execution feeds its raw result into `tryExtract`, which parses search payloads and assigns each source a stable 1-based position.
 
 ```typescript
-type CitationEntry = { position: number; url: string; title: string; snippet: string };
+type CitationEntry = {
+  position: number;
+  url: string;
+  title: string;
+  snippet: string;
+};
 
 export class CitationCollector {
   private readonly entries = new Map<string, CitationEntry>();
 
   tryExtract(result: string): void {
-    let doc: any;
+    let doc: unknown;
     try {
       doc = JSON.parse(result);
     } catch {
-      return; // non-JSON tool results are ignored
+      return;
     }
-    for (const item of doc?.results ?? []) {
+
+    for (const item of findResults(doc) ?? []) {
       const url = item.contentUrl ?? item.link;
       if (!url || this.entries.has(url)) continue;
-      const snippet = (item.content ?? item.description ?? '').slice(0, 160);
       this.entries.set(url, {
         position: this.entries.size + 1,
         url,
         title: item.title ?? '',
-        snippet,
+        snippet: (item.content ?? item.description ?? '').slice(0, 160),
       });
     }
   }
 }
 ```
 
-To wire it in, call `citations.tryExtract(text)` inside each MCP tool's callback before returning the result. The collected entries are attached to the final reply in [Enhancing the Teams Experience](./teams-enhancements#citations).
+The collected entries are attached to the final reply in [Enhancing the Teams Experience](./teams-enhancements#citations).

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/build-agent/typescript.incl.md
@@ -67,6 +67,8 @@ export const CLARIFICATION_TOOL_SCHEMA = {
     options: {
       type: 'array',
       items: { type: 'string' },
+      minItems: 2,
+      maxItems: 4,
     },
   },
   required: ['question', 'options'],
@@ -78,7 +80,7 @@ async function executeClarificationTool(
   pendingCards: AdaptiveCard[]
 ): Promise<string> {
   if (!isClarificationArgs(input)) {
-    throw new Error('request_clarification requires a question and 2-4 options.');
+    return 'request_clarification requires a question and 2-4 options.';
   }
   pendingCards.push(buildClarificationCard(input));
   return 'Clarification card attached.';
@@ -93,6 +95,21 @@ function isClarificationArgs(value: unknown): value is ClarificationArgs {
     input.options.length >= 2 &&
     input.options.length <= 4 &&
     input.options.every((option) => typeof option === 'string')
+  );
+}
+
+function buildClarificationCard(args: ClarificationArgs): AdaptiveCard {
+  return new AdaptiveCard(
+    new TextBlock(args.question, { weight: 'Bolder', size: 'Medium', wrap: true }),
+    new ChoiceSetInput(
+      ...args.options.map((option) => ({ title: option, value: option }))
+    )
+      .withId(CLARIFICATION_INPUT_ID)
+      .withIsRequired(true)
+  ).withActions(
+    new ExecuteAction({ title: 'Submit' })
+      .withData(new SubmitData(CLARIFICATION_VERB))
+      .withAssociatedInputs('auto')
   );
 }
 ```

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/csharp.incl.md
@@ -1,6 +1,7 @@
 <!-- samples -->
 
-- **[Build an agent in Teams](./build-agent)** — sample-backed by [`core/samples/ExtAIBot`](https://github.com/microsoft/teams.net/tree/main/core/samples/ExtAIBot), combining SDK 2.1 + Azure OpenAI + MCP tools.
+- **[AI agent quickstart](./agent-quickstart)** — run `ExtAIBot` with Azure OpenAI or Anthropic Claude by changing configuration.
+- **[Build an agent in Teams](./build-agent)** — use the provider-neutral `IChatClient` boundary with Teams streaming and MCP tools.
 - **[Enhancing the Teams Experience](./teams-enhancements)** — same `ExtAIBot` sample shows streaming, AI-generated metadata, adaptive-card clarification, suggested follow-ups, citations, and feedback handling.
-- **[Exposing Teams to AI Agents (MCP)](./mcp-server)** — sample-backed by [`core/samples/McpServer`](https://github.com/microsoft/teams.net/tree/main/core/samples/McpServer), using `AddMcpServer()` and `[McpServerTool]`.
-- **[Bot-to-Bot with A2A](./a2a)** — sample-backed by [`core/samples/A2ABot`](https://github.com/microsoft/teams.net/tree/main/core/samples/A2ABot), wiring A2A + Teams proactive handoff.
+- **[Exposing Teams to AI Agents (MCP)](./mcp-server)** — sample-backed by [`samples/McpServer`](https://github.com/microsoft/teams.net/tree/main/samples/McpServer), using `AddMcpServer()` and `[McpServerTool]`.
+- **[Bot-to-Bot with A2A](./a2a)** — sample-backed by [`samples/A2ABot`](https://github.com/microsoft/teams.net/tree/main/samples/A2ABot), wiring A2A + Teams proactive handoff.

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/mcp-server/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/mcp-server/csharp.incl.md
@@ -1,6 +1,6 @@
 <!-- intro -->
 
-This guide is based on [`core/samples/McpServer`](https://github.com/microsoft/teams.net/tree/main/core/samples/McpServer): a single ASP.NET process hosts both Teams (`/api/messages`) and MCP (`/mcp`).
+This guide is based on [`samples/McpServer`](https://github.com/microsoft/teams.net/tree/main/samples/McpServer): a single ASP.NET process hosts both Teams (`/api/messages`) and MCP (`/mcp`).
 
 <!-- define-tool -->
 

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/python.incl.md
@@ -1,6 +1,7 @@
 <!-- samples -->
 
-- **[Build an agent in Teams](./build-agent)** — create an agent with [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/), add a local clarification tool and remote MCP tool servers, stream responses into Teams, and preserve conversation history across turns.
+- **[AI agent quickstart](./agent-quickstart)** — run the same Agent Framework app with Azure OpenAI or Anthropic Claude by changing environment variables.
+- **[Build an agent in Teams](./build-agent)** — use Microsoft Agent Framework as the agent boundary, add local and MCP tools, stream responses into Teams, and preserve conversation history.
 - **[Enhancing the Teams Experience](./teams-enhancements)** — build on the base integration with richer conversational features: clarification cards, suggested follow-up prompts, inline citations, and structured feedback handling.
 - **[Exposing Teams to AI Agents (MCP)](./mcp-server)** — turn your bot into an [MCP](https://modelcontextprotocol.io/introduction) server so external agents can reach real users through Teams chat with tools like `find_user`, `notify`, `ask`, and `request_approval`. Useful for human-in-the-loop workflows.
 - **[Bot-to-Bot with A2A](./a2a)** — two Teams bots, each backed by its own agent, hand users off to each other over the [Agent2Agent](https://a2a-protocol.org/) protocol, opening a proactive chat with the user so the conversation continues seamlessly.

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/teams-enhancements/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/teams-enhancements/csharp.incl.md
@@ -26,6 +26,7 @@ await writer.FinalizeResponseAsync(msg, cancellationToken);
 <!-- feedback -->
 
 Enable built-in thumbs up/down controls on the reply and surface a custom feedback form when users respond.
+
 ```csharp
 MessageActivityInput reply = new MessageActivityInput().AddAIGenerated().AddFeedback(FeedbackTypes.Custom);
 await writer.FinalizeResponseAsync(msg, cancellationToken);

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/teams-enhancements/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/teams-enhancements/python.incl.md
@@ -91,6 +91,8 @@ async def _generate_follow_ups(last_user_text: str, last_ai_text: str) -> list[C
     return [CardAction(type=CardActionType.IM_BACK, title=q, value=q) for q in data.get("followUps", [])[:2]]
 ```
 
+The checked-in sample uses the selected Agent Framework client for this optional call, so Azure OpenAI and Anthropic follow the same path. You can also omit follow-up generation entirely; the Teams suggested-actions code below is provider-neutral.
+
 Attach the generated prompts to the reply with `with_suggested_actions`:
 
 ```python

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/teams-enhancements/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/teams-enhancements/typescript.incl.md
@@ -1,10 +1,14 @@
 <!-- streaming -->
 
 ```typescript
-const runner = client.chat.completions.runTools({ model, messages: history, tools, stream: true });
-runner.on('content', (delta: string) => stream.emit(delta));
-await runner.done();
+app.on('message', async ({ activity, stream }) => {
+  const userText = activity.stripMentionsText().text ?? '';
+  const result = await agent.run(activity.conversation.id, userText, stream);
+  shipResult(result, stream, activity.from.id);
+});
 ```
+
+The selected provider implementation emits text chunks through the same `IStreamer`.
 
 <!-- ai-label -->
 
@@ -31,7 +35,9 @@ function shipResult(result: AgentRunResult, stream: IStreamer, recipientId: stri
   if (result.pendingCard) {
     // Clarification card — discard any streamed text, then emit card-only.
     stream.clearText();
-    stream.emit(new MessageActivityInput().addCard('adaptive', result.pendingCard).addAiGenerated());
+    stream.emit(
+      new MessageActivityInput().addCard('adaptive', result.pendingCard).addAiGenerated()
+    );
     return;
   }
   // normal reply: attach follow-ups, citations, feedback (below).
@@ -43,7 +49,10 @@ The user's choice is captured by a card-action handler and fed straight back int
 ```typescript
 app.on('card.action.clarification', async ({ activity, stream }) => {
   const data = (activity.value.action.data ?? {}) as Record<string, unknown>;
-  const choice = typeof data[CLARIFICATION_INPUT_ID] === 'string' ? (data[CLARIFICATION_INPUT_ID] as string) : '';
+  const choice =
+    typeof data[CLARIFICATION_INPUT_ID] === 'string'
+      ? (data[CLARIFICATION_INPUT_ID] as string)
+      : '';
   if (choice) {
     const result = await agent.run(activity.conversation.id, choice, stream);
     shipResult(result, stream, activity.from.id);
@@ -61,11 +70,29 @@ const FOLLOW_UPS_PROMPT =
 
 const FOLLOW_UPS_SCHEMA = {
   type: 'object',
-  properties: { prompt1: { type: 'string' }, prompt2: { type: 'string' } },
+  properties: {
+    prompt1: { type: 'string' },
+    prompt2: { type: 'string' },
+  },
   required: ['prompt1', 'prompt2'],
   additionalProperties: false,
 } as const;
 
+function parseFollowUps(raw: string): string[] {
+  const parsed = JSON.parse(raw) as {
+    prompt1?: unknown;
+    prompt2?: unknown;
+  };
+  return [parsed.prompt1, parsed.prompt2].filter(
+    (prompt): prompt is string => typeof prompt === 'string' && prompt.length > 0
+  );
+}
+```
+
+<Tabs groupId="ai-provider">
+  <TabItem value="azure-openai" label="Azure OpenAI">
+
+```typescript
 async function generateFollowUps(history: ChatCompletionMessageParam[]): Promise<string[]> {
   try {
     const completion = await client.chat.completions.create({
@@ -73,16 +100,49 @@ async function generateFollowUps(history: ChatCompletionMessageParam[]): Promise
       messages: [...history, { role: 'system', content: FOLLOW_UPS_PROMPT }],
       response_format: {
         type: 'json_schema',
-        json_schema: { name: 'follow_ups', strict: true, schema: FOLLOW_UPS_SCHEMA },
+        json_schema: {
+          name: 'follow_ups',
+          strict: true,
+          schema: FOLLOW_UPS_SCHEMA,
+        },
       },
     });
-    const parsed = JSON.parse(completion.choices[0]?.message?.content ?? '{}');
-    return [parsed.prompt1, parsed.prompt2].filter((s): s is string => typeof s === 'string' && s.length > 0);
-  } catch {
-    return []; // degrade silently — the main reply still ships
+    return parseFollowUps(completion.choices[0]?.message?.content ?? '{}');
+  } catch (error) {
+    log.warn(`Follow-up generation failed: ${String(error)}`);
+    return [];
   }
 }
 ```
+
+  </TabItem>
+  <TabItem value="anthropic" label="Anthropic Claude">
+
+```typescript
+async function generateFollowUps(history: Anthropic.MessageParam[]): Promise<string[]> {
+  try {
+    const response = await client.messages.create({
+      model,
+      max_tokens: 200,
+      system: 'Return valid JSON only with string properties "prompt1" and "prompt2".',
+      messages: [...history, { role: 'user', content: FOLLOW_UPS_PROMPT }],
+    });
+    const raw = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map((block) => block.text)
+      .join('');
+    return parseFollowUps(raw.match(/\{[\s\S]*\}/)?.[0] ?? '{}');
+  } catch (error) {
+    log.warn(`Follow-up generation failed: ${String(error)}`);
+    return [];
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+Treat follow-up generation as optional. If parsing or the extra model call fails, return an empty array so the main response still ships.
 
 Attach the generated prompts to the reply with `withSuggestedActions`:
 

--- a/teams.md/src/components/include/in-depth-guides/ai-integrations/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai-integrations/typescript.incl.md
@@ -1,6 +1,7 @@
 <!-- samples -->
 
-- **[Build an agent in Teams](./build-agent)** — create an agent with the [OpenAI SDK](https://github.com/openai/openai-node) and Azure OpenAI, add a local clarification tool and remote MCP tool servers, stream responses into Teams, and preserve conversation history across turns.
+- **[AI agent quickstart](./agent-quickstart)** — run the same Teams agent with Azure OpenAI or Anthropic Claude by changing environment variables.
+- **[Build an agent in Teams](./build-agent)** — create an agent with Azure OpenAI or Anthropic Claude, add a local clarification tool and remote MCP tool servers, stream responses into Teams, and preserve conversation history across turns.
 - **[Enhancing the Teams Experience](./teams-enhancements)** — build on the base integration with richer conversational features: clarification cards, suggested follow-up prompts, inline citations, and structured feedback handling.
 - **[Exposing Teams to AI Agents (MCP)](./mcp-server)** — turn your bot into an [MCP](https://modelcontextprotocol.io/introduction) server so external agents can reach real users through Teams chat with tools like `find_user`, `notify`, `ask`, and `request_approval`. Useful for human-in-the-loop workflows.
 - **[Bot-to-Bot with A2A](./a2a)** — two Teams bots, each backed by its own agent, hand users off to each other over the [Agent2Agent](https://a2a-protocol.org/) protocol, opening a proactive chat with the user so the conversation continues seamlessly.

--- a/teams.md/src/pages/templates/in-depth-guides/ai-integrations/README.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai-integrations/README.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: AI Integrations
-summary: Plug AI agents into Teams apps — bring your own framework or the OpenAI SDK, add MCP tools and servers, and coordinate bots with A2A.
+summary: Plug AI agents into Teams apps — choose Azure OpenAI or Anthropic Claude, add MCP tools and servers, and coordinate bots with A2A.
 languages: ['python', 'typescript', 'csharp']
 ---
 
@@ -12,7 +12,7 @@ import Language from '@site/src/components/Language';
 <Language language="typescript">
 
 :::warning[Our AI libraries are deprecated]
-The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of dedicated AI frameworks. Use the pattern shown in these guides instead: bring the OpenAI SDK (or any framework you like), and wire MCP and A2A directly into your Teams app.
+The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of provider SDKs and dedicated AI frameworks. Bring the model or agent runtime that fits your application; Teams SDK remains the channel, streaming, and presentation layer.
 :::
 
 </Language>
@@ -20,11 +20,13 @@ The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` 
 <Language language="csharp">
 
 :::warning[SDK 2.0 AI libraries are deprecated]
-For .NET, AI-specific libraries and older patterns from SDK 2.0 are deprecated. In SDK 2.1, use `Microsoft.Teams.Apps` as the Teams transport/runtime layer and integrate your preferred AI stack (for example Microsoft Agent Framework, OpenAI SDK, MCP, and A2A) in your handlers.
+For .NET, AI-specific libraries and older patterns from SDK 2.0 are deprecated. In SDK 2.1, use `Microsoft.Teams.Apps` as the Teams transport/runtime layer and integrate your preferred `IChatClient`, agent framework, MCP, and A2A libraries in your handlers.
 :::
 
 </Language>
 
 Microsoft Teams SDK provides the platform and conversational interface for your app while remaining agnostic to the underlying intelligence. You can choose any AI framework, model, or protocol that suits your scenario and integrate it into your message handlers. The samples below walk through a few common ways to do that, from a single bot reasoning with an agent to multiple bots collaborating with each other.
+
+Start with the [AI agent quickstart](./agent-quickstart) to run the same Teams agent with Azure OpenAI or Anthropic Claude.
 
 <LanguageInclude section="samples" />

--- a/teams.md/src/pages/templates/in-depth-guides/ai-integrations/a2a.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai-integrations/a2a.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Bot-to-Bot with A2A
 title: Bot-to-Bot with A2A
 summary: Hand a user off between two Teams bots over the Agent2Agent protocol — the receiving bot opens a proactive 1:1 and greets the user with full context so the conversation continues seamlessly.
@@ -14,7 +14,7 @@ import Language from '@site/src/components/Language';
 <Language language="typescript">
 
 :::warning[Our AI libraries are deprecated]
-The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of dedicated AI frameworks. Use the pattern shown in these guides instead: bring the OpenAI SDK (or any framework you like), and wire MCP and A2A directly into your Teams app.
+The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of provider SDKs and dedicated AI frameworks. Bring the model or agent runtime that fits your application; Teams SDK remains the channel, streaming, and presentation layer.
 :::
 
 </Language>
@@ -35,11 +35,11 @@ This guide walks through a **handoff** between two Teams bots, **Alice** and **B
 
 ## Advertising capabilities with an Agent Card
 
-Every A2A server publishes an `AgentCard` — a small machine-readable document describing who the agent is and what it can do. Peers fetch this card to learn about each other; their LLMs then read the `description` field to decide *when* to hand off a user.
+Every A2A server publishes an `AgentCard` — a small machine-readable document describing who the agent is and what it can do. Peers fetch this card to learn about each other; their LLMs then read the `description` field to decide _when_ to hand off a user.
 
 <LanguageInclude section="agent-card" />
 
-The `description` is the most important knob in this sample — it's the natural-language summary another bot's LLM uses to decide whether *this* bot is the right peer for a given user. Tweak it to match the persona and expertise you want each bot to advertise.
+The `description` is the most important knob in this sample — it's the natural-language summary another bot's LLM uses to decide whether _this_ bot is the right peer for a given user. Tweak it to match the persona and expertise you want each bot to advertise.
 
 ## The handoff message contract
 
@@ -53,7 +53,7 @@ Routing is not a hard-coded rule — the LLM decides. Each bot exposes a single 
 
 <LanguageInclude section="handoff-tool" />
 
-The identity needed to build the handoff is captured from the inbound Teams activity and stashed for the duration of the turn, so the tool callback can reach it without threading it through every call. A handoff *greeting* runs with no identity set — the tool guards against that to prevent a ping-pong.
+The identity needed to build the handoff is captured from the inbound Teams activity and stashed for the duration of the turn, so the tool callback can reach it without threading it through every call. A handoff _greeting_ runs with no identity set — the tool guards against that to prevent a ping-pong.
 
 ## Sending a handoff over A2A
 

--- a/teams.md/src/pages/templates/in-depth-guides/ai-integrations/agent-quickstart.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai-integrations/agent-quickstart.mdx
@@ -1,0 +1,60 @@
+---
+sidebar_position: 1
+sidebar_label: Agent quickstart
+title: AI agent quickstart
+summary: Run the same Teams agent with either Azure OpenAI or Anthropic Claude, including streaming, MCP tools, citations, cards, and follow-up prompts.
+languages: ['typescript', 'csharp', 'python']
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# AI agent quickstart
+
+Run a working Teams agent and choose the model provider through configuration. The Teams application code stays the same: Teams SDK handles activities, streaming, cards, citations, and feedback while the provider implementation handles model messages and tool calls.
+
+## Prerequisites
+
+<LanguageInclude section="prerequisites" />
+
+## Get the sample
+
+<LanguageInclude section="get-sample" />
+
+## Register the Teams app
+
+Expose the local `/api/messages` endpoint with a development tunnel, then create the Teams app:
+
+<LanguageInclude section="register-app" />
+
+The CLI writes the Teams credentials to the sample's `.env` file.
+
+## Choose a model provider
+
+<LanguageInclude section="provider-config" />
+
+## Run the agent
+
+<LanguageInclude section="run-sample" />
+
+At startup, the sample connects to the Microsoft Learn MCP server before listening for Teams activities.
+
+## Try it in Teams
+
+Install the app using the link returned by `teams app create`, then try:
+
+- `Tell me about streaming` to display a clarification card.
+- `How do I stream in the Teams SDK?` to search Microsoft Learn and return citations.
+- `How do I list users with Microsoft Graph?` to invoke an MCP tool and return suggested follow-up prompts.
+
+## Keep Teams code provider-neutral
+
+<LanguageInclude section="provider-boundary" />
+
+The provider implementations differ internally, but both return the same result shape to the Teams handlers.
+
+## Next steps
+
+- [Build an agent in Teams](./build-agent) explains the tool loops, memory, and citation flow.
+- [Enhance the Teams Experience](./teams-enhancements) covers clarification cards, feedback, citations, and follow-up prompts.
+- <LanguageInclude section="sample-link" />

--- a/teams.md/src/pages/templates/in-depth-guides/ai-integrations/build-agent.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai-integrations/build-agent.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: Build an agent in Teams
 title: Build an agent in Teams
 summary: Create an agent, add a local clarification tool and remote MCP tool servers, stream responses into Teams, and preserve conversation history across turns.
@@ -8,13 +8,15 @@ languages: ['python', 'typescript', 'csharp']
 
 import ClarificationCardImgUrl from '@site/static/screenshots/clarification.png';
 import Language from '@site/src/components/Language';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Build an agent in Teams
 
 <Language language="typescript">
 
 :::warning[Our AI libraries are deprecated]
-The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of dedicated AI frameworks. Use the pattern shown in these guides instead: bring the OpenAI SDK (or any framework you like), and wire MCP and A2A directly into your Teams app.
+The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of provider SDKs and dedicated AI frameworks. Bring the model or agent runtime that fits your application; Teams SDK remains the channel, streaming, and presentation layer.
 :::
 
 </Language>

--- a/teams.md/src/pages/templates/in-depth-guides/ai-integrations/mcp-server.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai-integrations/mcp-server.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Exposing Teams to AI Agents (MCP)
 title: Exposing Teams to AI Agents (MCP)
 summary: Turn your Teams bot into an MCP server so external AI agents can reach real users — finding them by name, sending notifications, asking questions, and requesting approvals through chat.
@@ -14,7 +14,7 @@ import Language from '@site/src/components/Language';
 <Language language="typescript">
 
 :::warning[Our AI libraries are deprecated]
-The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of dedicated AI frameworks. Use the pattern shown in these guides instead: bring the OpenAI SDK (or any framework you like), and wire MCP and A2A directly into your Teams app.
+The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of provider SDKs and dedicated AI frameworks. Bring the model or agent runtime that fits your application; Teams SDK remains the channel, streaming, and presentation layer.
 :::
 
 </Language>

--- a/teams.md/src/pages/templates/in-depth-guides/ai-integrations/teams-enhancements.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/ai-integrations/teams-enhancements.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: Teams Enhancements
 title: Teams Enhancements
 summary: Round out a Teams agent reply with streaming, the AI-generated label, custom feedback, clarification cards, dynamic follow-up prompts, and inline citations.
@@ -11,13 +11,15 @@ import SuggestedPromptsImgUrl from '@site/static/screenshots/suggested-prompts.g
 import CitationsImgUrl from '@site/static/screenshots/citations.gif';
 import ClarificationImgUrl from '@site/static/screenshots/clarification.gif';
 import Language from '@site/src/components/Language';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Enhance the Teams Experience
 
 <Language language="typescript">
 
 :::warning[Our AI libraries are deprecated]
-The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of dedicated AI frameworks. Use the pattern shown in these guides instead: bring the OpenAI SDK (or any framework you like), and wire MCP and A2A directly into your Teams app.
+The Teams SDK has deprecated its own AI libraries — the `@microsoft/teams.ai` packages (`ChatPrompt`, `Model`, and the older `@microsoft/teams.mcp` / `@microsoft/teams.a2a` plugins) — in favor of provider SDKs and dedicated AI frameworks. Bring the model or agent runtime that fits your application; Teams SDK remains the channel, streaming, and presentation layer.
 :::
 
 </Language>


### PR DESCRIPTION
## Summary
- add AI agent quickstarts for TypeScript, C#, and Python with Azure OpenAI and Anthropic Claude paths
- make provider boundaries explicit for the TypeScript runner, .NET `IChatClient`, and Python Agent Framework
- update AI integration, enhancements, MCP, A2A, and onboarding guidance to remove provider-biased or stale wording
- link AI from the main build quickstart

## Validated sample PRs
- TypeScript: https://github.com/microsoft/teams.ts/pull/726
- C#: https://github.com/microsoft/teams.net/pull/650
- Python: https://github.com/microsoft/teams.py/pull/559

## Validation
- `npm run generate:docs`
- `npm run build`
- verified all three generated AI quickstart routes return HTTP 200 and include Anthropic configuration

The build still reports the existing unrelated broken-anchor warnings in the TypeScript and Python BotBuilder migration integration pages.
