### PR TITLE
docs: remove preview markers for GA messaging features

### DIFF
--- a/teams.md/docs/main/teams/choosing-an-sdk.md
+++ b/teams.md/docs/main/teams/choosing-an-sdk.md
@@ -45,7 +45,7 @@ Everything in the cross-channel essentials above, **plus** the Teams-native surf
 |---|---|
 | @Mentions | Mention a specific user in a message; receive a `mention` activity when the bot is mentioned |
 | Reactions | Add / remove emoji reactions on messages |
-| Targeted (ephemeral) messages *(preview)* | Deliver a message to a specific user in a shared conversation; other participants don't see it |
+| Targeted (ephemeral) messages | Deliver a message to a specific user in a shared conversation; other participants don't see it |
 | Quoted replies | Parse incoming quoted-reply context; send replies that auto-quote the user's message or quote a specific message by ID |
 | Threaded replies | Reply to a specific message in a channel; channel reply chains |
 | Channel events | Channel created / renamed / deleted; team member changes |

--- a/teams.md/src/components/include/essentials/sending-messages/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/sending-messages/csharp.incl.md
@@ -169,18 +169,6 @@ teams.OnMessage(async (context, cancellationToken) =>
   </TabItem>
 </Tabs>
 
-<!-- targeted-preview-note -->
-
-:::tip[.NET]
-In .NET, targeted message APIs are marked with `[Experimental("ExperimentalTeamsTargeted")]` and will produce a compiler error until you opt in. Suppress the diagnostic inline with `#pragma warning disable ExperimentalTeamsTargeted` or project-wide in your `.csproj`:
-
-```xml
-<PropertyGroup>
-  <NoWarn>$(NoWarn);ExperimentalTeamsTargeted</NoWarn>
-</PropertyGroup>
-```
-:::
-
 <!-- prompt-preview-proactive-example -->
 
 <Tabs groupId="csharp-sdk-version" defaultValue="core">

--- a/teams.md/src/components/include/essentials/sending-messages/python.incl.md
+++ b/teams.md/src/components/include/essentials/sending-messages/python.incl.md
@@ -64,9 +64,6 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     )
 ```
 
-<!-- targeted-preview-note -->
-N/A
-
 <!-- prompt-preview-proactive-example -->
 
 ```python

--- a/teams.md/src/components/include/essentials/sending-messages/typescript.incl.md
+++ b/teams.md/src/components/include/essentials/sending-messages/typescript.incl.md
@@ -59,9 +59,6 @@ app.on('message', async ({ send, activity }) => {
 });
 ```
 
-<!-- targeted-preview-note -->
-N/A
-
 <!-- prompt-preview-proactive-example -->
 
 ```typescript

--- a/teams.md/src/pages/templates/essentials/on-activity/README.mdx
+++ b/teams.md/src/pages/templates/essentials/on-activity/README.mdx
@@ -38,10 +38,6 @@ Here is an example of a basic message handler:
 
 ## Slash Commands
 
-:::info[Preview]
-Slash commands are available in public preview. General availability is planned for a future release.
-:::
-
 Slash commands are manifest-declared commands users run from the compose box. To enable slash commands, set `supportsTargetedMessages: true` in your app manifest under the `bots` section. You can opt in with an explicit command list by declaring specific commands using `commandLists` with `triggers: ["slash"]`, which Teams shows in the slash menu when a user types `/`. Without a command list, users can still invoke your agent via `/agent-name` and provide free-form input.
 
 ```json

--- a/teams.md/src/pages/templates/essentials/sending-messages/README.mdx
+++ b/teams.md/src/pages/templates/essentials/sending-messages/README.mdx
@@ -45,17 +45,11 @@ Sending a message at `@mentions` a user is as simple including the details of th
 
 ## Targeted Messages
 
-:::info[Preview]
-Targeted messages are available in public preview. General availability is planned for a future release.
-:::
-
 Targeted messages, also known as ephemeral messages, are delivered to a specific user in a shared conversation. From a single user's perspective, they appear as regular inline messages in a conversation. Other participants won't see these messages, making them useful for authentication flows, help or error responses, personal reminders, or sharing contextual information without cluttering the group conversation.
 
 To send a targeted message when responding to an incoming activity, use the <LanguageInclude section="targeted-method-name" /> method with the recipient account and set the targeting flag to true.
 
 <LanguageInclude section="targeted-send-example" />
-
-<LanguageInclude section="targeted-preview-note" />
 
 ### Prompt Preview
 

--- a/teams.md/src/pages/templates/essentials/sending-messages/proactive-messaging.mdx
+++ b/teams.md/src/pages/templates/essentials/sending-messages/proactive-messaging.mdx
@@ -23,10 +23,6 @@ In this example, you see how to get the <LanguageInclude section="conversation-i
 
 ## Targeted Proactive Messages
 
-:::info[Preview]
-Targeted messages are available in public preview. General availability is planned for a future release.
-:::
-
 Targeted messages, also known as ephemeral messages, are delivered to a specific user in a shared conversation. From a single user's perspective, they appear as regular inline messages in a conversation. Other participants won't see these messages.
 
 When sending targeted messages proactively, you must explicitly specify the recipient account.


### PR DESCRIPTION
## Summary

Slash commands and targeted messages are now generally available. This removes outdated preview and .NET experimental opt-in guidance so the feature status is consistent across the shared templates, language includes, and SDK comparison documentation.