### PR TITLE
docs: explain receiving inline images

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/csharp.incl.md
@@ -13,7 +13,8 @@ teams.OnMessage(async (context, cancellationToken) =>
 {
     TeamsAttachment? image = context.Activity.Attachments?.FirstOrDefault(
         attachment =>
-            attachment.ContentType.Value.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            attachment.ContentType is not null
+            && attachment.ContentType.Value.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
             && attachment.ContentUrl is not null);
 
     if (image?.ContentUrl is Uri contentUrl)

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/csharp.incl.md
@@ -1,0 +1,34 @@
+<!-- download-image -->
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Teams.Apps.Clients;
+using Microsoft.Teams.Apps.Schema;
+
+HttpClient imageClient = app.Services
+    .GetRequiredService<IHttpClientFactory>()
+    .CreateClient(nameof(ApiClient));
+
+teams.OnMessage(async (context, cancellationToken) =>
+{
+    TeamsAttachment? image = context.Activity.Attachments?.FirstOrDefault(
+        attachment =>
+            attachment.ContentType.Value.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            && attachment.ContentUrl is not null);
+
+    if (image?.ContentUrl is Uri contentUrl)
+    {
+        using HttpResponseMessage response = await imageClient.GetAsync(
+            contentUrl,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        // Read the response body as raw image bytes.
+        byte[] bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        string base64 = Convert.ToBase64String(bytes);
+
+        // Pass bytes or base64 to your image-processing or model client.
+    }
+});
+```

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/python.incl.md
@@ -1,0 +1,30 @@
+<!-- download-image -->
+
+```python
+import base64
+
+from microsoft_teams.api import MessageActivity
+from microsoft_teams.apps import ActivityContext
+
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    image = next(
+        (
+            attachment
+            for attachment in (ctx.activity.attachments or [])
+            if attachment.content_type
+            and attachment.content_type.startswith("image/")
+            and attachment.content_url
+        ),
+        None,
+    )
+
+    if image and image.content_url:
+        response = await app.api.http.get(image.content_url)
+        # The response content contains the image body as bytes.
+        image_bytes = response.content
+        image_base64 = base64.b64encode(image_bytes).decode("ascii")
+
+        # Pass image_bytes or image_base64 to your image-processing or model client.
+```

--- a/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/file-handling/receiving-inline-images/typescript.incl.md
@@ -1,0 +1,21 @@
+<!-- download-image -->
+
+```typescript
+app.on('message', async ({ activity }) => {
+  const image = activity.attachments?.find(
+    (attachment) => attachment.contentType?.startsWith('image/') && attachment.contentUrl
+  );
+
+  if (image?.contentUrl) {
+    // Request binary data so the client does not decode the image as text or JSON.
+    const res = await app.api.http.get<ArrayBuffer>(image.contentUrl, {
+      responseType: 'arraybuffer',
+    });
+
+    const bytes = Buffer.from(res.data);
+    const base64 = bytes.toString('base64');
+
+    // Pass `bytes` or `base64` to your image-processing or model client.
+  }
+});
+```

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
@@ -14,7 +14,7 @@ The high-level file API is being rolled out incrementally. Today it supports **r
 
 ## Files vs. attachments
 
-On incoming messages, <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> carries every non-text part: files the user attached, inline images, Adaptive Cards, `@mentions`, link previews, and other content the client or the platform adds. A **file** is the specific subset of attachments that describes a document the user attached, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
+In personal scope, <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> carries every non-text part: files the user attached, inline images, Adaptive Cards, `@mentions`, link previews, and other content the client or the platform adds. A **file** is the specific subset of attachments that describes a document the user attached, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
 
 The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor is the attached-file view over that raw array. It maps each attached file to a lazy handle you can download from, and skips everything else. The original <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> array is always available when you need the raw payload or a non-file attachment.
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/README.mdx
@@ -1,26 +1,29 @@
 ---
 sidebar_position: 1
-title: 'File Handling'
+title: 'File and Image Handling'
 suppressLanguageIncludeWarning: true
 ---
 
-# File Handling
+# File and Image Handling
 
-This section covers how your app receives files and reads their bytes.
+This section covers how your app receives files and inline images and reads their bytes.
 
 :::info[Preview]
-File handling is being rolled out incrementally. Today the SDK supports **receiving** files attached to messages in personal (1:1) chats via the TypeScript, Python, and C# SDKs.
+The high-level file API is being rolled out incrementally. Today it supports **receiving** files attached to messages in personal (1:1) chats via the TypeScript, Python, and C# SDKs. Inline images use the raw activity attachments instead.
 :::
 
 ## Files vs. attachments
 
-In personal scope, <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> carries every non-text part of a received message: files the user attached, but also Adaptive Cards, `@mentions`, link previews, and other content the client or the platform adds. A **file** is the specific subset of attachments that describes a document the user attached, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
+On incoming messages, <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> carries every non-text part: files the user attached, inline images, Adaptive Cards, `@mentions`, link previews, and other content the client or the platform adds. A **file** is the specific subset of attachments that describes a document the user attached, one whose <LanguageInclude content={{"typescript": "`contentType`", "python": "`content_type`", "csharp": "`ContentType`"}} /> is `file.download.info`.
 
 The <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} /> accessor is the attached-file view over that raw array. It maps each attached file to a lazy handle you can download from, and skips everything else. The original <LanguageInclude content={{"typescript": "`activity.attachments`", "python": "`activity.attachments`", "csharp": "`Activity.Attachments`"}} /> array is always available when you need the raw payload or a non-file attachment.
+
+An **inline image** is an image attachment with an authenticated download URL, commonly paired with an HTML attachment that describes where the image appeared in the composed message. Inline images are not surfaced by the high-level file API.
 
 ## In this section
 
 - **[Receiving Files](./receiving-files)** — read files a user attaches to a message, stream or download their bytes, and handle unsupported scopes and expired links.
+- **[Receiving Inline Images](./receiving-inline-images)** — identify images pasted into a message and download their bytes with the authenticated HTTP client.
 
 ## Resources
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-files.mdx
@@ -92,7 +92,7 @@ Every file the accessor returns retains its original wire attachment on <Languag
 
 <LanguageInclude section="raw-attachment" />
 
-Attachments that are **not** files (Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> and therefore have no <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} />. Reach those directly through <LanguageInclude content={{"typescript": "`ctx.activity.attachments`", "python": "`ctx.activity.attachments`", "csharp": "`context.Activity.Attachments`"}} />.
+Attachments that are **not** files (inline images, Adaptive Cards, mentions, link previews), and malformed file entries the accessor skips, are not returned by <LanguageInclude content={{"typescript": "`list()`", "python": "`list()`", "csharp": "`ListAsync()`"}} /> and therefore have no <LanguageInclude content={{"typescript": "`IIncomingFile`", "python": "`IncomingFile`", "csharp": "`IncomingFile`"}} />. Reach those directly through <LanguageInclude content={{"typescript": "`ctx.activity.attachments`", "python": "`ctx.activity.attachments`", "csharp": "`context.Activity.Attachments`"}} />. For image attachments, see [Receiving Inline Images](./receiving-inline-images).
 
 ## Conversation scope support
 

--- a/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-inline-images.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/file-handling/receiving-inline-images.mdx
@@ -1,0 +1,45 @@
+---
+sidebar_position: 3
+title: 'Receiving Inline Images'
+sidebar_label: 'Receiving Inline Images'
+summary: Receive images pasted into Teams messages, identify their attachments, and download their bytes with the authenticated HTTP client.
+languages: ['python', 'typescript', 'csharp']
+suppressLanguageIncludeWarning: true
+---
+
+# Receiving Inline Images
+
+When a user pastes an image into the Teams compose box, the image does not arrive inside <LanguageInclude content={{"typescript": "`activity.text`", "python": "`activity.text`", "csharp": "`Activity.Text`"}} />. Teams sends it as an attachment on the inbound message activity.
+
+Inline image attachments are distinct from files attached through the compose box. They do not use the `file.download.info` content type and are not surfaced by <LanguageInclude content={{"typescript": "`ctx.files`", "python": "`ctx.files`", "csharp": "`context.Files`"}} />.
+
+## Understand the attachment shape
+
+An inbound message with an inline image typically contains two related attachments:
+
+```json
+{
+  "attachments": [
+    {
+      "contentType": "image/png",
+      "contentUrl": "https://.../v3/attachments/{id}/views/original"
+    },
+    {
+      "contentType": "text/html",
+      "content": "<p><img src=\"https://.../objects/{id}/views/imgo\" ...></p>"
+    }
+  ]
+}
+```
+
+Use the `image/*` attachment as the canonical source of the image. Its `contentUrl` points to the downloadable image bytes.
+
+The `text/html` attachment preserves layout context, including where the image appeared among the message's text and other content. Do not use the HTML attachment's `<img src>` URL to download the image.
+
+## Download the image
+
+The image attachment's `contentUrl` is authenticated rather than public. Fetch it with the app's authenticated HTTP client:
+
+<LanguageInclude section="download-image" />
+
+The example buffers the complete image in memory. Keep the byte representation when your downstream API accepts it, or convert it to base64 when required by an image-processing or model API.


### PR DESCRIPTION
## Summary

Teams delivers images pasted into messages as raw activity attachments, not through the SDK’s attached-file abstraction. This adds a focused guide showing how to identify the canonical `image/*` attachment and download its authenticated `contentUrl` with the SDK HTTP client in TypeScript, Python, and C#.

## Decisions

- **Separate inline images from uploaded files.** The companion `text/html` attachment describes placement, but image bytes come from the authenticated `image/*` attachment; keeping this in a dedicated guide avoids implying that `ctx.files` / `context.Files` supports both shapes.
- **Keep binary handling beside the code.** Each language example documents its byte-response behavior inline, including TypeScript’s required `arraybuffer` response type.

## Validation

The three examples were exercised with real images pasted into personal Teams chat. All SDKs downloaded the same non-empty payload through their authenticated clients; the generated TypeScript, Python, and C# documentation also builds successfully.