### PR TITLE
docs: update TS/PY auth docs for multi-connection oauth

### DIFF
--- a/teams.md/src/components/Language.tsx
+++ b/teams.md/src/components/Language.tsx
@@ -3,15 +3,17 @@ import { useLocation } from '@docusaurus/router';
 import { type Language } from '../constants/languages';
 
 export type LanguageProps = {
-  readonly language: Language;
+  readonly language: Language | readonly Language[];
 };
 
 // Component for inserting language-specific content onto a page.
 export default function Language({ language, children }: PropsWithChildren<LanguageProps>) {
   const location = useLocation();
 
-  // Only render if current path matches language
-  if (!location.pathname.includes(`/${language}/`)) {
+  const languages = Array.isArray(language) ? language : [language as Language];
+
+  // Only render if current path matches one of the languages
+  if (!languages.some((lang) => location.pathname.includes(`/${lang}/`))) {
     return null;
   }
 

--- a/teams.md/src/components/Language.tsx
+++ b/teams.md/src/components/Language.tsx
@@ -10,7 +10,7 @@ export type LanguageProps = {
 export default function Language({ language, children }: PropsWithChildren<LanguageProps>) {
   const location = useLocation();
 
-  const languages = Array.isArray(language) ? language : [language as Language];
+  const languages = Array.isArray(language) ? language : [language];
 
   // Only render if current path matches one of the languages
   if (!languages.some((lang) => location.pathname.includes(`/${lang}/`))) {

--- a/teams.md/src/components/include/essentials/graph/python.incl.md
+++ b/teams.md/src/components/include/essentials/graph/python.incl.md
@@ -31,9 +31,15 @@ You also have access to the `app_graph` object in the activity handler. This is 
 
 <!-- user-graph-intro -->
 
-You can also access the graph using the user's token from within a message handler via the `user_graph` property.
+You can also access the graph using the user's token from within a message handler.
 
 <!-- user-graph-example -->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+<TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```python
 @app.on_message
@@ -45,6 +51,33 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     print(f"User Job Title: {user.job_title}")
 ```
 Here, the "user_graph" object is a scoped graph client for the user that sent the message.
+
+</TabItem>
+<TabItem value="core" label="SDK 2.2 (current)" default>
+
+Build the client from an OAuth flow's token, so it's always scoped to the connection that owns it.
+
+```python
+from microsoft_teams.graph import get_graph_client
+
+graph = app.add_oauth_flow("graph")
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]):
+    token = await graph.sign_in(ctx)
+    if token is None:
+        return  # OAuth card sent — resumes on the callback turn
+
+    client = get_graph_client(token)
+    user = await client.me.get()
+    print(f"User ID: {user.id}")
+    print(f"User Display Name: {user.display_name}")
+    print(f"User Email: {user.mail}")
+    print(f"User Job Title: {user.job_title}")
+```
+
+</TabItem>
+</Tabs>
 
 <!-- advanced-sections -->
 

--- a/teams.md/src/components/include/essentials/graph/python.incl.md
+++ b/teams.md/src/components/include/essentials/graph/python.incl.md
@@ -39,7 +39,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-<TabItem value="legacy" label="SDK 2.1 (Legacy)">
+<TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 @app.on_message
@@ -53,7 +53,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 Here, the "user_graph" object is a scoped graph client for the user that sent the message.
 
 </TabItem>
-<TabItem value="core" label="SDK 2.2 (current)" default>
+<TabItem value="core" label="SDK 2.1 (current)" default>
 
 Build the client from an OAuth flow's token, so it's always scoped to the connection that owns it.
 

--- a/teams.md/src/components/include/essentials/graph/typescript.incl.md
+++ b/teams.md/src/components/include/essentials/graph/typescript.incl.md
@@ -49,9 +49,15 @@ You also have access to the `appGraph` object in the activity handler. This is e
 :::
 <!-- user-graph-intro -->
 
-You can also access the graph using the user's token from within a message handler via the `userGraph` prop.
+You can also access the graph using the user's token from within a message handler.
 
 <!-- user-graph-example -->
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+<TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```typescript
 import * as endpoints from '@microsoft/teams.graph-endpoints';
@@ -66,6 +72,34 @@ app.on('message', async ({ activity, userGraph }) => {
 });
 ```
 Here, the "userGraph" object is a scoped graph client for the user that sent the message.
+
+</TabItem>
+<TabItem value="core" label="SDK 2.2 (current)" default>
+
+Build the client from an OAuth flow's token, so it's always scoped to the connection that owns it.
+
+```typescript
+import { Client as GraphClient } from '@microsoft/teams.graph';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
+const graph = app.addOAuthFlow('graph');
+
+// Gets details of the current user
+app.on('message', async (ctx) => {
+  const token = await graph.signIn(ctx);
+  if (!token) return; // OAuth card sent — resumes on the callback turn
+
+  const client = new GraphClient({ token: () => token }, { baseUrlRoot: app.graphBaseUrl });
+  const me = await client.call(endpoints.me.get);
+  console.log(`User ID: ${me.id}`);
+  console.log(`User Display Name: ${me.displayName}`);
+  console.log(`User Email: ${me.mail}`);
+  console.log(`User Job Title: ${me.jobTitle}`);
+});
+```
+
+</TabItem>
+</Tabs>
 
 <!-- advanced-sections -->
 
@@ -84,7 +118,7 @@ The equivalent using the graph client would look like this:
 ```ts
 import { users } from '@microsoft/teams.graph-endpoints';
 
-const chat = await userGraph.call(users.teamwork.installedApps.chat.get, {
+const chat = await client.call(users.teamwork.installedApps.chat.get, {
   'user-id': user.id,
   'userScopeTeamsAppInstallation-id': appInstallationId,
   $select: ['id'],

--- a/teams.md/src/components/include/essentials/graph/typescript.incl.md
+++ b/teams.md/src/components/include/essentials/graph/typescript.incl.md
@@ -57,7 +57,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-<TabItem value="legacy" label="SDK 2.1 (Legacy)">
+<TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```typescript
 import * as endpoints from '@microsoft/teams.graph-endpoints';
@@ -74,7 +74,7 @@ app.on('message', async ({ activity, userGraph }) => {
 Here, the "userGraph" object is a scoped graph client for the user that sent the message.
 
 </TabItem>
-<TabItem value="core" label="SDK 2.2 (current)" default>
+<TabItem value="core" label="SDK 2.1 (current)" default>
 
 Build the client from an OAuth flow's token, so it's always scoped to the connection that owns it.
 

--- a/teams.md/src/components/include/essentials/on-event/python.incl.md
+++ b/teams.md/src/components/include/essentials/on-event/python.incl.md
@@ -33,6 +33,10 @@ flowchart LR
 Event handler registration uses `@app.event("<event_name>")` with an async function that receives an event object specific to the event type (e.g., `ErrorEvent`, `ActivityEvent`).
 :::
 
+:::tip
+The `sign_in` event fires for every OAuth connection. To react to just one, use that flow's `@flow.on_signin` handler instead. See the [auth guide](../in-depth-guides/user-authentication).
+:::
+
 <!-- example-1 -->
 
 ```python

--- a/teams.md/src/components/include/essentials/on-event/python.incl.md
+++ b/teams.md/src/components/include/essentials/on-event/python.incl.md
@@ -33,28 +33,31 @@ flowchart LR
 Event handler registration uses `@app.event("<event_name>")` with an async function that receives an event object specific to the event type (e.g., `ErrorEvent`, `ActivityEvent`).
 :::
 
-:::tip
-The `sign_in` event fires for every OAuth connection. To react to just one, use that flow's `@flow.on_signin` handler instead. See the [auth guide](../in-depth-guides/user-authentication).
-:::
-
 <!-- example-1 -->
 
 ```python
 @app.event("error")
 async def handle_error(event: ErrorEvent):
-    """Handle error events."""
     print(f"Error occurred: {event.error}")
-    if hasattr(event, "context") and event.context:
-        print(f"Context: {event.context}")
+    # Or alternatively, send it to an observability platform
 ```
 
 <!-- example-2 -->
 
-When an activity is received, log its payload.
+When a user signs in using `OAuth` or `SSO`, use the Graph API to fetch their profile and say hello.
 
 ```python
-@app.event("activity")
-async def handle_activity(event: ActivityEvent):
-    """Handle activity events."""
-    print(f"Activity received: {event.activity}")
+from microsoft_teams.graph import get_graph_client
+
+graph = app.add_oauth_flow("graph")
+
+@graph.on_signin
+async def handle_signin(event: SignInEvent):
+    client = get_graph_client(event.token_response.token)
+    me = await client.me.get()
+    await event.activity_ctx.send(f"👋 Hello {me.display_name}")
 ```
+
+:::tip
+The app-wide `sign_in` event fires for every connection. To react to just one, use its flow's `@flow.on_signin` handler as shown above. See the [auth guide](../in-depth-guides/user-authentication).
+:::

--- a/teams.md/src/components/include/essentials/on-event/typescript.incl.md
+++ b/teams.md/src/components/include/essentials/on-event/typescript.incl.md
@@ -42,10 +42,18 @@ app.event('error', ({ error }) => {
 When a user signs in using `OAuth` or `SSO`, use the graph api to fetch their profile and say hello.
 
 ```typescript
+import { Client as GraphClient } from '@microsoft/teams.graph';
 import * as endpoints from '@microsoft/teams.graph-endpoints';
 
-app.event('signin', async ({ activity, send, userGraph }) => {
-  const me = await userGraph.call(endpoints.me.get);
-  await send(`👋 Hello ${me.name}`);
+const graph = app.addOAuthFlow('graph');
+
+graph.onSignInComplete(async (ctx, token) => {
+  const client = new GraphClient({ token: () => token.token }, { baseUrlRoot: app.graphBaseUrl });
+  const me = await client.call(endpoints.me.get);
+  await ctx.send(`👋 Hello ${me.displayName}`);
 });
 ```
+
+:::tip
+The app-wide `signin` event fires for every connection. To react to just one, use its flow's `onSignInComplete` callback as shown above. See the [auth guide](../in-depth-guides/user-authentication).
+:::

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
@@ -253,6 +253,14 @@ teams.OnMessage("/signout github", async (context, cancellationToken) =>
   </TabItem>
 </Tabs>
 
+<!-- multiple-connections -->
+
+N/A
+
+<!-- connection-status -->
+
+N/A
+
 <!-- pending-messages -->
 
 <Tabs groupId="csharp-sdk-version" defaultValue="core">

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
@@ -255,11 +255,64 @@ teams.OnMessage("/signout github", async (context, cancellationToken) =>
 
 <!-- multiple-connections -->
 
-N/A
+```csharp
+builder.Services.AddTeamsBotApplication(options =>
+{
+    options.AddOAuthFlow("graph", oauth => oauth.OAuthCardText = "Sign in with Microsoft");
+    options.AddOAuthFlow("github", oauth => oauth.OAuthCardText = "Sign in with GitHub");
+});
+
+OAuthFlow graphAuth = teams.GetOAuthFlow("graph");
+OAuthFlow githubAuth = teams.GetOAuthFlow("github");
+
+teams.OnMessage("/graph", async (context, cancellationToken) =>
+{
+    string? token = await graphAuth.SignInAsync(context, cancellationToken);
+    if (token is not null)
+    {
+        await SendGraphProfileAsync(context, token, cancellationToken);
+    }
+});
+
+teams.OnMessage("/github", async (context, cancellationToken) =>
+{
+    string? token = await githubAuth.SignInAsync(context, cancellationToken);
+    if (token is not null)
+    {
+        await SendGitHubProfileAsync(context, token, cancellationToken);
+    }
+});
+
+graphAuth.OnSignInComplete(async (context, tokenResponse, cancellationToken) =>
+    await SendGraphProfileAsync(context, tokenResponse.Token, cancellationToken));
+
+githubAuth.OnSignInComplete(async (context, tokenResponse, cancellationToken) =>
+    await SendGitHubProfileAsync(context, tokenResponse.Token, cancellationToken));
+
+teams.OnMessage("/signout github", async (context, cancellationToken) =>
+{
+    await githubAuth.SignOutAsync(context, cancellationToken);
+    await context.SendAsync("Signed out of GitHub.", cancellationToken);
+});
+```
+
+Signing out of one connection leaves the other signed in.
 
 <!-- connection-status -->
 
-N/A
+```csharp
+using Microsoft.Teams.Core;
+
+teams.OnMessage("/status", async (context, cancellationToken) =>
+{
+    IList<GetTokenStatusResult> statuses = await graphAuth.GetConnectionStatusAsync(context, cancellationToken);
+    IEnumerable<string> lines = statuses.Select(status =>
+        $"- `{status.ConnectionName}`: {(status.HasToken == true ? "signed in" : "signed out")}");
+    await context.SendAsync(string.Join("\n", lines), cancellationToken);
+});
+```
+
+`GetConnectionStatusAsync` reports every connection registered on the bot, so calling it on any flow returns the same list.
 
 <!-- pending-messages -->
 

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/python.incl.md
@@ -22,7 +22,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 from microsoft_teams.apps import App
@@ -35,7 +35,7 @@ app = App(
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 Register the connections you plan to use. `add_oauth_flow` returns the object that owns one.
 
@@ -67,7 +67,7 @@ This uses the Single Sign-On (SSO) authentication flow. To learn more about all 
 :::
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 @app.on_message
@@ -81,7 +81,7 @@ async def handle_signin_message(ctx: ActivityContext[MessageActivity]):
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```python
 @app.on_message_pattern("/signin")
@@ -98,7 +98,7 @@ async def handle_signin_message(ctx: ActivityContext[MessageActivity]):
 <!-- signin-event -->
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 @app.event("sign_in")
@@ -108,7 +108,7 @@ async def handle_sign_in(event: SignInEvent):
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 The handler is scoped to its connection, so there's no need to branch on the connection name.
 
@@ -134,7 +134,7 @@ A flow can have more than one handler. They run in registration order and are is
 From this point, you can query graph for the signed-in user, for example to reply to the `/whoami` message, or in any other route.
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 Use the `is_signed_in` flag and the `user_graph` client.
 
@@ -152,7 +152,7 @@ async def handle_whoami_message(ctx: ActivityContext[MessageActivity]):
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 Build the client from the flow's token, so it always talks to the connection that owns it.
 
@@ -177,7 +177,7 @@ async def handle_whoami_message(ctx: ActivityContext[MessageActivity]):
 <!-- signing-out -->
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 @app.on_message
@@ -192,7 +192,7 @@ async def handle_signout_message(ctx: ActivityContext[MessageActivity]):
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```python
 @app.on_message_pattern("/signout")
@@ -257,7 +257,7 @@ async def handle_status(ctx: ActivityContext[MessageActivity]):
 <!-- pending-messages -->
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 from microsoft_teams.apps import App, ActivityContext, SignInEvent
@@ -296,7 +296,7 @@ async def handle_sign_in(event: SignInEvent):
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```python
 from microsoft_teams.apps import App, ActivityContext, SignInEvent
@@ -339,7 +339,7 @@ async def on_graph_signin(event: SignInEvent):
 <!-- signin-failure -->
 
 <Tabs groupId="python-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```python
 @app.on_signin_failure()
@@ -354,7 +354,7 @@ Registering a custom handler does **not** replace the built-in default handler. 
 :::
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```python
 from microsoft_teams.apps import SignInFailureEvent

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/python.incl.md
@@ -18,24 +18,56 @@ This command:
 
 <!-- configure-oauth -->
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+
 ```python
-from teams import App
-from teams.api import MessageActivity, SignInEvent
-from teams.apps import ActivityContext
-from teams.logger import ConsoleLogger, ConsoleLoggerOptions
+from microsoft_teams.apps import App
 
 app = App(
     # The name of the auth connection to use.
-    # It should be the same as the Oauth connection name defined in the Azure Bot configuration.
+    # It should be the same as the OAuth connection name defined in the Azure Bot configuration.
     default_connection_name="graph",
-    logger=ConsoleLogger().create_logger("auth", options=ConsoleLoggerOptions(level="debug")))
+)
 ```
+
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+Register the connections you plan to use. `add_oauth_flow` returns the object that owns one.
+
+```python
+from microsoft_teams.apps import App
+
+app = App()
+
+graph = app.add_oauth_flow(
+    "graph",
+    oauth_card_text="Sign in to your account",
+    sign_in_button_text="Sign in",
+)
+```
+
+Both card options are optional. Use `app.get_oauth_flow("graph")` to get the flow again from another module.
+
+:::note
+Registering a flow enables per-turn state unless you set `state` yourself, so sign-in callbacks that don't name a connection can be traced back to the one that started them.
+:::
+
+  </TabItem>
+</Tabs>
 
 <!-- signing-in -->
 
 :::note
 This uses the Single Sign-On (SSO) authentication flow. To learn more about all the available flows and their differences see the [official documentation](https://learn.microsoft.com/en-us/azure/bot-service/bot-builder-concept-authentication?view=azure-bot-service-4.0).
 :::
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```python
 @app.on_message
@@ -48,7 +80,25 @@ async def handle_signin_message(ctx: ActivityContext[MessageActivity]):
         await ctx.sign_in()
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```python
+@app.on_message_pattern("/signin")
+async def handle_signin_message(ctx: ActivityContext[MessageActivity]):
+    """Handle message activities for signing in."""
+    token = await graph.sign_in(ctx)
+    if token:
+        await ctx.send("You are already signed in.")
+```
+
+  </TabItem>
+</Tabs>
+
 <!-- signin-event -->
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```python
 @app.event("sign_in")
@@ -57,10 +107,36 @@ async def handle_sign_in(event: SignInEvent):
     await event.activity_ctx.send("You are now signed in!")
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+The handler is scoped to its connection, so there's no need to branch on the connection name.
+
+```python
+@graph.on_signin
+async def on_graph_signin(event: SignInEvent):
+    """Only fires for the `graph` connection."""
+    await event.activity_ctx.send(
+        f"Signed in on {event.connection_name}. "
+        "Type **/whoami** to see your profile or **/signout** to sign out."
+    )
+```
+
+:::note
+A flow can have more than one handler. They run in registration order and are isolated — if one raises, the error is logged and the rest still run. The app-wide `sign_in` event also still fires for every connection.
+:::
+
+  </TabItem>
+</Tabs>
+
 <!-- using-graph -->
 
-From this point, you can use the `IsSignedIn` flag and the `userGraph` client to query graph, for example to reply to the `/whoami` message, or in any other route.
+From this point, you can query graph for the signed-in user, for example to reply to the `/whoami` message, or in any other route.
 
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+
+Use the `is_signed_in` flag and the `user_graph` client.
 
 ```python
 @app.on_message
@@ -73,17 +149,35 @@ async def handle_whoami_message(ctx: ActivityContext[MessageActivity]):
     # Access user's Microsoft Graph data
     me = await ctx.user_graph.me.get()
     await ctx.send(f"Hello {me.display_name}! Your email is {me.mail or me.user_principal_name}")
-
-@app.on_message
-async def handle_all_messages(ctx: ActivityContext[MessageActivity]):
-    """Handle all other messages."""
-    if ctx.is_signed_in:
-        await ctx.send(f'You said: "{ctx.activity.text}". Please type **/whoami** to see your profile or **/signout** to sign out.')
-    else:
-        await ctx.send(f'You said: "{ctx.activity.text}". Please type **/signin** to sign in.')
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+Build the client from the flow's token, so it always talks to the connection that owns it.
+
+```python
+from microsoft_teams.graph import get_graph_client
+
+@app.on_message_pattern("/whoami")
+async def handle_whoami_message(ctx: ActivityContext[MessageActivity]):
+    """Handle messages to show user information from Microsoft Graph."""
+    token = await graph.sign_in(ctx)
+    if token is None:
+        return  # OAuth card sent — resumes on the callback turn
+
+    client = get_graph_client(token)
+    me = await client.me.get()
+    await ctx.send(f"Hello {me.display_name}! Your email is {me.mail or me.user_principal_name}")
+```
+
+  </TabItem>
+</Tabs>
+
 <!-- signing-out -->
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```python
 @app.on_message
@@ -97,16 +191,82 @@ async def handle_signout_message(ctx: ActivityContext[MessageActivity]):
     await ctx.send("You have been signed out!")
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```python
+@app.on_message_pattern("/signout")
+async def handle_signout_message(ctx: ActivityContext[MessageActivity]):
+    """Handle sign out requests."""
+    await graph.sign_out(ctx)
+    await ctx.send("You have been signed out!")
+```
+
+  </TabItem>
+</Tabs>
+
+<!-- multiple-connections -->
+
+```python
+app = App()
+
+graph = app.add_oauth_flow("graph", oauth_card_text="Sign in with Microsoft")
+github = app.add_oauth_flow("github", oauth_card_text="Sign in with GitHub")
+
+@app.on_message_pattern("/graph")
+async def handle_graph(ctx: ActivityContext[MessageActivity]):
+    token = await graph.sign_in(ctx)
+    if token:
+        await send_graph_profile(ctx, token)
+
+@app.on_message_pattern("/github")
+async def handle_github(ctx: ActivityContext[MessageActivity]):
+    token = await github.sign_in(ctx)
+    if token:
+        await send_github_profile(ctx, token)
+
+@graph.on_signin
+async def on_graph_signin(event: SignInEvent):
+    await send_graph_profile(event.activity_ctx, event.token_response.token)
+
+@github.on_signin
+async def on_github_signin(event: SignInEvent):
+    await send_github_profile(event.activity_ctx, event.token_response.token)
+
+@app.on_message_pattern("/signout github")
+async def handle_signout_github(ctx: ActivityContext[MessageActivity]):
+    await github.sign_out(ctx)
+    await ctx.send("Signed out of GitHub.")
+```
+
+Signing out of one connection leaves the other signed in.
+
+<!-- connection-status -->
+
+```python
+@app.on_message_pattern("/status")
+async def handle_status(ctx: ActivityContext[MessageActivity]):
+    statuses = await ctx.get_connection_status()
+    lines = [
+        f"- `{status.connection_name}`: {'signed in' if status.has_token else 'signed out'}"
+        for status in statuses
+    ]
+    await ctx.send("\n".join(lines))
+```
+
 <!-- pending-messages -->
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```python
 from microsoft_teams.apps import App, ActivityContext, SignInEvent
-from microsoft_teams.apps.routing.activity_context import SignInOptions
+from microsoft_teams.apps.routing import SignInOptions
 from microsoft_teams.api import MessageActivity
 
 app = App()
 
-pending_messages: dict[str, dict] = {}
+pending_messages: dict[str, str] = {}
 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
@@ -117,10 +277,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
     if token is None:
         # OAuth card sent — store the original message for later
-        pending_messages[ctx.activity.from_.id] = {
-            "text": ctx.activity.text,
-            "activity": ctx.activity,
-        }
+        pending_messages[ctx.activity.from_.id] = ctx.activity.text
         return
 
     # User is already signed in — process normally
@@ -133,12 +290,56 @@ async def handle_sign_in(event: SignInEvent):
 
     if pending:
         await event.activity_ctx.send("Successfully signed in! Processing your original request...")
-        await process_message(pending["text"], event.activity_ctx)
+        await process_message(pending, event.activity_ctx)
     else:
         await event.activity_ctx.send("You are now signed in!")
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```python
+from microsoft_teams.apps import App, ActivityContext, SignInEvent
+from microsoft_teams.apps.routing import SignInOptions
+from microsoft_teams.api import MessageActivity
+
+app = App()
+graph = app.add_oauth_flow("graph")
+
+pending_messages: dict[str, str] = {}
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]):
+    # sign_in() returns the token if already signed in, or None if an OAuth card was sent
+    token = await graph.sign_in(ctx, SignInOptions(
+        oauth_card_text="To help with that, I need to sign you in first."
+    ))
+
+    if token is None:
+        pending_messages[ctx.activity.from_.id] = ctx.activity.text
+        return
+
+    await process_message(ctx.activity.text, ctx, token)
+
+@graph.on_signin
+async def on_graph_signin(event: SignInEvent):
+    user_id = event.activity_ctx.activity.from_.id
+    pending = pending_messages.pop(user_id, None)
+
+    if pending:
+        await event.activity_ctx.send("Successfully signed in! Processing your original request...")
+        await process_message(pending, event.activity_ctx, event.token_response.token)
+    else:
+        await event.activity_ctx.send("You are now signed in!")
+```
+
+  </TabItem>
+</Tabs>
+
 <!-- signin-failure -->
+
+<Tabs groupId="python-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```python
 @app.on_signin_failure()
@@ -149,12 +350,28 @@ async def handle_signin_failure(ctx):
 ```
 
 :::note
-In Python, registering a custom handler does **not** replace the built-in default handler. Both will run as part of the middleware chain.
+Registering a custom handler does **not** replace the built-in default handler. Both will run as part of the middleware chain.
 :::
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```python
+from microsoft_teams.apps import SignInFailureEvent
+
+@graph.on_signin_failure
+async def on_graph_signin_failure(event: SignInFailureEvent):
+    ctx = event.activity_ctx
+    ctx.logger.error(f"Graph sign-in failed: {event.code} - {event.message}")
+    await ctx.send("Graph sign-in failed.")
+```
+
+A flow can have more than one failure handler; they run in registration order and are isolated from each other.
+
+  </TabItem>
+</Tabs>
+
 <!-- regional-bot -->
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 ## Regional Configs
 You may be building a regional bot that is deployed in a specific Azure region (such as West Europe, East US, etc.) rather than global. This is important for organizations that have data residency requirements or want to reduce latency by keeping data and authentication flows within a specific area.

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/typescript.incl.md
@@ -18,22 +18,58 @@ This command:
 
 <!-- configure-oauth -->
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+
 ```ts
 import { App } from '@microsoft/teams.apps';
-import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App({
   oauth: {
+    // The name of the auth connection to use.
+    // It should be the same as the OAuth connection name defined in the Azure Bot configuration.
     defaultConnectionName: 'graph',
   },
 });
 ```
+
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+Register the connections you plan to use. `addOAuthFlow` returns the object that owns one.
+
+```ts
+import { App } from '@microsoft/teams.apps';
+
+const app = new App();
+
+// Or register up front: new App({ oauthFlows: ['graph'] })
+const graph = app.addOAuthFlow('graph', {
+  oauthCardText: 'Sign in to your account',
+  signInButtonText: 'Sign in',
+});
+```
+
+Both card options are optional. Use `app.getOAuthFlow('graph')` to get the flow again from another module.
+
+:::note
+Registering a flow enables per-turn state unless you set `state` yourself, so sign-in callbacks that don't name a connection can be traced back to the one that started them. `oauth.defaultConnectionName` can't be combined with registered flows.
+:::
+
+  </TabItem>
+</Tabs>
 
 <!-- signing-in -->
 
 :::note
 This uses the Single Sign-On (SSO) authentication flow. To learn more about all the available flows and their differences see the [official documentation](https://learn.microsoft.com/en-us/azure/bot-service/bot-builder-concept-authentication?view=azure-bot-service-4.0).
 :::
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```ts
 app.message('/signin', async ({ signin, send }) => {
@@ -43,7 +79,25 @@ app.message('/signin', async ({ signin, send }) => {
 });
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```ts
+app.message('/signin', async (ctx) => {
+  const token = await graph.signIn(ctx);
+  if (token) {
+    await ctx.send('you are already signed in!');
+  }
+});
+```
+
+  </TabItem>
+</Tabs>
+
 <!-- signin-event -->
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```ts
 app.event('signin', async ({ send, token }) => {
@@ -53,10 +107,34 @@ app.event('signin', async ({ send, token }) => {
 });
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+The callback is scoped to its connection, so there's no need to branch on the connection name.
+
+```ts
+graph.onSignInComplete(async (ctx, token) => {
+  await ctx.send(
+    `Signed in on ${token.connectionName}. Please type **/whoami** to see your profile or **/signout** to sign out.`
+  );
+});
+```
+
+:::note
+Each flow holds a single completion callback — registering again replaces the previous one. The app-wide `signin` event still fires for every connection if you need one place to observe them all.
+:::
+
+  </TabItem>
+</Tabs>
+
 <!-- using-graph -->
 
-From this point, you can use the `IsSignedIn` flag and the `userGraph` client to query graph, for example to reply to the `/whoami` message, or in any other route.
+From this point, you can query graph for the signed-in user, for example to reply to the `/whoami` message, or in any other route.
 
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+
+Use the `isSignedIn` flag and the `userGraph` client.
 
 ```ts
 import * as endpoints from '@microsoft/teams.graph-endpoints';
@@ -82,7 +160,34 @@ app.on('message', async ({ send, activity, signin }) => {
 });
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+Build the client from the flow's token, so it always talks to the connection that owns it.
+
+```ts
+import { Client as GraphClient } from '@microsoft/teams.graph';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
+app.message('/whoami', async (ctx) => {
+  const token = await graph.signIn(ctx);
+  if (!token) return; // OAuth card sent — resumes on the callback turn
+
+  const client = new GraphClient({ token: () => token }, { baseUrlRoot: app.graphBaseUrl });
+  const me = await client.call(endpoints.me.get);
+  await ctx.send(
+    `you are signed in as "${me.displayName}" and your email is "${me.mail || me.userPrincipalName}"`
+  );
+});
+```
+
+  </TabItem>
+</Tabs>
+
 <!-- signing-out -->
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```ts
 app.message('/signout', async ({ send, signout, isSignedIn }) => {
@@ -92,7 +197,64 @@ app.message('/signout', async ({ send, signout, isSignedIn }) => {
 });
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```ts
+app.message('/signout', async (ctx) => {
+  await graph.signOut(ctx);
+  await ctx.send('you have been signed out!');
+});
+```
+
+  </TabItem>
+</Tabs>
+
+<!-- multiple-connections -->
+
+```ts
+const app = new App();
+
+const graph = app.addOAuthFlow('graph', { oauthCardText: 'Sign in with Microsoft' });
+const github = app.addOAuthFlow('github', { oauthCardText: 'Sign in with GitHub' });
+
+app.message('/graph', async (ctx) => {
+  const token = await graph.signIn(ctx);
+  if (token) await sendGraphProfile(ctx, token);
+});
+
+app.message('/github', async (ctx) => {
+  const token = await github.signIn(ctx);
+  if (token) await sendGitHubProfile(ctx, token);
+});
+
+graph.onSignInComplete(async (ctx, token) => sendGraphProfile(ctx, token.token));
+github.onSignInComplete(async (ctx, token) => sendGitHubProfile(ctx, token.token));
+
+app.message('/signout github', async (ctx) => {
+  await github.signOut(ctx);
+  await ctx.send('Signed out of GitHub.');
+});
+```
+
+Signing out of one connection leaves the other signed in.
+
+<!-- connection-status -->
+
+```ts
+app.message('/status', async (ctx) => {
+  const statuses = await ctx.getConnectionStatus();
+  const lines = statuses.map(
+    (status) => `- \`${status.connectionName}\`: ${status.hasToken ? 'signed in' : 'signed out'}`
+  );
+  await ctx.send(lines.join('\n'));
+});
+```
+
 <!-- pending-messages -->
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```ts
 const pendingMessages = new Map<string, { text: string; activity: any }>();
@@ -130,7 +292,48 @@ app.event('signin', async ({ send, userGraph, activity }) => {
 });
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```ts
+const pendingMessages = new Map<string, string>();
+
+app.on('message', async (ctx) => {
+  // signIn() returns the token if already signed in, or undefined if an OAuth card was sent
+  const token = await graph.signIn(ctx, {
+    oauthCardText: 'To help with that, I need to sign you in first.',
+  });
+
+  if (!token) {
+    pendingMessages.set(ctx.activity.from.id, ctx.activity.text);
+    return;
+  }
+
+  await processMessage(ctx.activity.text, ctx, token);
+});
+
+graph.onSignInComplete(async (ctx, token) => {
+  const userId = ctx.activity.from.id;
+  const pending = pendingMessages.get(userId);
+
+  if (!pending) {
+    await ctx.send('You are now signed in!');
+    return;
+  }
+
+  pendingMessages.delete(userId);
+  await ctx.send('Successfully signed in! Processing your original request...');
+  await processMessage(pending, ctx, token.token);
+});
+```
+
+  </TabItem>
+</Tabs>
+
 <!-- signin-failure -->
+
+<Tabs groupId="typescript-sdk-version" defaultValue="core">
+  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
 
 ```ts
 app.on('signin.failure', async ({ activity, send }) => {
@@ -140,9 +343,22 @@ app.on('signin.failure', async ({ activity, send }) => {
 });
 ```
 
+  </TabItem>
+  <TabItem value="core" label="SDK 2.2 (current)" default>
+
+```ts
+graph.onSignInFailure(async (ctx, failure) => {
+  ctx.log.error(`Graph sign-in failed: ${failure?.code} - ${failure?.message}`);
+  await ctx.send('Graph sign-in failed.');
+});
+```
+
+`failure` is undefined for token-service and token-exchange failures, which carry no Teams payload.
+
+  </TabItem>
+</Tabs>
+
 <!-- regional-bot -->
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 ## Regional Configs
 You may be building a regional bot that is deployed in a specific Azure region (such as West Europe, East US, etc.) rather than global. This is important for organizations that have data residency requirements or want to reduce latency by keeping data and authentication flows within a specific area.

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/typescript.incl.md
@@ -22,7 +22,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```ts
 import { App } from '@microsoft/teams.apps';
@@ -37,7 +37,7 @@ const app = new App({
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 Register the connections you plan to use. `addOAuthFlow` returns the object that owns one.
 
@@ -69,7 +69,7 @@ This uses the Single Sign-On (SSO) authentication flow. To learn more about all 
 :::
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```ts
 app.message('/signin', async ({ signin, send }) => {
@@ -80,7 +80,7 @@ app.message('/signin', async ({ signin, send }) => {
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```ts
 app.message('/signin', async (ctx) => {
@@ -97,7 +97,7 @@ app.message('/signin', async (ctx) => {
 <!-- signin-event -->
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```ts
 app.event('signin', async ({ send, token }) => {
@@ -108,7 +108,7 @@ app.event('signin', async ({ send, token }) => {
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 The callback is scoped to its connection, so there's no need to branch on the connection name.
 
@@ -132,7 +132,7 @@ Each flow holds a single completion callback — registering again replaces the 
 From this point, you can query graph for the signed-in user, for example to reply to the `/whoami` message, or in any other route.
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 Use the `isSignedIn` flag and the `userGraph` client.
 
@@ -161,7 +161,7 @@ app.on('message', async ({ send, activity, signin }) => {
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 Build the client from the flow's token, so it always talks to the connection that owns it.
 
@@ -187,7 +187,7 @@ app.message('/whoami', async (ctx) => {
 <!-- signing-out -->
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```ts
 app.message('/signout', async ({ send, signout, isSignedIn }) => {
@@ -198,7 +198,7 @@ app.message('/signout', async ({ send, signout, isSignedIn }) => {
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```ts
 app.message('/signout', async (ctx) => {
@@ -254,7 +254,7 @@ app.message('/status', async (ctx) => {
 <!-- pending-messages -->
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```ts
 const pendingMessages = new Map<string, { text: string; activity: any }>();
@@ -293,7 +293,7 @@ app.event('signin', async ({ send, userGraph, activity }) => {
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```ts
 const pendingMessages = new Map<string, string>();
@@ -333,7 +333,7 @@ graph.onSignInComplete(async (ctx, token) => {
 <!-- signin-failure -->
 
 <Tabs groupId="typescript-sdk-version" defaultValue="core">
-  <TabItem value="legacy" label="SDK 2.1 (Legacy)">
+  <TabItem value="legacy" label="SDK 2.0 (Legacy)">
 
 ```ts
 app.on('signin.failure', async ({ activity, send }) => {
@@ -344,7 +344,7 @@ app.on('signin.failure', async ({ activity, send }) => {
 ```
 
   </TabItem>
-  <TabItem value="core" label="SDK 2.2 (current)" default>
+  <TabItem value="core" label="SDK 2.1 (current)" default>
 
 ```ts
 graph.onSignInFailure(async (ctx, failure) => {

--- a/teams.md/src/components/include/migrations/botbuilder/user-authentication/python.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/user-authentication/python.incl.md
@@ -91,24 +91,23 @@
     from microsoft_teams.apps import ActivityContext, App, SignInEvent
     from microsoft_teams.api import MessageActivity
 
-    app = App(default_connection_name=connection_name)
+    app = App()
+    flow = app.add_oauth_flow(connection_name)
 
     @app.on_message_pattern("/signout")
-    async def on_signout(context: ActivityContext[MessageActivity]):
-        if not context.is_signed_in:
+    async def on_signout(ctx: ActivityContext[MessageActivity]):
+        if not await flow.is_signed_in(ctx):
             return
-        await context.sign_out()
-        await context.send("You have been signed out.")
+        await flow.sign_out(ctx)
+        await ctx.send("You have been signed out.")
 
     @app.on_message
-    async def on_message(context: ActivityContext[MessageActivity]):
-        if not context.is_signed_in:
-            await context.sign_in()
-            return
+    async def on_message(ctx: ActivityContext[MessageActivity]):
+        await flow.sign_in(ctx)
 
-    @app.event("sign_in")
+    @flow.on_signin
     async def on_signin(event: SignInEvent):
-        await context.send("You have been signed in.")
+        await event.activity_ctx.send("You have been signed in.")
     ```
 
   </TabItem>

--- a/teams.md/src/components/include/migrations/botbuilder/user-authentication/python.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/user-authentication/python.incl.md
@@ -103,7 +103,9 @@
 
     @app.on_message
     async def on_message(ctx: ActivityContext[MessageActivity]):
-        await flow.sign_in(ctx)
+        token = await flow.sign_in(ctx)
+        if token:
+            await ctx.send("You have been signed in.")
 
     @flow.on_signin
     async def on_signin(event: SignInEvent):

--- a/teams.md/src/components/include/migrations/botbuilder/user-authentication/typescript.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/user-authentication/typescript.incl.md
@@ -140,28 +140,22 @@
     <TabItem value="Teams SDK">
       ```typescript showLineNumbers
       import { App } from '@microsoft/teams.apps';
-      import { ConsoleLogger } from '@microsoft/teams.common/logging';
 
-      const app = new App({
-        oauth: {
-          defaultConnectionName: process.env.connectionName
-        }
+      const app = new App();
+      const flow = app.addOAuthFlow(process.env.connectionName!);
+
+      app.message('/signout', async (ctx) => {
+        if (!(await flow.isSignedIn(ctx))) return;
+        await flow.signOut(ctx);
+        await ctx.send('You have been signed out.');
       });
 
-      app.message('/signout', async ({ send, signout, isSignedIn }) => {
-        if (!isSignedIn) return;
-        await signout();
-        await send('You have been signed out.');
+      app.on('message', async (ctx) => {
+        await flow.signIn(ctx);
       });
 
-      app.on('message', async ({ send, signin }) => {
-        if (!await signin()) {
-          return;
-        }
-      });
-
-      app.event('signin', async ({ send }) => {
-        await send('You have been signed in.');
+      flow.onSignInComplete(async (ctx) => {
+        await ctx.send('You have been signed in.');
       });
 
       (async () => {

--- a/teams.md/src/components/include/migrations/botbuilder/user-authentication/typescript.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/user-authentication/typescript.incl.md
@@ -151,7 +151,8 @@
       });
 
       app.on('message', async (ctx) => {
-        await flow.signIn(ctx);
+        const token = await flow.signIn(ctx);
+        if (token) await ctx.send('You have been signed in.');
       });
 
       flow.onSignInComplete(async (ctx) => {

--- a/teams.md/src/components/include/migrations/v1/python.incl.md
+++ b/teams.md/src/components/include/migrations/v1/python.incl.md
@@ -583,23 +583,24 @@ Note that on Microsoft Teams, task modules have been renamed to dialogs.
     # highlight-error-end
     # highlight-success-start
 +    app = App()
++    graph = app.add_oauth_flow("graph")
 +
 +    @app.on_message
 +    async def handle_message(ctx: ActivityContext[MessageActivity]):
 +        ctx.logger.info("User requested sign-in.")
-+        if ctx.is_signed_in:
++        if await graph.is_signed_in(ctx):
 +            await ctx.send("You are already signed in.")
 +        else:
-+            await ctx.sign_in()
++            await graph.sign_in(ctx)
 +
 +    @app.on_message_pattern("/signout")
 +    async def handle_sign_out(ctx: ActivityContext[MessageActivity]):
-+        await ctx.sign_out()
++        await graph.sign_out(ctx)
 +        await ctx.send("You have been signed out.")
 +
-+    @app.event("sign_in")
++    @graph.on_signin
 +    async def handle_sign_in(event: SignInEvent):
-+        """Handle sign-in events."""
++        """Handle sign-in for the graph connection."""
 +        await event.activity_ctx.send("You are now signed in!")
 +
 +    @app.event("error")
@@ -615,23 +616,24 @@ Note that on Microsoft Teams, task modules have been renamed to dialogs.
   <TabItem value="v2" label="Teams SDK v2">
     ```python
     app = App()
+    graph = app.add_oauth_flow("graph")
 
     @app.on_message
     async def handle_message(ctx: ActivityContext[MessageActivity]):
         ctx.logger.info("User requested sign-in.")
-        if ctx.is_signed_in:
+        if await graph.is_signed_in(ctx):
             await ctx.send("You are already signed in.")
         else:
-            await ctx.sign_in()
+            await graph.sign_in(ctx)
 
     @app.on_message_pattern("/signout")
     async def handle_sign_out(ctx: ActivityContext[MessageActivity]):
-        await ctx.sign_out()
+        await graph.sign_out(ctx)
         await ctx.send("You have been signed out.")
 
-    @app.event("sign_in")
+    @graph.on_signin
     async def handle_sign_in(event: SignInEvent):
-        """Handle sign-in events."""
+        """Handle sign-in for the graph connection."""
         await event.activity_ctx.send("You are now signed in!")
 
     @app.event("error")

--- a/teams.md/src/components/include/migrations/v1/typescript.incl.md
+++ b/teams.md/src/components/include/migrations/v1/typescript.incl.md
@@ -578,37 +578,32 @@ Note that on Microsoft Teams, task modules have been renamed to dialogs.
     // highlight-error-end
     // highlight-success-start
 +    const app = new App({
-+      oauth: {
-+        defaultConnectionName: 'graph',
-+      },
 +      logger: new ConsoleLogger('@tests/auth', { level: 'debug' }),
 +    });
 +
-+    app.message('/signout', async ({ isSignedIn, signout, send }) => {
-+      if (!isSignedIn) return;
-+      await signout();
-+      await send('you have been signed out!');
++    const graph = app.addOAuthFlow('graph');
++
++    app.message('/signout', async (ctx) => {
++      if (!(await graph.isSignedIn(ctx))) return;
++      await graph.signOut(ctx);
++      await ctx.send('you have been signed out!');
 +    });
 +
 +    app.message('/help', async ({ send }) => {
 +      await send('your help text');
 +    });
 +
-+    app.on('message', async ({ signin, userGraph, log }) => {
-+      if (!await signin({
++    app.on('message', async (ctx) => {
++      const token = await graph.signIn(ctx, {
 +        oauthCardText: 'Sign in to your account',
 +        signInButtonText: 'Sign in',
-+      })) {
-+        return;
-+      }
-+      const me = await userGraph.me.get();
-+      log.info(`user "${me.displayName}" already signed in!`);
++      });
++      if (!token) return;
++      ctx.log.info('user already signed in!');
 +    });
 +
-+    app.event('signin', async ({ userGraph, send, token }) => {
-+      const me = await userGraph.me.get();
-+      await send(`user "${me.displayName}" signed in.`);
-+      await send(`Token string length: ${token.token.length}`);
++    graph.onSignInComplete(async (ctx, token) => {
++      await ctx.send(`signed in. Token string length: ${token.token.length}`);
 +    });
     // highlight-success-end
     ```
@@ -617,44 +612,40 @@ Note that on Microsoft Teams, task modules have been renamed to dialogs.
   <TabItem value="v2" label="Teams SDK v2">
     ```ts
     const app = new App({
-      oauth: {
-        // oauth configurations
-        /**
-         * The name of the auth connection to use.
-         * It should be the same as the OAuth connection name defined in the Azure Bot configuration.
-         */
-        defaultConnectionName: 'graph',
-      },
       logger: new ConsoleLogger('@tests/auth', { level: 'debug' }),
     });
 
-    app.message('/signout', async ({ isSignedIn, signout, send }) => {
-      if (!isSignedIn) return;
-      await signout(); // call signout for your auth connection...
-      await send('you have been signed out!');
+    /**
+     * Register the auth connection.
+     * The name should match the OAuth connection name defined in the Azure Bot configuration.
+     */
+    const graph = app.addOAuthFlow('graph');
+
+    app.message('/signout', async (ctx) => {
+      if (!(await graph.isSignedIn(ctx))) return;
+      await graph.signOut(ctx); // call signOut for this auth connection...
+      await ctx.send('you have been signed out!');
     });
 
     app.message('/help', async ({ send }) => {
       await send('your help text');
     });
 
-    app.on('message', async ({ signin, userGraph, log }) => {
-      if (!await signin({
+    app.on('message', async (ctx) => {
+      const token = await graph.signIn(ctx, {
         // Customize the OAuth card text (only renders in OAuth flow, not SSO)
         oauthCardText: 'Sign in to your account',
         signInButtonText: 'Sign in',
-      })) { // call signin for your auth connection...
-        return;
-      }
+      });
 
-      const me = await userGraph.me.get();
-      log.info(`user "${me.displayName}" already signed in!`);
+      // An OAuth card was sent — the flow resumes on the callback turn.
+      if (!token) return;
+
+      ctx.log.info('user already signed in!');
     });
 
-    app.event('signin', async ({ userGraph, send, token }) => {
-      const me = await userGraph.me.get();
-      await send(`user "${me.displayName}" signed in.`);
-      await send(`Token string length: ${token.token.length}`);
+    graph.onSignInComplete(async (ctx, token) => {
+      await ctx.send(`signed in. Token string length: ${token.token.length}`);
     });
     ```
 

--- a/teams.md/src/pages/templates/in-depth-guides/user-authentication.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/user-authentication.mdx
@@ -48,9 +48,11 @@ Make sure you use the same name you used when creating the OAuth connection in t
 :::
 
 <Language language={['typescript', 'python']}>
+
 :::note
 In many templates, `graph` is the default name of the OAuth connection, but you can register the connection under any name — it just has to match the OAuth connection configured on the Azure Bot.
 :::
+
 </Language>
 
 ## Signing In

--- a/teams.md/src/pages/templates/in-depth-guides/user-authentication.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/user-authentication.mdx
@@ -49,19 +49,19 @@ Make sure you use the same name you used when creating the OAuth connection in t
 
 <Language language={['typescript', 'python']}>
 :::note
-In many templates, `graph` is the default name of the OAuth connection, but you can change that by supplying a different connection name in your app configuration.
+In many templates, `graph` is the default name of the OAuth connection, but you can register the connection under any name — it just has to match the OAuth connection configured on the Azure Bot.
 :::
 </Language>
 
 ## Signing In
 
-You must call the `signin` method inside your route handler, for example: to signin when receiving the `/signin` message:
+Start sign-in from inside a route handler, for example when receiving the `/signin` message:
 
 <LanguageInclude section="signing-in" />
 
-## Subscribe to the SignIn event
+## Handling sign-in completion
 
-You can subscribe to the `signin` event, that will be triggered once the OAuth flow completes.
+The sign-in method returns a token when the user already has one, and otherwise sends an OAuth card and returns nothing. The flow finishes on a later turn, so completion is delivered through a callback.
 
 <LanguageInclude section="signin-event" />
 
@@ -78,6 +78,22 @@ The default graph configuration requests the `User.ReadBasic.All` permission. It
 You can signout by calling the `signout` method, this will remove the token from the User Token service cache
 
 <LanguageInclude section="signing-out" />
+
+## Using multiple OAuth connections
+
+An agent may need more than one identity — for example Graph for the user's profile and GitHub for their repos. Each connection is registered separately, so tokens, callbacks and sign-out are scoped to the connection that owns them.
+
+<LanguageInclude section="multiple-connections" />
+
+:::info
+Each connection must exist on the Azure Bot resource under the name you register it with. Follow the [User Authentication Setup guide](/cli/guides/user-authentication-setup) once per connection.
+:::
+
+## Checking connection status
+
+One call returns the status of every registered connection, so you don't have to probe them individually.
+
+<LanguageInclude section="connection-status" />
 
 ## Resuming Pending Messages After Sign-In
 
@@ -99,6 +115,12 @@ When using SSO, if the token exchange fails Teams sends a `signin/failure` invok
 
 :::tip
 The most common failure codes are `installedappnotfound` (bot app not installed for the user) and `resourcematchfailed` (Token Exchange URL doesn't match the Application ID URI). See [SSO Setup - Troubleshooting](/teams/user-authentication/sso-setup#troubleshooting) for a full list of failure codes and troubleshooting steps.
+:::
+
+:::warning
+A `signin/failure` activity doesn't name its connection. The SDK attributes it from the pending sign-in recorded when the flow started; if that can't be resolved, *every* registered connection's failure handler is notified. Check the connection first if your handler does something destructive.
+
+Registering a flow also turns on per-turn state unless you configure `state` yourself, defaulting to local, in-process storage. Configure shared state storage before running more than one instance — otherwise pending sign-in attribution and token-exchange dedup don't cross processes, and sign-in fails intermittently.
 :::
 
 <LanguageInclude section="regional-bot" />


### PR DESCRIPTION
adds tabs across the TypeScript and Python user-authentication guide and updates examples to the new per-connection OAuth flow API

- user-authentication
- essentials/graph: 
- essentials/on-event: 
- migrations (botbuilder + v1)