### PR TITLE
docs: add TypeScript and Python state guides

### DIFF
--- a/teams.md/src/components/include/in-depth-guides/state/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/csharp.incl.md
@@ -1,0 +1,78 @@
+<!-- overview -->
+
+The Teams SDK provides built-in `ConversationState` and `UserState` for storing per-conversation and per-user data across turns. State is backed by `IDistributedCache` — in-memory by default for local development, and swappable for any distributed cache provider (Redis, SQL, Azure Cache for Redis) for production without changing your handler code.
+
+<!-- setup -->
+
+Call `UseState()` inside `AddTeamsBotApplication()`:
+
+```csharp title="Program.cs"
+using Microsoft.Teams.Apps;
+
+WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.AddTeamsBotApplication(options =>
+{
+    options.UseState();
+});
+
+WebApplication app = builder.Build();
+TeamsBotApplication teams = app.UseTeamsBotApplication();
+```
+
+<!-- read-write -->
+
+Use `context.State.ConversationState` and `context.State.UserState` in any handler:
+
+```csharp
+teams.OnMessage(async (context, cancellationToken) =>
+{
+    // Write
+    context.State.ConversationState.Set("lastMessage", context.Activity.Text ?? string.Empty);
+    context.State.UserState.Set("messageCount",
+        (context.State.UserState.Get<int>("messageCount")) + 1);
+
+    // Read
+    string? last = context.State.ConversationState.Get<string>("lastMessage");
+    int count = context.State.UserState.Get<int>("messageCount");
+
+    await context.SendAsync(
+        $"Message #{count}. Last message was: {last}",
+        cancellationToken);
+});
+```
+
+Use `ContainsKey()`, `Remove()`, and `Clear()` to inspect or remove values. If you mutate an object or collection returned by `Get<T>(string)`, call `Set()` with the updated value so the scope is marked for persistence.
+
+<!-- clearing -->
+
+Remove a value with `Remove()` or clear a scope with `Clear()`. To remove both scopes from the backing store:
+
+```csharp
+await context.State.DeleteAsync(cancellationToken);
+```
+
+Values written after `DeleteAsync()` are saved normally at the end of the current turn.
+
+<!-- distributed-state -->
+
+For production or multi-instance deployments, register a distributed cache provider before calling `UseState()`. Your handler code stays exactly the same:
+
+```csharp title="Program.cs"
+using Microsoft.Teams.Apps;
+using StackExchange.Redis;
+
+WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
+
+// Register Redis — UseState() picks this up automatically
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = builder.Configuration["Redis:ConnectionString"];
+});
+
+builder.Services.AddTeamsBotApplication(options =>
+{
+    options.UseState();
+});
+```
+
+Any `IDistributedCache` implementation works — Redis, SQL Server (`AddDistributedSqlServerCache`), or Azure Cache for Redis.

--- a/teams.md/src/components/include/in-depth-guides/state/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/csharp.incl.md
@@ -38,11 +38,19 @@ teams.OnMessage(async (context, cancellationToken) =>
 });
 ```
 
+<!-- state-operations -->
+
+Use `ContainsKey()` to check for a value, `Remove()` to remove one, and `Clear()` to remove all values. If you mutate an object or collection returned by `Get<T>(string)`, call `Set()` with the updated value so the scope is marked for persistence.
+
 <!-- clear-example -->
 
 ```csharp
 await context.State.DeleteAsync(cancellationToken);
 ```
+
+<!-- distributed-intro -->
+
+For production or multi-instance deployments, register a shared, durable `IDistributedCache` provider, such as Redis, SQL Server, or Azure Cache for Redis, before calling `UseState()`. The state API used by handlers doesn't change:
 
 <!-- distributed-example -->
 
@@ -63,3 +71,7 @@ builder.Services.AddTeamsBotApplication(options =>
     options.UseState();
 });
 ```
+
+<!-- distributed-details -->
+
+The SDK serializes each scope as UTF-8 JSON bytes and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. Configure cache entry expiration and the key prefix through `UseState()`. Configure any provider-specific options when registering the `IDistributedCache` implementation.

--- a/teams.md/src/components/include/in-depth-guides/state/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/csharp.incl.md
@@ -1,10 +1,4 @@
-<!-- overview -->
-
-The Teams SDK provides built-in `ConversationState` and `UserState` for storing per-conversation and per-user data across turns. State is backed by `IDistributedCache` — in-memory by default for local development, and swappable for any distributed cache provider (Redis, SQL, Azure Cache for Redis) for production without changing your handler code.
-
-<!-- setup -->
-
-Call `UseState()` inside `AddTeamsBotApplication()`:
+<!-- setup-example -->
 
 ```csharp title="Program.cs"
 using Microsoft.Teams.Apps;
@@ -19,9 +13,12 @@ WebApplication app = builder.Build();
 TeamsBotApplication teams = app.UseTeamsBotApplication();
 ```
 
-<!-- read-write -->
+<!-- oauth-note -->
 
-Use `context.State.ConversationState` and `context.State.UserState` in any handler:
+Registering an OAuth flow with `AddOAuthFlow()` automatically enables state so pending sign-ins can be associated with the correct flow.
+
+<!-- read-write-example -->
+
 
 ```csharp
 teams.OnMessage(async (context, cancellationToken) =>
@@ -41,21 +38,13 @@ teams.OnMessage(async (context, cancellationToken) =>
 });
 ```
 
-Use `ContainsKey()`, `Remove()`, and `Clear()` to inspect or remove values. If you mutate an object or collection returned by `Get<T>(string)`, call `Set()` with the updated value so the scope is marked for persistence.
-
-<!-- clearing -->
-
-Remove a value with `Remove()` or clear a scope with `Clear()`. To remove both scopes from the backing store:
+<!-- clear-example -->
 
 ```csharp
 await context.State.DeleteAsync(cancellationToken);
 ```
 
-Values written after `DeleteAsync()` are saved normally at the end of the current turn.
-
-<!-- distributed-state -->
-
-For production or multi-instance deployments, register a distributed cache provider before calling `UseState()`. Your handler code stays exactly the same:
+<!-- distributed-example -->
 
 ```csharp title="Program.cs"
 using Microsoft.Teams.Apps;
@@ -74,5 +63,3 @@ builder.Services.AddTeamsBotApplication(options =>
     options.UseState();
 });
 ```
-
-Any `IDistributedCache` implementation works — Redis, SQL Server (`AddDistributedSqlServerCache`), or Azure Cache for Redis.

--- a/teams.md/src/components/include/in-depth-guides/state/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/python.incl.md
@@ -31,11 +31,19 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
     await ctx.send(f"Hello, {name}. Message #{count}.")
 ```
 
+<!-- state-operations -->
+
+Use `key in scope` to check for a value, `del scope[key]` to remove one, and `clear()` to remove all values. Changes inside stored lists and dictionaries are detected automatically when the turn is saved.
+
 <!-- clear-example -->
 
 ```python
 await ctx.state.delete()
 ```
+
+<!-- distributed-intro -->
+
+For production or multi-instance deployments, implement the Teams SDK's `Storage[str, Any]` contract with a shared, durable backend and pass it through `StateOptions`. The state API used by handlers doesn't change:
 
 <!-- distributed-example -->
 
@@ -54,3 +62,7 @@ def create_app(durable_storage: Storage[str, Any]) -> App:
         )
     )
 ```
+
+<!-- distributed-details -->
+
+The SDK serializes each scope as a JSON string and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. Configure expiry, retries, and other storage-specific behavior on your storage implementation.

--- a/teams.md/src/components/include/in-depth-guides/state/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/python.incl.md
@@ -1,10 +1,4 @@
-<!-- overview -->
-
-The Teams SDK provides opt-in, per-turn state for storing conversation and user data across activities. State is loaded before each activity handler runs, saved automatically after the turn, and exposed through `ctx.state`.
-
-<!-- setup -->
-
-Set the `App` option `state` to `True`. With no storage provider configured, state uses process-local `LocalStorage` and is lost when the process restarts.
+<!-- setup-example -->
 
 ```python
 from microsoft_teams.apps import App
@@ -12,15 +6,11 @@ from microsoft_teams.apps import App
 app = App(state=True)
 ```
 
-State is disabled by default. When it is disabled, `ctx.state` is `None`.
+<!-- oauth-note -->
 
-:::note
-Calling `add_oauth_flow()` automatically enables state because OAuth uses it to associate pending sign-ins with the correct flow. Set `state=False` explicitly to opt out.
-:::
+Registering an OAuth flow with `add_oauth_flow()` automatically enables state so pending sign-ins can be associated with the correct flow. Set `state=False` explicitly to fall back to process-local in-memory maps.
 
-<!-- read-write -->
-
-Use `ctx.state.conversation` and `ctx.state.user` in an activity handler. The scopes behave like dictionaries, and values must be JSON-serializable.
+<!-- read-write-example -->
 
 ```python
 from microsoft_teams.api import MessageActivity
@@ -41,21 +31,13 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
     await ctx.send(f"Hello, {name}. Message #{count}.")
 ```
 
-State scopes work like Python dictionaries. Check for a value with `key in scope`, remove one with `del scope[key]`, or remove all values with `scope.clear()`. Changes inside stored lists and dictionaries are detected automatically when the turn is saved.
-
-<!-- clearing -->
-
-Remove a value with `del scope[key]` or clear one scope with `ctx.state.conversation.clear()` or `ctx.state.user.clear()`. To remove both scopes from the backing store:
+<!-- clear-example -->
 
 ```python
 await ctx.state.delete()
 ```
 
-Values written after `delete()` are saved normally at the end of the current turn.
-
-<!-- distributed-state -->
-
-Process-local storage is intended for development only. For production or multi-instance deployments, pass a shared `Storage[str, Any]` implementation through `StateOptions`. The state API used by handlers does not change:
+<!-- distributed-example -->
 
 ```python
 from typing import Any
@@ -72,5 +54,3 @@ def create_app(durable_storage: Storage[str, Any]) -> App:
         )
     )
 ```
-
-The provider stores JSON strings. Configure expiry, retries, and other provider-specific behavior on the provider itself. Each save replaces the complete scope, so concurrent turns use last-writer-wins semantics.

--- a/teams.md/src/components/include/in-depth-guides/state/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/python.incl.md
@@ -14,6 +14,10 @@ app = App(state=True)
 
 State is disabled by default. When it is disabled, `ctx.state` is `None`.
 
+:::note
+Calling `add_oauth_flow()` automatically enables state because OAuth uses it to associate pending sign-ins with the correct flow. Set `state=False` explicitly to opt out.
+:::
+
 <!-- read-write -->
 
 Use `ctx.state.conversation` and `ctx.state.user` in an activity handler. The scopes behave like dictionaries, and values must be JSON-serializable.

--- a/teams.md/src/components/include/in-depth-guides/state/python.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/python.incl.md
@@ -1,0 +1,72 @@
+<!-- overview -->
+
+The Teams SDK provides opt-in, per-turn state for storing conversation and user data across activities. State is loaded before each activity handler runs, saved automatically after the turn, and exposed through `ctx.state`.
+
+<!-- setup -->
+
+Set the `App` option `state` to `True`. With no storage provider configured, state uses process-local `LocalStorage` and is lost when the process restarts.
+
+```python
+from microsoft_teams.apps import App
+
+app = App(state=True)
+```
+
+State is disabled by default. When it is disabled, `ctx.state` is `None`.
+
+<!-- read-write -->
+
+Use `ctx.state.conversation` and `ctx.state.user` in an activity handler. The scopes behave like dictionaries, and values must be JSON-serializable.
+
+```python
+from microsoft_teams.api import MessageActivity
+from microsoft_teams.apps import ActivityContext
+
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    assert ctx.state is not None
+
+    count = ctx.state.conversation.get("message_count", 0) + 1
+    ctx.state.conversation["message_count"] = count
+
+    if ctx.state.user is not None and ctx.activity.text.startswith("my name is "):
+        ctx.state.user["name"] = ctx.activity.text[len("my name is "):].strip()
+
+    name = ctx.state.user.get("name", "there") if ctx.state.user is not None else "there"
+    await ctx.send(f"Hello, {name}. Message #{count}.")
+```
+
+State scopes work like Python dictionaries. Check for a value with `key in scope`, remove one with `del scope[key]`, or remove all values with `scope.clear()`. Changes inside stored lists and dictionaries are detected automatically when the turn is saved.
+
+<!-- clearing -->
+
+Remove a value with `del scope[key]` or clear one scope with `ctx.state.conversation.clear()` or `ctx.state.user.clear()`. To remove both scopes from the backing store:
+
+```python
+await ctx.state.delete()
+```
+
+Values written after `delete()` are saved normally at the end of the current turn.
+
+<!-- distributed-state -->
+
+Process-local storage is intended for development only. For production or multi-instance deployments, pass a shared `Storage[str, Any]` implementation through `StateOptions`. The state API used by handlers does not change:
+
+```python
+from typing import Any
+
+from microsoft_teams.apps import App, StateOptions
+from microsoft_teams.common import Storage
+
+
+def create_app(durable_storage: Storage[str, Any]) -> App:
+    return App(
+        state=StateOptions(
+            storage=durable_storage,
+            key_prefix="my-app",
+        )
+    )
+```
+
+The provider stores JSON strings. Configure expiry, retries, and other provider-specific behavior on the provider itself. Each save replaces the complete scope, so concurrent turns use last-writer-wins semantics.

--- a/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
@@ -35,11 +35,19 @@ app.on('message', async (ctx) => {
 });
 ```
 
+<!-- state-operations -->
+
+Use `has()` to check for a value, `delete()` to remove one, and `clear()` to remove all values. If you mutate an object or array returned by `get()`, call `set()` with the updated value so the scope is marked for persistence.
+
 <!-- clear-example -->
 
 ```typescript
 await ctx.state.delete();
 ```
+
+<!-- distributed-intro -->
+
+For production or multi-instance deployments, implement the Teams SDK's `IStorage<string, string>` contract with a shared, durable backend and pass it through `state.storage`. The state API used by handlers doesn't change:
 
 <!-- distributed-example -->
 
@@ -56,3 +64,7 @@ function createApp(durableStorage: IStorage<string, string>): App {
   });
 }
 ```
+
+<!-- distributed-details -->
+
+The SDK serializes each scope as a JSON string and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. Configure expiry, retries, and other storage-specific behavior on your storage implementation.

--- a/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
@@ -1,0 +1,74 @@
+<!-- overview -->
+
+The Teams SDK provides opt-in, per-turn state for storing conversation and user data across activities. State is loaded before each activity handler runs, saved automatically after the turn, and exposed through `ctx.state`.
+
+<!-- setup -->
+
+Set the `App` option `state` to `true`. With no storage provider configured, state uses process-local `LocalStorage` and is lost when the process restarts.
+
+```typescript
+import { App } from '@microsoft/teams.apps';
+
+const app = new App({
+  state: true,
+});
+```
+
+State is disabled by default. When it is disabled, `ctx.state` is `undefined`.
+
+<!-- read-write -->
+
+Use `ctx.state.conversation` and `ctx.state.user` in an activity handler. Values must be JSON-serializable.
+
+```typescript
+app.on('message', async (ctx) => {
+  if (!ctx.state) {
+    throw new Error('Turn state is not enabled.');
+  }
+
+  const count = (ctx.state.conversation.get<number>('messageCount') ?? 0) + 1;
+  ctx.state.conversation.set('messageCount', count);
+
+  if (ctx.state.user && ctx.activity.text?.startsWith('my name is ')) {
+    ctx.state.user.set(
+      'name',
+      ctx.activity.text.slice('my name is '.length).trim()
+    );
+  }
+
+  const name = ctx.state.user?.get<string>('name') ?? 'there';
+  await ctx.reply(`Hello, ${name}. Message #${count}.`);
+});
+```
+
+Use `has()`, `delete()`, and `clear()` to inspect or remove values. If you mutate an object or array returned by `get()`, call `set()` with the updated value so the scope is marked for persistence.
+
+<!-- clearing -->
+
+Remove a value with `delete()` or clear one scope with `ctx.state.conversation.clear()` or `ctx.state.user?.clear()`. To remove both scopes from the backing store:
+
+```typescript
+await ctx.state.delete();
+```
+
+Values written after `delete()` are saved normally at the end of the current turn.
+
+<!-- distributed-state -->
+
+Process-local storage is intended for development only. For production or multi-instance deployments, pass a shared `IStorage<string, string>` implementation through `state.storage`. The state API used by handlers does not change:
+
+```typescript
+import type { IStorage } from '@microsoft/teams.common';
+import { App } from '@microsoft/teams.apps';
+
+function createApp(durableStorage: IStorage<string, string>): App {
+  return new App({
+    state: {
+      storage: durableStorage,
+      keyPrefix: 'my-app',
+    },
+  });
+}
+```
+
+The provider stores JSON strings. Configure expiry, retries, and other provider-specific behavior on the provider itself. Each save replaces the complete scope, so concurrent turns use last-writer-wins semantics.

--- a/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
@@ -1,10 +1,4 @@
-<!-- overview -->
-
-The Teams SDK provides opt-in, per-turn state for storing conversation and user data across activities. State is loaded before each activity handler runs, saved automatically after the turn, and exposed through `ctx.state`.
-
-<!-- setup -->
-
-Set the `App` option `state` to `true`. With no storage provider configured, state uses process-local `LocalStorage` and is lost when the process restarts.
+<!-- setup-example -->
 
 ```typescript
 import { App } from '@microsoft/teams.apps';
@@ -14,15 +8,11 @@ const app = new App({
 });
 ```
 
-State is disabled by default. When it is disabled, `ctx.state` is `undefined`.
+<!-- oauth-note -->
 
-:::note
-Calling `addOAuthFlow()` automatically enables state because OAuth uses it to associate pending sign-ins with the correct flow. Set `state: false` explicitly to opt out.
-:::
+Registering an OAuth flow with `addOAuthFlow()` automatically enables state so pending sign-ins can be associated with the correct flow. Set `state: false` explicitly to fall back to process-local in-memory maps.
 
-<!-- read-write -->
-
-Use `ctx.state.conversation` and `ctx.state.user` in an activity handler. Values must be JSON-serializable.
+<!-- read-write-example -->
 
 ```typescript
 app.on('message', async (ctx) => {
@@ -45,21 +35,13 @@ app.on('message', async (ctx) => {
 });
 ```
 
-Use `has()`, `delete()`, and `clear()` to inspect or remove values. If you mutate an object or array returned by `get()`, call `set()` with the updated value so the scope is marked for persistence.
-
-<!-- clearing -->
-
-Remove a value with `delete()` or clear one scope with `ctx.state.conversation.clear()` or `ctx.state.user?.clear()`. To remove both scopes from the backing store:
+<!-- clear-example -->
 
 ```typescript
 await ctx.state.delete();
 ```
 
-Values written after `delete()` are saved normally at the end of the current turn.
-
-<!-- distributed-state -->
-
-Process-local storage is intended for development only. For production or multi-instance deployments, pass a shared `IStorage<string, string>` implementation through `state.storage`. The state API used by handlers does not change:
+<!-- distributed-example -->
 
 ```typescript
 import type { IStorage } from '@microsoft/teams.common';
@@ -74,5 +56,3 @@ function createApp(durableStorage: IStorage<string, string>): App {
   });
 }
 ```
-
-The provider stores JSON strings. Configure expiry, retries, and other provider-specific behavior on the provider itself. Each save replaces the complete scope, so concurrent turns use last-writer-wins semantics.

--- a/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/state/typescript.incl.md
@@ -16,6 +16,10 @@ const app = new App({
 
 State is disabled by default. When it is disabled, `ctx.state` is `undefined`.
 
+:::note
+Calling `addOAuthFlow()` automatically enables state because OAuth uses it to associate pending sign-ins with the correct flow. Set `state: false` explicitly to opt out.
+:::
+
 <!-- read-write -->
 
 Use `ctx.state.conversation` and `ctx.state.user` in an activity handler. Values must be JSON-serializable.

--- a/teams.md/src/pages/templates/in-depth-guides/state.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/state.mdx
@@ -12,24 +12,44 @@ languages: ['typescript', 'python', 'csharp']
 Built-in state management is a **Teams SDK 2.1** feature.
 :::
 
-<LanguageInclude section="overview" />
+The Teams SDK provides built-in, per-turn state for storing conversation and user data across activities. State is loaded before each activity handler runs, saved automatically after the turn, and exposed through <LanguageInclude content={{"typescript": "`ctx.state`", "python": "`ctx.state`", "csharp": "`context.State`"}} />.
 
 ## Setup
 
-<LanguageInclude section="setup" />
+State is disabled by default. Enable it with <LanguageInclude content={{"typescript": "the `state: true` app option", "python": "the `state=True` app option", "csharp": "`UseState()`"}} />:
+
+<LanguageInclude section="setup-example" />
+
+Without a dedicated provider, state uses <LanguageInclude content={{"typescript": "the Teams SDK's process-local, in-memory `LocalStorage` implementation", "python": "the Teams SDK's process-local, in-memory `LocalStorage` implementation", "csharp": "the in-memory `IDistributedCache` implementation"}} />. This is useful for local development, but values are lost when the process restarts and aren't shared across instances.
+
+:::note
+<LanguageInclude section="oauth-note" />
+:::
 
 ## Reading and writing state
 
-<LanguageInclude section="read-write" />
+Use <LanguageInclude content={{"typescript": "`ctx.state.conversation` and `ctx.state.user`", "python": "`ctx.state.conversation` and `ctx.state.user`", "csharp": "`context.State.ConversationState` and `context.State.UserState`"}} /> in an activity handler. Values must be JSON-serializable.
+
+<LanguageInclude section="read-write-example" />
+
+Use <LanguageInclude content={{"typescript": "`has()`", "python": "`key in scope`", "csharp": "`ContainsKey()`"}} /> to check for a value, <LanguageInclude content={{"typescript": "`delete()`", "python": "`del scope[key]`", "csharp": "`Remove()`"}} /> to remove one, and <LanguageInclude content={{"typescript": "`clear()`", "python": "`clear()`", "csharp": "`Clear()`"}} /> to remove all values. <LanguageInclude content={{"typescript": "If you mutate an object or array returned by `get()`, call `set()` with the updated value so the scope is marked for persistence.", "python": "Changes inside stored lists and dictionaries are detected automatically when the turn is saved.", "csharp": "If you mutate an object or collection returned by `Get<T>(string)`, call `Set()` with the updated value so the scope is marked for persistence."}} />
 
 Conversation state is shared by everyone in the current conversation. User state is scoped to the current sender **within that conversation** and is unavailable when an activity has no usable sender ID.
 
-Only changed scopes are persisted. After the handler chain finishes, the SDK saves state and seals both scopes. Do not retain turn state for background work; accessing a sealed scope throws an error.
+The SDK writes a scope to storage only when it changes during the current activity. After all handlers for that activity finish, the SDK saves those changes and closes the turn state. Read or update state only while handling the activity. Don't capture it for timers or background tasks because accessing it after the turn ends throws <LanguageInclude content={{"typescript": "`TurnStateSealedError`", "python": "`TurnStateSealedError`", "csharp": "`InvalidOperationException`"}} />.
 
 ## Clearing state
 
-<LanguageInclude section="clearing" />
+Remove a value with <LanguageInclude content={{"typescript": "`delete()`", "python": "`del scope[key]`", "csharp": "`Remove()`"}} />, or clear a scope with <LanguageInclude content={{"typescript": "`clear()`", "python": "`clear()`", "csharp": "`Clear()`"}} />. To remove both scopes from the backing store:
+
+<LanguageInclude section="clear-example" />
+
+Values written after <LanguageInclude content={{"typescript": "`delete()`", "python": "`delete()`", "csharp": "`DeleteAsync()`"}} /> are saved normally at the end of the current turn.
 
 ## Scaling to distributed state
 
-<LanguageInclude section="distributed-state" />
+For production or multi-instance deployments, <LanguageInclude content={{"typescript": "implement the Teams SDK's `IStorage<string, string>` contract with a shared, durable backend and pass it through `state.storage`", "python": "implement the Teams SDK's `Storage[str, Any]` contract with a shared, durable backend and pass it through `StateOptions`", "csharp": "register an `IDistributedCache` provider before calling `UseState()`"}} />. The state API used by handlers doesn't change:
+
+<LanguageInclude section="distributed-example" />
+
+The SDK serializes each scope as JSON and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. Configure expiry, retries, and other storage-specific behavior on the selected provider.

--- a/teams.md/src/pages/templates/in-depth-guides/state.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/state.mdx
@@ -32,7 +32,7 @@ Use <LanguageInclude content={{"typescript": "`ctx.state.conversation` and `ctx.
 
 <LanguageInclude section="read-write-example" />
 
-Use <LanguageInclude content={{"typescript": "`has()`", "python": "`key in scope`", "csharp": "`ContainsKey()`"}} /> to check for a value, <LanguageInclude content={{"typescript": "`delete()`", "python": "`del scope[key]`", "csharp": "`Remove()`"}} /> to remove one, and <LanguageInclude content={{"typescript": "`clear()`", "python": "`clear()`", "csharp": "`Clear()`"}} /> to remove all values. <LanguageInclude content={{"typescript": "If you mutate an object or array returned by `get()`, call `set()` with the updated value so the scope is marked for persistence.", "python": "Changes inside stored lists and dictionaries are detected automatically when the turn is saved.", "csharp": "If you mutate an object or collection returned by `Get<T>(string)`, call `Set()` with the updated value so the scope is marked for persistence."}} />
+<LanguageInclude section="state-operations" />
 
 Conversation state is shared by everyone in the current conversation. User state is scoped to the current sender **within that conversation** and is unavailable when an activity has no usable sender ID.
 
@@ -48,8 +48,8 @@ Values written after <LanguageInclude content={{"typescript": "`delete()`", "pyt
 
 ## Scaling to distributed state
 
-For production or multi-instance deployments, <LanguageInclude content={{"typescript": "implement the Teams SDK's `IStorage<string, string>` contract with a shared, durable backend and pass it through `state.storage`", "python": "implement the Teams SDK's `Storage[str, Any]` contract with a shared, durable backend and pass it through `StateOptions`", "csharp": "register a shared, durable `IDistributedCache` provider, such as Redis, SQL Server, or Azure Cache for Redis, before calling `UseState()`"}} />. The state API used by handlers doesn't change:
+<LanguageInclude section="distributed-intro" />
 
 <LanguageInclude section="distributed-example" />
 
-The SDK serializes each scope as <LanguageInclude content={{"typescript": "a JSON string", "python": "a JSON string", "csharp": "UTF-8 JSON bytes"}} /> and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. <LanguageInclude content={{"typescript": "Configure expiry, retries, and other storage-specific behavior on your storage implementation.", "python": "Configure expiry, retries, and other storage-specific behavior on your storage implementation.", "csharp": "Configure cache entry expiration and the key prefix through `UseState()`. Configure any provider-specific options when registering the `IDistributedCache` implementation."}} />
+<LanguageInclude section="distributed-details" />

--- a/teams.md/src/pages/templates/in-depth-guides/state.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/state.mdx
@@ -48,8 +48,8 @@ Values written after <LanguageInclude content={{"typescript": "`delete()`", "pyt
 
 ## Scaling to distributed state
 
-For production or multi-instance deployments, <LanguageInclude content={{"typescript": "implement the Teams SDK's `IStorage<string, string>` contract with a shared, durable backend and pass it through `state.storage`", "python": "implement the Teams SDK's `Storage[str, Any]` contract with a shared, durable backend and pass it through `StateOptions`", "csharp": "register an `IDistributedCache` provider before calling `UseState()`"}} />. The state API used by handlers doesn't change:
+For production or multi-instance deployments, <LanguageInclude content={{"typescript": "implement the Teams SDK's `IStorage<string, string>` contract with a shared, durable backend and pass it through `state.storage`", "python": "implement the Teams SDK's `Storage[str, Any]` contract with a shared, durable backend and pass it through `StateOptions`", "csharp": "register a shared, durable `IDistributedCache` provider, such as Redis, SQL Server, or Azure Cache for Redis, before calling `UseState()`"}} />. The state API used by handlers doesn't change:
 
 <LanguageInclude section="distributed-example" />
 
-The SDK serializes each scope as JSON and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. Configure expiry, retries, and other storage-specific behavior on the selected provider.
+The SDK serializes each scope as <LanguageInclude content={{"typescript": "a JSON string", "python": "a JSON string", "csharp": "UTF-8 JSON bytes"}} /> and replaces the complete scope on save, so concurrent turns use last-writer-wins semantics. <LanguageInclude content={{"typescript": "Configure expiry, retries, and other storage-specific behavior on your storage implementation.", "python": "Configure expiry, retries, and other storage-specific behavior on your storage implementation.", "csharp": "Configure cache entry expiration and the key prefix through `UseState()`. Configure any provider-specific options when registering the `IDistributedCache` implementation."}} />

--- a/teams.md/src/pages/templates/in-depth-guides/state.mdx
+++ b/teams.md/src/pages/templates/in-depth-guides/state.mdx
@@ -2,79 +2,34 @@
 sidebar_position: 10
 title: State Management
 sidebar_label: 🗄️ State Management
-summary: Store and retrieve conversation and user state in your Teams bot using the built-in state management in Teams SDK for .NET 2.1.
-languages: ['csharp']
+summary: Store and retrieve conversation and user state across activity turns with the Teams SDK.
+languages: ['typescript', 'python', 'csharp']
 ---
 
 # State Management
 
 :::info[SDK 2.1]
-Built-in state management is a **Teams SDK for .NET 2.1** feature.
+Built-in state management is a **Teams SDK 2.1** feature.
 :::
 
-The Teams SDK provides built-in `ConversationState` and `UserState` for storing per-conversation and per-user data across turns. State is backed by `IDistributedCache` — in-memory by default for local development, and swappable for any distributed cache provider (Redis, SQL, Azure Cache for Redis) for production without changing your handler code.
+<LanguageInclude section="overview" />
 
 ## Setup
 
-Call `UseState()` inside `AddTeamsBotApplication()`:
-
-```csharp title="Program.cs"
-using Microsoft.Teams.Apps;
-
-WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
-builder.Services.AddTeamsBotApplication(options =>
-{
-    options.UseState();
-});
-
-WebApplication app = builder.Build();
-TeamsBotApplication teams = app.UseTeamsBotApplication();
-```
+<LanguageInclude section="setup" />
 
 ## Reading and writing state
 
-Use `context.State.ConversationState` and `context.State.UserState` in any handler:
+<LanguageInclude section="read-write" />
 
-```csharp
-teams.OnMessage(async (context, cancellationToken) =>
-{
-    // Write
-    context.State.ConversationState.Set("lastMessage", context.Activity.Text ?? string.Empty);
-    context.State.UserState.Set("messageCount",
-        (context.State.UserState.Get<int>("messageCount")) + 1);
+Conversation state is shared by everyone in the current conversation. User state is scoped to the current sender **within that conversation** and is unavailable when an activity has no usable sender ID.
 
-    // Read
-    string? last = context.State.ConversationState.Get<string>("lastMessage");
-    int count = context.State.UserState.Get<int>("messageCount");
+Only changed scopes are persisted. After the handler chain finishes, the SDK saves state and seals both scopes. Do not retain turn state for background work; accessing a sealed scope throws an error.
 
-    await context.SendAsync(
-        $"Message #{count}. Last message was: {last}",
-        cancellationToken);
-});
-```
+## Clearing state
 
-`ConversationState` is scoped to the current conversation. `UserState` is scoped to the current user across all conversations.
+<LanguageInclude section="clearing" />
 
 ## Scaling to distributed state
 
-For production or multi-instance deployments, register a distributed cache provider before calling `UseState()`. Your handler code stays exactly the same:
-
-```csharp title="Program.cs"
-using Microsoft.Teams.Apps;
-using StackExchange.Redis;
-
-WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(args);
-
-// Register Redis — UseState() picks this up automatically
-builder.Services.AddStackExchangeRedisCache(options =>
-{
-    options.Configuration = builder.Configuration["Redis:ConnectionString"];
-});
-
-builder.Services.AddTeamsBotApplication(options =>
-{
-    options.UseState();
-});
-```
-
-Any `IDistributedCache` implementation works — Redis, SQL Server (`AddDistributedSqlServerCache`), or Azure Cache for Redis.
+<LanguageInclude section="distributed-state" />

--- a/teams.md/static/missing-pages.json
+++ b/teams.md/static/missing-pages.json
@@ -27,10 +27,6 @@
   "in-depth-guides/server/http-server": [
     "csharp"
   ],
-  "in-depth-guides/state": [
-    "typescript",
-    "python"
-  ],
   "in-depth-guides/tabs": [
     "python"
   ],


### PR DESCRIPTION
## Summary

- expand the state management guide to TypeScript and Python using their SDK 2.1 APIs
- move shared conversation/user scope and turn lifecycle behavior into the common template
- document language-specific setup, reads/writes, clearing, and durable storage configuration
- retain the C# guide as a language include and remove TypeScript/Python from the missing-pages manifest

## Validation

- generated all language-specific documentation
- built the Docusaurus site successfully